### PR TITLE
Add Multi-Object Delete API support (Fixes #413)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -37,7 +37,8 @@ s3Client = Minio('s3.amazonaws.com',
 | [`bucket_exists`](#bucket_exists) | [`copy_object`](#copy_object) | [`presigned_post_policy`](#presigned_post_policy) | [`get_bucket_notification`](#get_bucket_notification) |
 | [`remove_bucket`](#remove_bucket) | [`stat_object`](#stat_object) | | [`set_bucket_notification`](#set_bucket_notification) |
 | [`list_objects`](#list_objects) | [`remove_object`](#remove_object) | | [`remove_all_bucket_notification`](#remove_all_bucket_notification) |
-| [`list_incomplete_uploads`](#list_incomplete_uploads) | [`remove_incomplete_upload`](#remove_incomplete_upload) | | [`listen_bucket_notification`](#listen_bucket_notification) |
+| [`list_incomplete_uploads`](#list_incomplete_uploads) | [`remove_objects`](#remove_objects) | | [`listen_bucket_notification`](#listen_bucket_notification) |
+| | [`remove_incomplete_upload`](#remove_incomplete_upload) | | |
 | | [`fput_object`](#fput_object) | | |
 | | [`fget_object`](#fget_object) | | |
 | | [`get_partial_object`](#get_partial_object) | | |
@@ -823,6 +824,58 @@ __Example__
 # Remove an object.
 try:
     minioClient.remove_object('mybucket', 'myobject')
+except ResponseError as err:
+    print(err)
+
+```
+
+<a name="remove_objects"></a>
+### remove_objects(bucket_name, objects_iter)
+Removes multiple objects in a bucket.
+
+__Parameters__
+
+|Param   |Type   |Description   |
+|:---|:---|:---|
+|``bucket_name``   | _string_  | Name of the bucket.   |
+|``objects_iter``   | _list_ , _tuple_ or _iterator_ | List-like value containing object-name strings to delete.   |
+
+__Return Value__
+
+|Param   |Type   |Description   |
+|:---|:---|:---|
+|``delete_error_iterator`` | _iterator_ of _MultiDeleteError_ instances | Lazy iterator of delete errors described below. |
+
+_NOTE:_
+
+1. The iterator returned above must be evaluated (for e.g. using
+a loop), as the function is lazy and will not evaluate by default.
+
+2. The iterator will contain items only if there are errors when the
+service performs a delete operation on it. Each item contains error
+information for an object that had a delete error.
+
+Each delete error produced by the iterator has the following
+structure:
+
+|Param |Type |Description |
+|:---|:---|:---|
+|``MultiDeleteError.object_name`` | _string_ | Object name that had a delete error. |
+|``MultiDeleteError.error_code`` | _string_ | Error code. |
+|``MultiDeleteError.error_message`` | _string_ | Error message. |
+
+__Example__
+
+
+```py
+
+# Remove multiple objects in a single library call.
+try:
+    objects_to_delete = ['myobject-1', 'myobject-2', 'myobject-3']
+    # force evaluation of the remove_objects() call by iterating over
+    # the returned value.
+    for del_err in minioClient.remove_objects('mybucket', objects_to_delete):
+        print("Deletion Error: {}".format(del_err))
 except ResponseError as err:
     print(err)
 

--- a/examples/removing_objects.py
+++ b/examples/removing_objects.py
@@ -28,3 +28,13 @@ try:
     client.remove_object('my-bucketname', 'my-objectname')
 except ResponseError as err:
     print(err)
+
+# Remove multiple objects in a single library call.
+try:
+    objects_to_delete = ['myobject-1', 'myobject-2', 'myobject-3']
+    # force evaluation of the remove_objects() call by iterating over
+    # the returned value.
+    for del_err in client.remove_objects('mybucket', objects_to_delete):
+        print("Deletion Error: {}".format(del_err))
+except ResponseError as err:
+    print(err)

--- a/minio/error.py
+++ b/minio/error.py
@@ -117,6 +117,28 @@ class InvalidXMLError(Exception):
         return string_format.format(self.message)
 
 
+class MultiDeleteError(object):
+    """
+    Represents an error raised when trying to delete an object in a
+    Multi-Object Delete API call :class:`MultiDeleteError <MultiDeleteError>`
+
+    :object_name: Object name that had a delete error.
+    :error_code: Error code.
+    :error_message: Error message.
+    """
+    def __init__(self, object_name, err_code, err_message):
+        self.object_name = object_name
+        self.error_code = err_code
+        self.error_message = err_message
+
+    def __str__(self):
+        string_format = '<MultiDeleteError: object_name: {} error_code: {}' \
+                        ' error_message: {}>'
+        return string_format.format(self.object_name,
+                                    self.error_code,
+                                    self.error_message)
+
+
 class ResponseError(Exception):
     """
     ResponseError is raised when an API call doesn't succeed.

--- a/minio/xml_marshal.py
+++ b/minio/xml_marshal.py
@@ -197,3 +197,29 @@ def _add_notification_config_to_xml(node, element_name, configs):
                 value_node = s3_xml.SubElement(filter_rule_node, 'Value')
                 value_node.text = filter_rule['Value']
     return node
+
+def xml_marshal_delete_objects(object_names):
+    """
+    Marshal Multi-Object Delete request body from object names.
+
+    :param object_names: List of object keys to be deleted.
+    :return: Serialized XML string for multi-object delete request body.
+    """
+    root = s3_xml.Element('Delete')
+
+    # use quiet mode in the request - this causes the S3 Server to
+    # limit its response to only object keys that had errors during
+    # the delete operation.
+    quiet = s3_xml.SubElement(root, 'Quiet')
+    quiet.text = "true"
+
+    # add each object to the request.
+    for object_name in object_names:
+        object_elt = s3_xml.SubElement(root, 'Object')
+        key_elt = s3_xml.SubElement(object_elt, 'Key')
+        key_elt.text = object_name
+
+    # return the marshalled xml.
+    data = io.BytesIO()
+    s3_xml.ElementTree(root).write(data, encoding=None, xml_declaration=False)
+    return data.getvalue()

--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -177,6 +177,28 @@ def main():
     if policy_name != Policy.NONE:
         raise ValueError('Policy name is invalid ' + policy_name)
 
+    # Upload some new objects to prepare for multi-object delete test.
+    print("Prepare for remove_objects() test.")
+    object_names = []
+    for i in range(10):
+        curr_object_name = object_name+"-{}".format(i)
+        print("object-name: {}".format(curr_object_name))
+        print(client.fput_object(
+            bucket_name, curr_object_name, "testfile"))
+        object_names.append(curr_object_name)
+
+    # delete the objects in a single library call.
+    print("Performing remove_objects() test.")
+    del_errs = client.remove_objects(bucket_name, object_names)
+    had_errs = False
+    for del_err in del_errs:
+        had_errs = True
+        print("Err is {}".format(del_err))
+    if had_errs:
+        print("remove_objects() FAILED - it had unexpected errors.")
+    else:
+        print("remove_objects() worked as expected.")
+
     # Remove a bucket. This operation will only work if your bucket is empty.
     print(client.remove_bucket(bucket_name))
     print(client.remove_bucket(bucket_name+'.unique'))

--- a/tests/unit/remove_objects_test.py
+++ b/tests/unit/remove_objects_test.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2016 Minio, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+import itertools
+
+from unittest import TestCase
+from nose.tools import raises
+
+from minio import Minio
+from minio.api import _DEFAULT_USER_AGENT
+from minio.error import InvalidBucketError
+
+from .minio_mocks import MockResponse, MockConnection
+
+class RemoveObjectsTest(TestCase):
+    @raises(TypeError)
+    def test_object_is_non_string_iterable_1(self):
+        client = Minio('localhost:9000')
+        for err in client.remove_objects('hello', 1234):
+            print(err)
+
+    @raises(TypeError)
+    def test_object_is_non_string_iterable_2(self):
+        client = Minio('localhost:9000')
+        for err in client.remove_objects('hello', u'abc'):
+            print(err)
+
+    @raises(TypeError)
+    def test_object_is_non_string_iterable_3(self):
+        client = Minio('localhost:9000')
+        for err in client.remove_objects('hello', b'abc'):
+            print(err)
+
+    @raises(InvalidBucketError)
+    def test_bucket_invalid_name(self):
+        client = Minio('localhost:9000')
+        for err in client.remove_objects('ABCD', 'world'):
+            print(err)
+
+    @mock.patch('urllib3.PoolManager')
+    def test_object_is_list(self, mock_connection):
+        mock_server = MockConnection()
+        mock_connection.return_value = mock_server
+        mock_server.mock_add_request(
+            MockResponse('POST',
+                         'https://localhost:9000/hello/?delete',
+                         {'Content-Length': 95,
+                          'User-Agent': _DEFAULT_USER_AGENT,
+                          'Content-Md5': u'5Tg5SmU9Or43L4+iIyfPrQ=='}, 200,
+                         content='<Delete/>')
+        )
+        client = Minio('localhost:9000')
+        for err in client.remove_objects('hello', ["Ab", "c"]):
+            print(err)
+
+    @mock.patch('urllib3.PoolManager')
+    def test_object_is_tuple(self, mock_connection):
+        mock_server = MockConnection()
+        mock_connection.return_value = mock_server
+        mock_server.mock_add_request(
+            MockResponse('POST',
+                         'https://localhost:9000/hello/?delete',
+                         {'Content-Length': 95,
+                          'User-Agent': _DEFAULT_USER_AGENT,
+                          'Content-Md5': u'5Tg5SmU9Or43L4+iIyfPrQ=='}, 200,
+                         content='<Delete/>')
+        )
+        client = Minio('localhost:9000')
+        for err in client.remove_objects('hello', ('Ab', 'c')):
+            print(err)
+
+    @mock.patch('urllib3.PoolManager')
+    def test_object_is_iterator(self, mock_connection):
+        mock_server = MockConnection()
+        mock_connection.return_value = mock_server
+        mock_server.mock_add_request(
+            MockResponse('POST',
+                         'https://localhost:9000/hello/?delete',
+                         {'Content-Length': 95,
+                          'User-Agent': _DEFAULT_USER_AGENT,
+                          'Content-Md5': u'5Tg5SmU9Or43L4+iIyfPrQ=='}, 200,
+                         content='<Delete/>')
+        )
+        client = Minio('localhost:9000')
+        it = itertools.chain(('Ab', 'c'))
+        for err in client.remove_objects('hello', it):
+            print(err)


### PR DESCRIPTION
* Adds new `remove_objects` method that performs multi-object delete.
* Adds unit tests.
* Adds functional tests.
* Adds documentation and example.