### PR TITLE
api: Fix python3 compatibility issue by using compat values.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -36,10 +36,10 @@ s3Client = Minio('s3.amazonaws.com',
 |[`list_buckets`](#list_buckets)   | [`put_object`](#put_object)  | [`presigned_put_object`](#presigned_put_object)  |
 | [`bucket_exists`](#bucket_exists)  |[`stat_object`](#stat_object)   |[`presigned_post_policy`](#presigned_post_policy)   |
 |[`remove_bucket`](#remove_bucket)   | [`remove_object`](#remove_object)  |   |
-| [`list_objects`](#list_objects)  | [`remove_incomplete_upload`](#remove_incomplete_upload)  |   | 
+| [`list_objects`](#list_objects)  | [`remove_incomplete_upload`](#remove_incomplete_upload)  |   |
 |[`list_incomplete_uploads`](#list_incomplete_uploads)   |  [`fput_object`](#fput_object) |   |
-| [`get_bucket_policy`](#get_bucket_policy) |[`fget_object`](#fget_object)  |  | 
-| [`set_bucket_policy`](#set_bucket_policy) | [`get_partial_object`](#get_partial_object) |  | 
+| [`get_bucket_policy`](#get_bucket_policy) |[`fget_object`](#fget_object)  |  |
+| [`set_bucket_policy`](#set_bucket_policy) | [`get_partial_object`](#get_partial_object) |  |
 
 ## 1. Constructor
 
@@ -98,7 +98,7 @@ __Parameters__
 
 | Param  | Type  | Description  |
 |---|---|---|
-|`bucket_name`  | _string_  | Name of the bucket. | 
+|`bucket_name`  | _string_  | Name of the bucket. |
 | `location`  |  _string_ | Default value is us-east-1 Region where the bucket is created. Valid values are listed below: |
 | | |us-east-1 |
 | | |us-west-1 |
@@ -108,7 +108,7 @@ __Parameters__
 | | | ap-southeast-1|
 | | | ap-northeast-1|
 | | | ap-southeast-2|
-| | | sa-east-1| 
+| | | sa-east-1|
 
 __Example__
 
@@ -292,16 +292,20 @@ print(policy)
 ```
 
 <a name="set_bucket_policy"></a>
-### set_bucket_policy(policy, bucket_name, prefix)
-Sets policy to a bucket.
+### set_bucket_policy(bucket_name, prefix, policy)
+
+Set a bucket policy for a specified bucket. If `prefix` is not empty,
+the bucket policy will only be assigned to objects that fit the
+given prefix.
 
 __Parameters__
 
 |Param   |Type   |Description   |
 |:---|:---|:---|
-|``Policy``   | _minio.policy.Policy_   |Policy enum. Policy.READ_ONLY,Policy.WRITE_ONLY,Policy.READ_WRITE or Policy.NONE.   |
 |``bucketname``   | _string_  |Name of the bucket.|
 |``prefix``   |_string_ |The prefix of objects to get current policy. |
+|``Policy``   | _minio.policy.Policy_   |Policy enum. Policy.READ_ONLY,Policy.WRITE_ONLY,Policy.READ_WRITE or Policy.NONE.   |
+
 
 __Example__
 
@@ -309,9 +313,9 @@ __Example__
 ```py
 
 # Set policy Policy.READ_ONLY to all object paths in bucket that begin with my-prefixname.
-minioClient.get_bucket_policy(Policy.READ_ONLY,
-                              'mybucket',
-                              'my-prefixname')
+minioClient.set_bucket_policy('mybucket',
+                              'my-prefixname',
+                              Policy.READ_ONLY)
 
 ```
 
@@ -451,7 +455,7 @@ except ResponseError as err:
 
 <a name="fput_object"></a>
 ### fput_object(bucket_name, object_name, file_path, content_type)
-Uploads contents from a file to objectName. 
+Uploads contents from a file to objectName.
 
 __Parameters__
 
@@ -668,7 +672,7 @@ Get the POST form key/value object:
 try:
     signed_form_data = minioClient.presigned_post_policy(post_policy)
 except ResponseError as err:
-    print(err)    
+    print(err)
 
 ```
 
@@ -689,8 +693,7 @@ print(' '.join(curl_cmd))
 ```
 
 ## 5. Explore Further
- 
-- [Minio Golang Client SDK Quickstart Guide](https://docs.minio.io/docs/golang-client-quickstart-guide) 
-- [Minio Java Client SDK Quickstart Guide](https://docs.minio.io/docs/java-client-quickstart-guide) 
-- [Minio JavaScript Client SDK Quickstart Guide](https://docs.minio.io/docs/javascript-client-quickstart-guide)
 
+- [Minio Golang Client SDK Quickstart Guide](https://docs.minio.io/docs/golang-client-quickstart-guide)
+- [Minio Java Client SDK Quickstart Guide](https://docs.minio.io/docs/java-client-quickstart-guide)
+- [Minio JavaScript Client SDK Quickstart Guide](https://docs.minio.io/docs/javascript-client-quickstart-guide)

--- a/examples/set_bucket_policy.py
+++ b/examples/set_bucket_policy.py
@@ -29,22 +29,22 @@ client = Minio('s3.amazonaws.com', secure=True,
 try:
     # Set policy Policy.READ_ONLY to bucket 'my-bucketname' which
     # enables 'my-bucketname' readable by everyone.
-    client.set_bucket_policy(Policy.READ_ONLY, 'my-bucketname')
+    client.set_bucket_policy('my-bucketname', '', Policy.READ_ONLY)
 
     # Set policy Policy.READ_WRITE to bucket 'my-bucketname' and
     # prefix 'public-folder/' which enables
     # 'my-bucketname/public-folder/' read/writeable by everyone.
-    client.set_bucket_policy(Policy.READ_WRITE, 'my-bucketname',
-                             'public-folder/')
+    client.set_bucket_policy('my-bucketname', 'public-folder/',
+                             Policy.READ_WRITE)
 
     # Set policy Policy.WRITE_ONLY to bucket 'my-bucketname' and
     # prefix 'incoming' which enables 'my-bucketname/incoming'
     # writeable by everyone.
-    client.set_bucket_policy(Policy.WRITE_ONLY, 'my-bucketname',
-                             'incoming')
+    client.set_bucket_policy('my-bucketname', 'incoming',
+                             Policy.WRITE_ONLY)
 
     # Set policy Policy.NONE to bucket 'my-bucketname' which
     # removes existing policy and set no access to everyone.
-    client.set_bucket_policy(Policy.NONE, 'my-bucketname')
+    client.set_bucket_policy('my-bucketname', '', Policy.NONE)
 except ResponseError as err:
     print(err)

--- a/minio/api.py
+++ b/minio/api.py
@@ -311,7 +311,7 @@ class Minio(object):
                                       bucket_name=bucket_name,
                                       query={"policy": ""},
                                       headers={})
-            policy_dict = json.loads(response.data)
+            policy_dict = json.loads(response.read().decode('utf-8'))
         except ResponseError as e:
             # Ignore 'NoSuchBucketPolicy' error.
             if e.code != 'NoSuchBucketPolicy':
@@ -336,7 +336,7 @@ class Minio(object):
 
         return policy.get_policy(statements, bucket_name, prefix)
 
-    def set_bucket_policy(self, policy_access, bucket_name, prefix=""):
+    def set_bucket_policy(self, bucket_name, prefix, policy_access):
         """
         Set bucket policy of given bucket name and object prefix.
 
@@ -368,9 +368,11 @@ class Minio(object):
             policy_dict['Statement'] = statements
             content = json.dumps(policy_dict)
 
-            headers = {'Content-Length': str(len(content)),
-                       'Content-MD5': encode_to_base64(get_md5(content))}
-            content_sha256_hex = encode_to_hex(get_sha256(content))
+            headers = {
+                'Content-Length': str(len(content)),
+                'Content-MD5': encode_to_base64(get_md5(content.encode('utf-8')))
+            }
+            content_sha256_hex = encode_to_hex(get_sha256(content.encode('utf-8')))
 
             self._url_open("PUT",
                            bucket_name=bucket_name,

--- a/minio/policy.py
+++ b/minio/policy.py
@@ -24,6 +24,8 @@ This module implements policy management.
 
 """
 
+from .compat import basestring
+
 import collections
 import fnmatch
 import itertools

--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -24,6 +24,7 @@ import certifi
 from datetime import datetime, timedelta
 
 from minio import Minio, PostPolicy
+from minio.policy import Policy
 from minio.error import ResponseError
 
 from faker import Factory
@@ -137,6 +138,21 @@ def main():
     # Remove an object.
     print(client.remove_object(bucket_name, object_name))
     print(client.remove_object(bucket_name, object_name+'-f'))
+
+    policy_name = client.get_bucket_policy(bucket_name)
+    if policy_name != Policy.NONE:
+        raise ValueError('Policy name is invalid ' + policy_name)
+
+    # Set read-write policy successfully.
+    client.set_bucket_policy(bucket_name, '', Policy.READ_WRITE)
+
+    # Reset policy to NONE.
+    client.set_bucket_policy(bucket_name, '', Policy.NONE)
+
+    # Validate if the policy is reverted back to NONE.
+    policy_name = client.get_bucket_policy(bucket_name)
+    if policy_name != Policy.NONE:
+        raise ValueError('Policy name is invalid ' + policy_name)
 
     # Remove a bucket. This operation will only work if your bucket is empty.
     print(client.remove_bucket(bucket_name))


### PR DESCRIPTION
Also fix the API set_bucket_policy() should take input
policy as the last option and API should be consistent
with other languages.

This patch also adds a functional test case.

Fixes #399