### PR TITLE
Changed response_header to lowercase in docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -957,7 +957,7 @@ __Parameters__
 |``bucket_name``   |_string_   |Name of the bucket.   |
 |``object_name``   |_string_    |Name of the object.   |
 |``expiry``   | _datetime.datetime_    |Expiry in seconds. Default expiry is set to 7 days.    |
-|``response_headers``   | _dictionary_    |Additional headers to include (e.g. `Response-Content-Type` or `Response-Content-Disposition`)     |
+|``response_headers``   | _dictionary_    |Additional headers to include (e.g. `response-content-type` or `response-content-disposition`)     |
 
 __Example__
 


### PR DESCRIPTION
It seems that the Minio Server expects the response_headers in lowercase.  When using the camel case version of the header names, the server does not include the headers. Thus, I modified the docs according to this convention.