### PR TITLE
Add List Objects V2 API (Fixes #376)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The full API Reference is available here.
 * [`bucket_exists`](https://docs.minio.io/docs/python-client-api-reference#bucket_exists)
 * [`remove_bucket`](https://docs.minio.io/docs/python-client-api-reference#remove_bucket)
 * [`list_objects`](https://docs.minio.io/docs/python-client-api-reference#list_objects)
+* [`list_objects_v2`](https://docs.minio.io/docs/python-client-api-reference#list_objects_v2)
 * [`list_incomplete_uploads`](https://docs.minio.io/docs/python-client-api-reference#list_incomplete_uploads)
 
 ### API Reference : Bucket policy Operations
@@ -131,6 +132,7 @@ The full API Reference is available here.
 * [`copy_object`](https://docs.minio.io/docs/python-client-api-reference#copy_object)
 * [`get_partial_object`](https://docs.minio.io/docs/python-client-api-reference#get_partial_object)
 * [`remove_object`](https://docs.minio.io/docs/python-client-api-reference#remove_object)
+* [`remove_objects`](https://docs.minio.io/docs/python-client-api-reference#remove_objects)
 * [`remove_incomplete_upload`](https://docs.minio.io/docs/python-client-api-reference#remove_incomplete_upload)
 
 ### API Reference : Presigned Operations
@@ -180,6 +182,7 @@ The full API Reference is available here.
 * [copy_object.py](https://github.com/minio/minio-py/blob/master/examples/copy_object.py)
 * [get_partial_object.py](https://github.com/minio/minio-py/blob/master/examples/get_partial_object.py)
 * [remove_object.py](https://github.com/minio/minio-py/blob/master/examples/remove_object.py)
+* [remove_objects.py](https://github.com/minio/minio-py/blob/master/examples/remove_objects.py)
 * [remove_incomplete_upload.py](https://github.com/minio/minio-py/blob/master/examples/remove_incomplete_upload.py)
 
 #### Full Examples : Presigned Operations

--- a/docs/API.md
+++ b/docs/API.md
@@ -37,8 +37,8 @@ s3Client = Minio('s3.amazonaws.com',
 | [`bucket_exists`](#bucket_exists) | [`copy_object`](#copy_object) | [`presigned_post_policy`](#presigned_post_policy) | [`get_bucket_notification`](#get_bucket_notification) |
 | [`remove_bucket`](#remove_bucket) | [`stat_object`](#stat_object) | | [`set_bucket_notification`](#set_bucket_notification) |
 | [`list_objects`](#list_objects) | [`remove_object`](#remove_object) | | [`remove_all_bucket_notification`](#remove_all_bucket_notification) |
-| [`list_incomplete_uploads`](#list_incomplete_uploads) | [`remove_objects`](#remove_objects) | | [`listen_bucket_notification`](#listen_bucket_notification) |
-| | [`remove_incomplete_upload`](#remove_incomplete_upload) | | |
+| [`list_objects_v2`](#list_objects_v2) | [`remove_objects`](#remove_objects) | | [`listen_bucket_notification`](#listen_bucket_notification) |
+| [`list_incomplete_uploads`](#list_incomplete_uploads) | [`remove_incomplete_upload`](#remove_incomplete_upload) | | |
 | | [`fput_object`](#fput_object) | | |
 | | [`fget_object`](#fget_object) | | |
 | | [`get_partial_object`](#get_partial_object) | | |
@@ -221,6 +221,45 @@ __Example__
 
 # List all object paths in bucket that begin with my-prefixname.
 objects = minioClient.list_objects('mybucket', prefix='my-prefixname',
+                              recursive=True)
+for obj in objects:
+    print(obj.bucket_name, obj.object_name.encode('utf-8'), obj.last_modified,
+          obj.etag, obj.size, obj.content_type)
+```
+
+<a name="list_objects_v2"></a>
+### list_objects_v2(bucket_name, prefix, recursive=False)
+Lists objects in a bucket using the Version 2 API.
+
+__Parameters__
+
+| Param  |Type  | Description  |
+|:---|:---|:---|
+|``bucket_name``   |_string_ | Name of the bucket.  |
+|``objectPrefix``   | _string_ |The prefix of the objects that should be listed. |
+|``recursive``   | _bool_ |``True`` indicates recursive style listing and ``False`` indicates directory style listing delimited by '/'. Optional default is False.   |
+
+__Return Value__
+
+| Param  |Type  | Description  |
+|:---|:---|:---|
+|``object``   |_Object_ | Iterator for all the objects in the bucket, the object is of the format listed below:  |
+
+| Param  |Type  | Description  |
+|:---|:---|:---|
+|``object.object_name``   |_string_ | name of the object.  |
+|``object.size`` |_int_ | size of the object.  |
+|``object.etag``   |_string_ | etag of the object.  |
+|``object.last_modified`` |_datetime.datetime_ | modified time stamp.  |
+
+
+
+__Example__
+
+```py
+
+# List all object paths in bucket that begin with my-prefixname.
+objects = minioClient.list_objects_v2('mybucket', prefix='my-prefixname',
                               recursive=True)
 for obj in objects:
     print(obj.bucket_name, obj.object_name.encode('utf-8'), obj.last_modified,

--- a/examples/remove_object.py
+++ b/examples/remove_object.py
@@ -13,26 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY, my-bucketname and my-prefixname
+# Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY, my-bucketname and my-objectname
 # are dummy values, please replace them with original values.
 
 from minio import Minio
+from minio.error import ResponseError
 
 client = Minio('s3.amazonaws.com',
                access_key='YOUR-ACCESSKEYID',
                secret_key='YOUR-SECRETACCESSKEY')
 
-# List all object paths in bucket that begin with my-prefixname.
-objects = client.list_objects('my-bucketname', prefix='my-prefixname',
-                              recursive=True)
-for obj in objects:
-    print(obj.bucket_name, obj.object_name.encode('utf-8'), obj.last_modified,
-          obj.etag, obj.size, obj.content_type)
-
-# List all object paths in bucket that begin with my-prefixname using
-# V2 listing API.
-objects = client.list_objects_v2('my-bucketname', prefix='my-prefixname',
-                              recursive=True)
-for obj in objects:
-    print(obj.bucket_name, obj.object_name.encode('utf-8'), obj.last_modified,
-          obj.etag, obj.size, obj.content_type)
+# Remove an object.
+try:
+    client.remove_object('my-bucketname', 'my-objectname')
+except ResponseError as err:
+    print(err)

--- a/examples/remove_objects.py
+++ b/examples/remove_objects.py
@@ -23,12 +23,6 @@ client = Minio('s3.amazonaws.com',
                access_key='YOUR-ACCESSKEYID',
                secret_key='YOUR-SECRETACCESSKEY')
 
-# Remove an object.
-try:
-    client.remove_object('my-bucketname', 'my-objectname')
-except ResponseError as err:
-    print(err)
-
 # Remove multiple objects in a single library call.
 try:
     objects_to_delete = ['myobject-1', 'myobject-2', 'myobject-3']

--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -125,7 +125,15 @@ def main():
     print(client.fget_object(bucket_name, object_name, 'newfile-f'))
 
     # List all object paths in bucket.
+    print("Listing using ListObjects API")
     objects = client.list_objects(bucket_name, recursive=True)
+    for obj in objects:
+        print(obj.bucket_name, obj.object_name, obj.last_modified, \
+            obj.etag, obj.size, obj.content_type)
+
+    # List all object paths in bucket using V2 API.
+    print("Listing using ListObjectsV2 API")
+    objects = client.list_objects_v2(bucket_name, recursive=True)
     for obj in objects:
         print(obj.bucket_name, obj.object_name, obj.last_modified, \
             obj.etag, obj.size, obj.content_type)

--- a/tests/unit/list_objects_v2_test.py
+++ b/tests/unit/list_objects_v2_test.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+
+from nose.tools import eq_, timed
+from unittest import TestCase
+
+from minio import Minio
+from minio.api import _DEFAULT_USER_AGENT
+
+from .minio_mocks import MockResponse, MockConnection
+
+class ListObjectsV2Test(TestCase):
+    @mock.patch('urllib3.PoolManager')
+    def test_empty_list_objects_works(self, mock_connection):
+        mock_data = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+              <Name>bucket</Name>
+              <Prefix></Prefix>
+              <KeyCount>0</KeyCount>
+              <MaxKeys>1000</MaxKeys>
+              <Delimiter></Delimiter>
+              <IsTruncated>false</IsTruncated>
+            </ListBucketResult>
+        '''
+        mock_server = MockConnection()
+        mock_connection.return_value = mock_server
+        mock_server.mock_add_request(MockResponse('GET',
+                                                  'https://localhost:9000/bucket/?list-type=2',
+                                                  {'User-Agent': _DEFAULT_USER_AGENT}, 200, content=mock_data))
+        client = Minio('localhost:9000')
+        object_iter = client.list_objects_v2('bucket', recursive=True)
+        objects = []
+        for obj in object_iter:
+            objects.append(obj)
+        eq_(0, len(objects))
+
+    @timed(1)
+    @mock.patch('urllib3.PoolManager')
+    def test_list_objects_works(self, mock_connection):
+        mock_data = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+              <Name>bucket</Name>
+              <Prefix></Prefix>
+              <KeyCount>2</KeyCount>
+              <MaxKeys>1000</MaxKeys>
+              <IsTruncated>false</IsTruncated>
+              <Contents>
+                <Key>6/f/9/6f9898076bb08572403f95dbb86c5b9c85e1e1b3</Key>
+                <LastModified>2016-11-27T07:55:53.000Z</LastModified>
+                <ETag>&quot;5d5512301b6b6e247b8aec334b2cf7ea&quot;</ETag>
+                <Size>493</Size>
+                <StorageClass>REDUCED_REDUNDANCY</StorageClass>
+              </Contents>
+              <Contents>
+                <Key>b/d/7/bd7f6410cced55228902d881c2954ebc826d7464</Key>
+                <LastModified>2016-11-27T07:10:27.000Z</LastModified>
+                <ETag>&quot;f00483d523ffc8b7f2883ae896769d85&quot;</ETag>
+                <Size>493</Size>
+                <StorageClass>REDUCED_REDUNDANCY</StorageClass>
+              </Contents>
+            </ListBucketResult>
+        '''
+        mock_server = MockConnection()
+        mock_connection.return_value = mock_server
+        mock_server.mock_add_request(
+            MockResponse(
+                'GET',
+                'https://localhost:9000/bucket/?delimiter=%2F&list-type=2',
+                {'User-Agent': _DEFAULT_USER_AGENT}, 200,
+                content=mock_data
+            )
+        )
+        client = Minio('localhost:9000')
+        objects_iter = client.list_objects_v2('bucket')
+        objects = []
+        for obj in objects_iter:
+            objects.append(obj)
+
+        eq_(2, len(objects))


### PR DESCRIPTION
* Adds new `list_objects_v2` function that uses the V2 List Objects API
* Adds unit test and functional test.
* Adds docs and example.

This patch also incorporates a better namespace aware XML parsing style. The existing `list_objects` function should also be separately improved to use this style.