### PR TITLE
Fix sign v4 breakage in Python 3

### DIFF
--- a/minio/signer.py
+++ b/minio/signer.py
@@ -191,7 +191,7 @@ def sign_v4(method, url, region, headers=None, access_key=None,
         content_sha256 = _UNSIGNED_PAYLOAD
     if content_sha256 is None:
         # with no payload, calculate sha256 for 0 length data.
-        content_sha256 = encode_to_hex(get_sha256(b''))
+        content_sha256 = encode_to_hex(get_sha256(b'')).decode('ascii')
 
     host = parsed_url.netloc
     headers['Host'] = host


### PR DESCRIPTION
It was introduced in commit id 31e8a35b18436267b0582cfb9e3f16f8ed65017a - once this was found (with git bisect), the fix was easy to figure out.

`_get_bucket_region()` was failing in Python 3 with signature mismatch
error.

Short program that demonstrates the issue:

```py
from minio import Minio
from minio.error import ResponseError
from sys import stdout
s3Client = Minio(
    'localhost:9000',
    access_key='minio',
    secret_key='minio123',
    secure=False,
)

s3Client.trace_on(stdout)

objects = s3Client.list_objects('aditya', recursive=True)

for c, obj in enumerate(objects):
    print(obj)
    if c > 10:
        break

```

Generates:
```sh
Traceback (most recent call last):
  File "../minio-test.py", line 21, in <module>
    for c, obj in enumerate(objects):
  File "/home/aditya/Code/minio-code/python/venv/lib/python3.5/site-packages/minio-2.0.3-py3.5.egg/minio/api.py", line 912, in list_objects
  File "/home/aditya/Code/minio-code/python/venv/lib/python3.5/site-packages/minio-2.0.3-py3.5.egg/minio/api.py", line 1699, in _url_open
  File "/home/aditya/Code/minio-code/python/venv/lib/python3.5/site-packages/minio-2.0.3-py3.5.egg/minio/api.py", line 1645, in _get_bucket_region
  File "/home/aditya/Code/minio-code/python/venv/lib/python3.5/site-packages/minio-2.0.3-py3.5.egg/minio/api.py", line 1678, in _get_bucket_location
minio.error.ResponseError: ResponseError: code: SignatureDoesNotMatch, message: The request signature we calculated does not match the signature you provided. Check your key and signing method., bucket_name: None, object_name: None, request_id: RUSVQ0114N14O0ZG, host_id: 3L137, region: 
```