### PR TITLE
minio-py: All functions should take native types if possible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,31 +41,31 @@ for bucket in buckets:
 
 [get_bucket_acl(bucket)](examples/bucket_acl.py)
 
-[set_bucket_acl(bucketName, acl=Acl.private())](examples/bucket_acl.py)
+[set_bucket_acl(bucket_name, acl=Acl.private())](examples/bucket_acl.py)
 
-[list_incomplete_uploads(bucketName, prefix=None, recursive=False)](examples/list_incomplete_uploads.py)
+[list_incomplete_uploads(bucket_name, prefix=None, recursive=False)](examples/list_incomplete_uploads.py)
 
 ### Object Operations.
 
-[get_object(bucketName, objectName)](examples/get_object.py)
+[get_object(bucket_name, object_name)](examples/get_object.py)
 
-[get_partial_object(bucketName, objectName, offset, length)](examples/get_partial_object.py)
+[get_partial_object(bucket_name, object_name, offset, length)](examples/get_partial_object.py)
 
-[put_object(bucketName, objectName, length, data, content_type='application/octet_stream')](examples/put_object.py)
+[put_object(bucket_name, object_name, length, data, content_type='application/octet_stream')](examples/put_object.py)
 
-[list_objects(bucketName, prefix=None, recursive=False)](examples/list_objects.py)
+[list_objects(bucket_name, prefix=None, recursive=False)](examples/list_objects.py)
 
-[stat_object(bucketName, objectName)](examples/stat_object.py)
+[stat_object(bucket_name, object_name)](examples/stat_object.py)
 
-[remove_object(bucketName, objectName)](examples/remove_object.py)
+[remove_object(bucket_name, object_name)](examples/remove_object.py)
 
-[remove_incomplete_upload(bucketName, objectName)](examples/remove_incomplete_upload.py)
+[remove_incomplete_upload(bucket_name, object_name)](examples/remove_incomplete_upload.py)
 
 ### Presigned Operations.
 
-[presigned_get_object(bucketName, objectName, expires=604800)](examples/presigned_get_object.py)
+[presigned_get_object(bucket_name, object_name, expires=604800)](examples/presigned_get_object.py)
 
-[presigned_put_object(bucketName, objectName, expires=604800)](examples/presigned_put_object.py)
+[presigned_put_object(bucket_name, object_name, expires=604800)](examples/presigned_put_object.py)
 
 [presigned_post_policy(policy=PostPolicy())](examples/presigned_post_policy.py)
 

--- a/examples/presigned_get_object.py
+++ b/examples/presigned_get_object.py
@@ -21,4 +21,5 @@ client = Minio('https://s3.amazonaws.com',
                access_key='YOUR-ACCESSKEYID',
                secret_key='YOUR-SECRETACCESSKEY')
 
+### Defaults to 7 days.
 print client.presigned_get_object('bucketName', 'objectName')

--- a/examples/presigned_put_object.py
+++ b/examples/presigned_put_object.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
+
 from minio import Minio
 
 __author__ = 'minio'
@@ -21,4 +23,5 @@ client = Minio('https://s3.amazonaws.com',
                access_key='YOUR-ACCESSKEYID',
                secret_key='YOUR-SECRETACCESSKEY')
 
-print client.presigned_put_object('bucketName', 'objectName')
+### Expires in 3 days.
+print client.presigned_put_object('bucketName', 'objectName', datetime.timedelta(days=3))

--- a/minio/definitions.py
+++ b/minio/definitions.py
@@ -23,10 +23,10 @@ class Bucket(object):
 
 
 class Object(object):
-    def __init__(self, bucketName, objectName, last_modified, etag, size,
+    def __init__(self, bucket_name, object_name, last_modified, etag, size,
                  content_type=None, is_dir=False):
-        self.bucketName = bucketName
-        self.objectName = objectName
+        self.bucket_name = bucket_name
+        self.object_name = object_name
         self.last_modified = last_modified
         self.etag = etag
         self.size = size
@@ -34,22 +34,22 @@ class Object(object):
         self.is_dir = is_dir
 
     def __str__(self):
-        string_format = '<Object: bucketName: {0} objectName: {1} last_modified: {2}' \
+        string_format = '<Object: bucket_name: {0} object_name: {1} last_modified: {2}' \
                         ' etag: {3} size: {4} content_type: {5}, is_dir: {6}>'
-        return string_format.format(self.bucketName, self.objectName, self.last_modified,
+        return string_format.format(self.bucket_name, self.object_name, self.last_modified,
                                     self.etag, self.size, self.content_type,
                                     self.is_dir)
 
 class IncompleteUpload(object):
-    def __init__(self, bucketName, objectName, upload_id):
-        self.bucketName = bucketName
-        self.objectName = objectName
+    def __init__(self, bucket_name, object_name, upload_id):
+        self.bucket_name = bucket_name
+        self.object_name = object_name
         self.upload_id = upload_id
 
     def __str__(self):
-        string_format = '<IncompleteUpload: bucketName: {0} objectName: {1}' \
+        string_format = '<IncompleteUpload: bucket_name: {0} object_name: {1}' \
                         ' upload_id: {2}>'
-        return string_format.format(self.bucketName, self.objectName, self.upload_id)
+        return string_format.format(self.bucket_name, self.object_name, self.upload_id)
 
 class PartMetadata(object):
     def __init__(self, md5digest, sha256digest, size):
@@ -58,10 +58,10 @@ class PartMetadata(object):
         self.size = size
 
 class UploadPart(object):
-    def __init__(self, bucketName, objectName, upload_id, part_number, etag,
+    def __init__(self, bucket_name, object_name, upload_id, part_number, etag,
                  last_modified, size):
-        self.bucketName = bucketName
-        self.objectName = objectName
+        self.bucket_name = bucket_name
+        self.object_name = object_name
         self.upload_id = upload_id
         self.part_number = part_number
         self.etag = etag
@@ -69,11 +69,11 @@ class UploadPart(object):
         self.size = size
 
     def __str__(self):
-        string_format = '<UploadPart: bucketName: {0} objectName: {1} upload_id: {2}' \
+        string_format = '<UploadPart: bucket_name: {0} object_name: {1} upload_id: {2}' \
                         ' part_number: {3} etag: {4} last_modified: {5}' \
                         ' size: {6}>'
-        return string_format.format(self.bucketName,
-                                    self.objectName,
+        return string_format.format(self.bucket_name,
+                                    self.object_name,
                                     self.upload_id,
                                     self.part_number,
                                     self.etag,

--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -44,27 +44,27 @@ def parts_manager(data, tmpdata, md5hasher, sha256hasher, part_size=5*1024*1024)
                         sha256hasher.digest(),
                         total_read)
 
-def get_target_url(url, bucketName=None, objectName=None, query=None):
+def get_target_url(url, bucket_name=None, object_name=None, query=None):
     """
     Construct target url
     """
     parsed_url = urlsplit(url)
 
-    if bucketName is None:
+    if bucket_name is None:
         url = parsed_url.scheme + '://' + parsed_url.netloc
     else:
         if 'amazonaws.com' in parsed_url.netloc:
-            url = parsed_url.scheme + '://' + bucketName + '.' + parsed_url.netloc
+            url = parsed_url.scheme + '://' + bucket_name + '.' + parsed_url.netloc
         else:
-            url = parsed_url.scheme + '://' + parsed_url.netloc + '/' + bucketName
+            url = parsed_url.scheme + '://' + parsed_url.netloc + '/' + bucket_name
 
     url_components = [url]
     url_components.append('/')
 
-    if objectName is not None:
-        objectName = encode_object_name(objectName)
-    if objectName is not None:
-        url_components.append(objectName)
+    if object_name is not None:
+        object_name = encode_object_name(object_name)
+    if object_name is not None:
+        url_components.append(object_name)
 
     if query is not None:
         ordered_query = collections.OrderedDict(sorted(query.items()))
@@ -122,15 +122,12 @@ def is_valid_bucket_name(bucket_name):
     "." character because these will cause SSL cert validation
     problems if we try to use virtual-hosting style addressing.
     """
-    validbucket = re.compile('[a-z0-9][a-z0-9\\-]*[a-z0-9]')
+    validbucket = re.compile('^[a-zA-Z][a-zA-Z0-9\\-]+[a-zA-Z0-9]$')
     if '.' in bucket_name:
         raise InvalidBucketError('bucket')
     if len(bucket_name) < 3 or len(bucket_name) > 63:
         # Wrong length
         raise InvalidBucketError('bucket')
-    if len(bucket_name) == 1:
-        if not bucket_name.isalnum():
-            raise InvalidBucketError('bucket')
     match = validbucket.match(bucket_name)
     if match is None or match.end() != len(bucket_name):
         raise InvalidBucketError('bucket')
@@ -144,12 +141,12 @@ def is_non_empty_string(input_string):
     if not input_string.strip():
         raise ValueError()
 
-def encode_object_name(objectName):
+def encode_object_name(object_name):
     """
     url encode object name
     """
-    is_non_empty_string(objectName)
-    return urlencode(objectName)
+    is_non_empty_string(object_name)
+    return urlencode(object_name)
 
 def get_sha256(content):
     """

--- a/tests/unit/bucket_exist_test.py
+++ b/tests/unit/bucket_exist_test.py
@@ -46,12 +46,7 @@ class BucketExists(TestCase):
         result = client.bucket_exists('hello')
         eq_(True, result)
 
-    @raises(ResponseError)
-    @mock.patch('urllib3.PoolManager')
-    def test_bucket_exists_invalid_name(self, mock_connection):
-        error_xml = generate_error('code', 'message', 'request_id', 'host_id', 'resource')
-        mock_server = MockConnection()
-        mock_connection.return_value = mock_server
-        mock_server.mock_add_request(MockResponse('HEAD', 'http://localhost:9000/1234/', {}, 400, content=error_xml))
+    @raises(InvalidBucketError)
+    def test_bucket_exists_invalid_name(self):
         client = minio.Minio('http://localhost:9000')
         client.bucket_exists('1234')

--- a/tests/unit/remove_bucket_test.py
+++ b/tests/unit/remove_bucket_test.py
@@ -37,6 +37,11 @@ class RemoveBucket(TestCase):
         client = minio.Minio('http://localhost:9000')
         client.remove_bucket('  \t \n  ')
 
+    @raises(InvalidBucketError)
+    def test_remove_bucket_invalid_name(self):
+        client = minio.Minio('http://localhost:9000')
+        client.remove_bucket('1234')
+
     @mock.patch('urllib3.PoolManager')
     def test_remove_bucket_works(self, mock_connection):
         mock_server = MockConnection()
@@ -44,13 +49,3 @@ class RemoveBucket(TestCase):
         mock_server.mock_add_request(MockResponse('DELETE', 'http://localhost:9000/hello/', {}, 204))
         client = minio.Minio('http://localhost:9000')
         client.remove_bucket('hello')
-
-    @mock.patch('urllib3.PoolManager')
-    @raises(ResponseError)
-    def test_remove_bucket_invalid_name(self, mock_connection):
-        error_xml = generate_error('code', 'message', 'request_id', 'host_id', 'resource')
-        mock_server = MockConnection()
-        mock_connection.return_value = mock_server
-        mock_server.mock_add_request(MockResponse('DELETE', 'http://localhost:9000/1234/', {}, 400, content=error_xml))
-        client = minio.Minio('http://localhost:9000')
-        client.remove_bucket('1234')

--- a/tests/unit/remove_object_test.py
+++ b/tests/unit/remove_object_test.py
@@ -18,13 +18,12 @@ import mock
 from nose.tools import raises
 
 from minio import minio
-from minio.error import ResponseError
+from minio.error import ResponseError, InvalidBucketError
 
 from .minio_mocks import MockResponse, MockConnection
 from .helpers import generate_error
 
 __author__ = 'minio'
-
 
 class StatObject(TestCase):
     @raises(TypeError)
@@ -37,6 +36,11 @@ class StatObject(TestCase):
         client = minio.Minio('http://localhost:9000')
         client.remove_object('hello', '  \t \n  ')
 
+    @raises(InvalidBucketError)
+    def test_remove_bucket_invalid_name(self):
+        client = minio.Minio('http://localhost:9000')
+        client.remove_object('1234', 'world')
+
     @mock.patch('urllib3.PoolManager')
     def test_remove_object_works(self, mock_connection):
         mock_server = MockConnection()
@@ -44,14 +48,3 @@ class StatObject(TestCase):
         mock_server.mock_add_request(MockResponse('DELETE', 'http://localhost:9000/hello/world', {}, 204))
         client = minio.Minio('http://localhost:9000')
         client.remove_object('hello', 'world')
-
-    @mock.patch('urllib3.PoolManager')
-    @raises(ResponseError)
-    def test_remove_object_invalid_name(self, mock_connection):
-        error_xml = generate_error('code', 'message', 'request_id', 'host_id', 'resource')
-        mock_server = MockConnection()
-        mock_connection.return_value = mock_server
-        mock_server.mock_add_request(
-            MockResponse('DELETE', 'http://localhost:9000/1234/world', {}, 400, content=error_xml))
-        client = minio.Minio('http://localhost:9000')
-        client.remove_object('1234', 'world')

--- a/tests/unit/set_bucket_acl_test.py
+++ b/tests/unit/set_bucket_acl_test.py
@@ -38,6 +38,11 @@ class SetBucketAclTest(TestCase):
         client = minio.Minio('http://localhost:9000')
         client.set_bucket_acl('  \t \n  ', Acl.private())
 
+    @raises(InvalidBucketError)
+    def test_set_bucket_acl_invalid_name(self):
+        client = minio.Minio('http://localhost:9000')
+        client.set_bucket_acl('1234', Acl.private())
+
     @mock.patch('urllib3.PoolManager')
     def test_set_bucket_acl_works(self, mock_connection):
         mock_server = MockConnection()
@@ -46,15 +51,3 @@ class SetBucketAclTest(TestCase):
                                                   {'x-amz-acl': 'private'}, 200))
         client = minio.Minio('http://localhost:9000')
         client.set_bucket_acl('hello', Acl.private())
-
-    @mock.patch('urllib3.PoolManager')
-    @raises(ResponseError)
-    def test_set_bucket_acl_invalid_name(self, mock_connection):
-        error_xml = generate_error('code', 'message', 'request_id', 'host_id', 'resource')
-        mock_server = MockConnection()
-        mock_connection.return_value = mock_server
-        mock_server.mock_add_request(MockResponse('PUT', 'http://localhost:9000/1234/?acl',
-                                                  {'x-amz-acl': 'private'},
-                                                  400, content=error_xml))
-        client = minio.Minio('http://localhost:9000')
-        client.set_bucket_acl('1234', Acl.private())


### PR DESCRIPTION
- presigned get/put request now always take native type for timedelta.
- presigned post policy shouldn't have policy as optional argument.
- is_valid_bucket_name regex should verify for Amazon S3 compatible
  bucket names, i.e bucket names can be capitalized and can contain numbers.
- improve upon documentation.

Fixes #296