### PR TITLE
api: change presigned_post_policy to return back proper URL.

### DIFF
--- a/API.md
+++ b/API.md
@@ -439,7 +439,7 @@ except ResponseError as err:
 
 ---------------------------------------
 <a name="presigned_post_policy">
-#### presigned_post_policy
+#### presigned_post_policy(policy)
 presigned_post_policy we can provide policies specifying conditions restricting
 what you want to allow in a POST request, such as bucket name where objects can be
 uploaded, key name prefixes that you want to allow for the object being created and more.
@@ -466,14 +466,14 @@ post_policy.set_expires(expires_date)
 Get the POST form key/value object:
 ```py
 try:
-    signed_form_data = s3client.presigned_post_policy(post_policy)
+    url_str, signed_form_data = s3client.presigned_post_policy(post_policy)
 except ResponseError as err:
     print(err)    
 ```
 
 POST your content from the command line using `curl`:
 ```py
-curl_str = 'curl -X POST my-bucketname.s3.amazonaws.com/'
+curl_str = 'curl -X POST {0}'.format(url_str)
 curl_cmd = [curl_str]
 for field in signed_form_data:
     curl_cmd.append('-F {0}={1}'.format(field, signed_form_data[field]))

--- a/examples/presigned_post_policy.py
+++ b/examples/presigned_post_policy.py
@@ -39,9 +39,9 @@ client = Minio('s3.amazonaws.com',
                secret_key='YOUR-SECRETACCESSKEY')
 
 try:
-    curl_str = 'curl -X POST my-bucketname.s3.amazonaws.com/'
+    url_str, signed_form_data = client.presigned_post_policy(post_policy)
+    curl_str = 'curl -X POST {0}'.format(url_str)
     curl_cmd = [curl_str]
-    signed_form_data = client.presigned_post_policy(post_policy)
     for field in signed_form_data:
         curl_cmd.append('-F {0}={1}'.format(field, signed_form_data[field]))
 

--- a/minio/api.py
+++ b/minio/api.py
@@ -1106,7 +1106,10 @@ class Minio(object):
                                            self._secret_key,
                                            policy_base64)
         policy.form_data['x-amz-signature'] = signature
-        return policy.form_data
+        url_str = get_target_url(self._endpoint_url,
+                                 bucket_name=policy.form_data['bucket'],
+                                 bucket_region=region)
+        return (url_str, policy.form_data)
 
     # All private functions below.
     def _get_partial_object(self, bucket_name, object_name,


### PR DESCRIPTION
The reason to do this is because bucket names can be in
various different regions and for users it becomes convenient
if we return back the proper endpoint which can be safely used
without worrying about virtual host style or path style.

We have enough information to provide a proper URL, this is also
consistent with other Presigned operations as it would be an
expected behavior.