### PR TITLE
Part 2 of Strings/Bytes Refactor:

### DIFF
--- a/minio/post_policy.py
+++ b/minio/post_policy.py
@@ -24,8 +24,9 @@ This module contains :class:`PostPolicy <PostPolicy>` implementation.
 
 """
 
-from .helpers import (is_non_empty_string, is_valid_bucket_name,
-                      encode_to_base64)
+import base64
+
+from .helpers import (is_non_empty_string, is_valid_bucket_name)
 
 
 # Policy explanation:
@@ -154,7 +155,7 @@ class PostPolicy(object):
         """
         Encode json byte array into base64.
         """
-        return encode_to_base64(self._marshal_json())
+        return base64.b64encode(self._marshal_json())
 
     def is_expiration_set(self):
         """

--- a/minio/signer.py
+++ b/minio/signer.py
@@ -33,8 +33,7 @@ import binascii
 from datetime import datetime
 from .error import InvalidArgumentError
 from .compat import urlsplit, parse_qs, basestring, urlencode
-from .helpers import (ignore_headers, encode_to_hex,
-                      get_sha256_hexdigest)
+from .helpers import (ignore_headers, get_sha256_hexdigest)
 
 # Signature version '4' algorithm.
 _SIGN_V4_ALGORITHM = 'AWS4-HMAC-SHA256'


### PR DESCRIPTION
- Modify `get_md5` to `get_md5_base64digest`. This function now works
  for both str and bytes type inputs and returns str
  type (i.e. unicode string). It performs base64 encoding. This
  simplifies md5 related hashing code. It has the same behaviour in
  both Py2 and Py3 now.

- Add new Hasher class that provides `md5` an `sha256` hashers similar
  to hashlib, but always returns unicode string encoded hex/base64
  digests.

Towards resolving #437