### PR TITLE
Make HTTP(S) responses always preload content by default:

### DIFF
--- a/tests/unit/minio_mocks.py
+++ b/tests/unit/minio_mocks.py
@@ -50,6 +50,9 @@ class MockResponse(object):
             return iter(bytearray(self.data, 'utf-8'))
         return iter([])
 
+    # dummy release connection call.
+    def release_conn(self):
+        return
 
 class MockConnection(object):
     def __init__(self):


### PR DESCRIPTION
For most API requests (except GET object), the response is not large
and can be loaded into memory. Preloading content makes re-use of
connections automatic - the connection is returned to the connection
pool before the response object is returned to the caller of
urlopen().

The only exception, GET object, uses preload_content=False - this
allows the caller to incrementally process the response - but as a
caveat would need to release the connection manually by calling
`release_conn()` on the returned object. Docstrings have been
updated to reflect this.

Fixes #458.