### PR TITLE
Fix doc for `put_object`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -699,7 +699,7 @@ __Parameters__
 |:---|:---|:---|
 |``bucket_name``   |_string_   |Name of the bucket.   |
 |``object_name``   |_string_    |Name of the object.   |
-|``data``   |_io.IOBase_   |Any python object implementing io.IOBase. |
+|``data``   |_io.RawIOBase_   |Any python object implementing io.RawIOBase. |
 |``length``   |_int_   |Total length of object.   |
 |``content_type``   |_string_ | Content type of the object. (optional, defaults to 'application/octet-stream').   |
 


### PR DESCRIPTION
Python's io.IOBase does not implement the read() method, but
io.RawIOBase does (in both major Python versions 2.7 and 3.5).

Technically, we only need an object that implements a `read()` method that takes an integer. We make no use of any of the other methods.