### PR TITLE
Custom certificate bundles

### DIFF
--- a/minio/api.py
+++ b/minio/api.py
@@ -119,7 +119,8 @@ class Minio(object):
     def __init__(self, endpoint, access_key=None,
                  secret_key=None, secure=True,
                  region=None,
-                 timeout=None):
+                 timeout=None,
+				 certificate_bundle=certifi.where()):
 
         # Validate endpoint.
         is_valid_endpoint(endpoint)
@@ -145,7 +146,7 @@ class Minio(object):
         self._http = urllib3.PoolManager(
             timeout=self._conn_timeout,
             cert_reqs='CERT_REQUIRED',
-            ca_certs=certifi.where(),
+            ca_certs=certificate_bundle,
             retries=urllib3.Retry(
                 total=5,
                 backoff_factor=0.2,

--- a/minio/api.py
+++ b/minio/api.py
@@ -120,7 +120,7 @@ class Minio(object):
                  secret_key=None, secure=True,
                  region=None,
                  timeout=None,
-				 certificate_bundle=certifi.where()):
+		 certificate_bundle=certifi.where()):
 
         # Validate endpoint.
         is_valid_endpoint(endpoint)


### PR DESCRIPTION
Added a parameter to the Minio class initialization method that allows users to provide their own certificate bundle. One example use case scenario would be if a user wanted to provide a self signed certificate to use with their Minio object. If the user doesn't provide a certificate bundle themselves, Minio will default to using Certifi's (certifi.where()) certificate bundle.