### PR TITLE
Allow bucket region cache to be overriden.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -60,8 +60,9 @@ __Parameters__
 |:---|:---|:---|
 | `endpoint`  | _string_  | S3 object storage endpoint.  |
 | `access_key`  | _string_  | Access key for the object storage endpoint. (Optional if you need anonymous access).  |
-|  `secret_key` | _string_  |  Secret key for the object storage endpoint. (Optional if you need anonymous access). |
+| `secret_key` | _string_  |  Secret key for the object storage endpoint. (Optional if you need anonymous access). |
 | `secure`  |_bool_   | Set this value to `True` to enable secure (HTTPS) access. (Optional defaults to `True`).  |
+| `region`  |_string_ | Set this value to override automatic bucket location discovery. (Optional defaults to `None`). |
 
 __Example__
 


### PR DESCRIPTION
Add region= option to our API constructor. This option
is added to avoid making calls to server when an
application written using `minio-py` is only meant
to generate presigned URLs which is a quite common use
case.

Setting this option - overrides any future region
changes and makes the API more stricter. For example
if you are going to use your initialized client
against a bucket which exists in a different region
all API operations would fail.