### PR TITLE
signV4: Fix signature issue while doing multipart upload.

### DIFF
--- a/minio/api.py
+++ b/minio/api.py
@@ -1205,7 +1205,7 @@ class Minio(object):
 
         # Initialize query parameters.
         query = {
-            'uploads': None,
+            'uploads': '',
             'max-uploads': 1000
         }
 
@@ -1700,7 +1700,7 @@ class Minio(object):
 
         response = self._url_open('POST', bucket_name=bucket_name,
                                   object_name=object_name,
-                                  query={'uploads': None},
+                                  query={'uploads': ''},
                                   headers=metadata)
 
         return parse_new_multipart_upload(response.data)

--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -94,10 +94,21 @@ def main():
                           file_stat.st_size)
     file_data.close()
 
+    with open('largefile', 'wb') as file_data:
+        for i in range(0, 104857):
+            file_data.write(fake.text().encode('utf-8'))
+    file_data.close()
+
     # Fput a file
     client.fput_object(bucket_name, object_name+'-f', 'testfile')
     if is_s3:
         client.fput_object(bucket_name, object_name+'-f', 'testfile',
+                           metadata={'x-amz-storage-class': 'STANDARD_IA'})
+
+    # Fput a large file.
+    client.fput_object(bucket_name, object_name+'-large', 'largefile')
+    if is_s3:
+        client.fput_object(bucket_name, object_name+'-large', 'largefile',
                            metadata={'x-amz-storage-class': 'STANDARD_IA'})
 
     # Copy a file
@@ -119,6 +130,9 @@ def main():
 
     # Fetch stats on your object.
     client.stat_object(bucket_name, object_name+'-f')
+
+    # Fetch stats on your large object.
+    client.stat_object(bucket_name, object_name+'-large')
 
     # Fetch stats on your object.
     client.stat_object(bucket_name, object_name+'-copy')
@@ -182,9 +196,10 @@ def main():
     policy.set_expires(expires_date)
     client.presigned_post_policy(policy)
 
-    # Remove an object.
+    # Remove all objects.
     client.remove_object(bucket_name, object_name)
     client.remove_object(bucket_name, object_name+'-f')
+    client.remove_object(bucket_name, object_name+'-large')
     client.remove_object(bucket_name, object_name+'-copy')
 
     policy_name = client.get_bucket_policy(bucket_name)
@@ -220,7 +235,7 @@ def main():
     had_errs = False
     for del_err in del_errs:
         had_errs = True
-        # print("Err is {}".format(del_err))
+        print("Remove objects err is {}".format(del_err))
     if had_errs:
         print("Removing objects FAILED - it had unexpected errors.")
         raise
@@ -237,6 +252,7 @@ def main():
     os.remove('testfile')
     os.remove('newfile')
     os.remove('newfile-f')
+    os.remove('largefile')
 
 if __name__ == "__main__":
     # Execute only if run as a script

--- a/tests/unit/list_incomplete_uploads_test.py
+++ b/tests/unit/list_incomplete_uploads_test.py
@@ -45,7 +45,7 @@ class ListIncompleteUploadsTest(TestCase):
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
             MockResponse('GET',
-                         'https://localhost:9000/bucket/?max-uploads=1000&uploads',
+                         'https://localhost:9000/bucket/?max-uploads=1000&uploads=',
                          {'User-Agent': _DEFAULT_USER_AGENT}, 200, content=mock_data))
         client = Minio('localhost:9000')
         upload_iter = client._list_incomplete_uploads('bucket', '', True, False)
@@ -102,7 +102,7 @@ class ListIncompleteUploadsTest(TestCase):
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
             MockResponse('GET',
-                         'https://localhost:9000/bucket/?delimiter=%2F&max-uploads=1000&uploads',
+                         'https://localhost:9000/bucket/?delimiter=%2F&max-uploads=1000&uploads=',
                          {'User-Agent': _DEFAULT_USER_AGENT},
                          200, content=mock_data))
 
@@ -203,7 +203,7 @@ class ListIncompleteUploadsTest(TestCase):
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
             MockResponse('GET',
-                         'https://localhost:9000/bucket/?max-uploads=1000&uploads',
+                         'https://localhost:9000/bucket/?max-uploads=1000&uploads=',
                          {'User-Agent': _DEFAULT_USER_AGENT}, 200, content=mock_data1))
 
         client = Minio('localhost:9000')
@@ -214,7 +214,7 @@ class ListIncompleteUploadsTest(TestCase):
                                                       'https://localhost:9000/bucket/?'
                                                       'key-marker=keymarker&'
                                                       'max-uploads=1000&'
-                                                      'upload-id-marker=uploadidmarker&uploads',
+                                                      'upload-id-marker=uploadidmarker&uploads=',
                                                       {'User-Agent': _DEFAULT_USER_AGENT}, 200, content=mock_data2))
             uploads.append(upload)
 


### PR DESCRIPTION
Setting query params in the following manner fails to
generate the proper query params used for validating
signature.

```
query = {'test': None}
```
Generates a url of form `/?test` doesn't work.

```
query = {'test': ''}
```

Generates a url of form `/?test=`  works.