### PR TITLE
Add support for `response_headers` argument on `presigned_get_object`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -957,6 +957,8 @@ __Parameters__
 |``bucket_name``   |_string_   |Name of the bucket.   |
 |``object_name``   |_string_    |Name of the object.   |
 |``expiry``   | _datetime.datetime_    |Expiry in seconds. Default expiry is set to 7 days.    |
+|``response_headers``   | _dictionary_    |Additional headers to include
+(e.g. `Response-Content-Type` or `Response-Content-Disposition`)     |
 
 __Example__
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -957,8 +957,7 @@ __Parameters__
 |``bucket_name``   |_string_   |Name of the bucket.   |
 |``object_name``   |_string_    |Name of the object.   |
 |``expiry``   | _datetime.datetime_    |Expiry in seconds. Default expiry is set to 7 days.    |
-|``response_headers``   | _dictionary_    |Additional headers to include
-(e.g. `Response-Content-Type` or `Response-Content-Disposition`)     |
+|``response_headers``   | _dictionary_    |Additional headers to include (e.g. `Response-Content-Type` or `Response-Content-Disposition`)     |
 
 __Example__
 

--- a/minio/api.py
+++ b/minio/api.py
@@ -1286,7 +1286,8 @@ class Minio(object):
                 return
 
     def presigned_get_object(self, bucket_name, object_name,
-                             expires=timedelta(days=7)):
+                             expires=timedelta(days=7),
+                             response_headers=None):
         """
         Presigns a get object request and provides a url
 
@@ -1313,7 +1314,8 @@ class Minio(object):
 
         return self._presigned_get_partial_object(bucket_name,
                                                   object_name,
-                                                  expires)
+                                                  expires,
+                                                  response_headers=response_headers)
 
     def presigned_put_object(self, bucket_name, object_name,
                              expires=timedelta(days=7)):
@@ -1463,7 +1465,8 @@ class Minio(object):
 
     def _presigned_get_partial_object(self, bucket_name, object_name,
                                       expires=timedelta(days=7),
-                                      offset=0, length=0):
+                                      offset=0, length=0,
+                                      response_headers=None):
         """
         Presigns a get partial object request and provides a url,
         this is a internal function not exposed.
@@ -1491,6 +1494,7 @@ class Minio(object):
                              bucket_name=bucket_name,
                              object_name=object_name,
                              bucket_region=region)
+
         headers = {}
 
         if request_range:
@@ -1502,6 +1506,7 @@ class Minio(object):
                                  self._secret_key,
                                  region=region,
                                  headers=headers,
+                                 response_headers=response_headers,
                                  expires=int(expires.total_seconds()))
         return presign_url
 

--- a/minio/signer.py
+++ b/minio/signer.py
@@ -60,7 +60,7 @@ def post_presign_signature(date, region, secret_key, policy_str):
 
 
 def presign_v4(method, url, access_key, secret_key, region=None,
-               headers=None, expires=None):
+               headers=None, expires=None, response_headers=None):
     """
     Calculates signature version '4' for regular presigned URLs.
 
@@ -96,6 +96,9 @@ def presign_v4(method, url, access_key, secret_key, region=None,
 
     headers_to_sign = dict(headers)
 
+    if response_headers is not None:
+        headers_to_sign.update(response_headers)
+
     # Remove amazon recommended headers.
     headers_to_sign = ignore_headers(headers)
 
@@ -108,6 +111,9 @@ def presign_v4(method, url, access_key, secret_key, region=None,
     query['X-Amz-Expires'] = expires
     signed_headers = get_signed_headers(headers_to_sign)
     query['X-Amz-SignedHeaders'] = ';'.join(signed_headers)
+
+    if response_headers is not None:
+        query.update(response_headers)
 
     # URL components.
     url_components = [parsed_url.geturl()]
@@ -144,6 +150,7 @@ def presign_v4(method, url, access_key, secret_key, region=None,
                          hashlib.sha256).hexdigest()
     new_parsed_url = urlsplit(new_url + "&X-Amz-Signature="+signature)
     return new_parsed_url.geturl()
+
 
 
 def get_signed_headers(headers):

--- a/tests/unit/presigned_get_object_test.py
+++ b/tests/unit/presigned_get_object_test.py
@@ -22,6 +22,7 @@ from unittest import TestCase
 from minio import Minio
 from minio.error import InvalidArgumentError
 
+
 class PresignedGetObjectTest(TestCase):
     @raises(TypeError)
     def test_object_is_string(self):
@@ -37,3 +38,17 @@ class PresignedGetObjectTest(TestCase):
     def test_expiry_limit(self):
         client = Minio('localhost:9000')
         client.presigned_get_object('hello', 'key', expires=timedelta(days=8))
+
+    def test_can_include_response_headers(self):
+        client = Minio('localhost:9000', 'my_access_key', 'my_secret_key',
+                       secure=True)
+        client._get_bucket_region = mock.Mock(return_value='us-east-1')
+        r = client.presigned_get_object(
+            'mybucket', 'myfile.pdf',
+            response_headers={
+                'Response-Content-Type': 'application/pdf',
+                'Response-Content-Disposition': 'inline;  filename="test.pdf"'
+            })
+        self.assertIn('inline', r)
+        self.assertIn('test.pdf', r)
+        self.assertIn(b'application%2Fpdf', r)

--- a/tests/unit/presigned_get_object_test.py
+++ b/tests/unit/presigned_get_object_test.py
@@ -51,4 +51,4 @@ class PresignedGetObjectTest(TestCase):
             })
         self.assertIn('inline', r)
         self.assertIn('test.pdf', r)
-        self.assertIn(b'application%2Fpdf', r)
+        self.assertIn('application%2Fpdf', r)


### PR DESCRIPTION
This allows users to specify additional querystring params supported by S3 API such as
`response-content-type` and `response-content-disposition`.

This was done following discussion on Gitter with @harshavardhana and @balamurugana