### PR TITLE
api: Return custom metadata in stat_object.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -645,6 +645,7 @@ __Return Value__
 |``obj.etag``|_string_|etag of the object.|
 |``obj.content_type``|_string_  | Content-Type of the object.|
 |``obj.last_modified``|_time.time_  |modified time stamp.|
+|``obj.metadata`` |_dict_ | Contains any additional metadata on the object. |
 
 __Example__
 
@@ -816,6 +817,7 @@ __Return Value__
 |``obj.etag``|_string_|etag of the object.|
 |``obj.content_type``|_string_  | Content-Type of the object.|
 |``obj.last_modified``|_time.time_  |modified time stamp.|
+|``obj.metadata`` |_dict_ | Contains any additional metadata on the object. |
 
 
 __Example__

--- a/minio/api.py
+++ b/minio/api.py
@@ -1048,11 +1048,26 @@ class Minio(object):
         size = int(response.headers.get('content-length', '0'))
         content_type = response.headers.get('content-type', '')
         last_modified = response.headers.get('last-modified')
+
+        ## Supported headers for object.
+        supported_headers = [
+            'cache-control',
+            'content-encoding',
+            'content-disposition',
+            ## Add more supported headers here.
+        ]
+
+        ## Capture only custom metadata.
+        custom_metadata = dict()
+        for k in response.headers:
+            if k in supported_headers or k.lower().startswith('x-amz-meta-'):
+                custom_metadata[k] = response.headers.get(k)
+
         if last_modified:
             http_time_format = "%a, %d %b %Y %H:%M:%S GMT"
             last_modified = mktime(strptime(last_modified, http_time_format))
-        return Object(bucket_name, object_name, content_type=content_type,
-                      last_modified=last_modified, etag=etag, size=size)
+        return Object(bucket_name, object_name, last_modified, etag, size,
+                      content_type=content_type, metadata=custom_metadata)
 
     def remove_object(self, bucket_name, object_name):
         """

--- a/minio/definitions.py
+++ b/minio/definitions.py
@@ -51,9 +51,10 @@ class Object(object):
     :param size: Size of the object on server.
     :param content_type: Optional parameter indicating content type.
     :param is_dir: Optional parameter differentiating object prefixes.
+    :param metadata: Optional parameter contains all the custom metadata.
     """
     def __init__(self, bucket_name, object_name, last_modified, etag, size,
-                 content_type=None, is_dir=False):
+                 content_type=None, is_dir=False, metadata=None):
         self.bucket_name = bucket_name
         self.object_name = object_name
         self.last_modified = last_modified
@@ -61,18 +62,19 @@ class Object(object):
         self.size = size
         self.content_type = content_type
         self.is_dir = is_dir
+        self.metadata = metadata
 
     def __str__(self):
         string_format = '<Object: bucket_name: {0} object_name: {1}' \
                         ' last_modified: {2} etag: {3} size: {4}' \
-                        ' content_type: {5}, is_dir: {6}>'
+                        ' content_type: {5}, is_dir: {6}, metadata: {7}>'
         return string_format.format(self.bucket_name,
                                     self.object_name.encode('utf-8'),
                                     self.last_modified,
                                     self.etag, self.size,
                                     self.content_type,
-                                    self.is_dir)
-
+                                    self.is_dir,
+                                    self.metadata)
 
 class MultipartUploadResult(object):
     """

--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -147,6 +147,17 @@ def main():
     # Get a full object locally.
     client.fget_object(bucket_name, object_name, 'newfile-f')
 
+    client.fput_object(bucket_name, object_name+'-f', 'testfile',
+                       metadata={'x-amz-meta-testing': 'value'})
+
+    stat = client.fget_object(bucket_name, object_name+'-f', 'newfile-f-custom')
+    if not stat.metadata.has_key('X-Amz-Meta-Testing'):
+        raise ValueError('Metadata key \'x-amz-meta-testing\' not found')
+    value = stat.metadata['X-Amz-Meta-Testing']
+    if value != 'value':
+        raise ValueError('Metadata key has unexpected'
+                         ' value {0}'.format(value))
+
     # List all object paths in bucket.
     print("Listing using ListObjects")
     objects = client.list_objects(bucket_name, recursive=True)
@@ -253,6 +264,7 @@ def main():
     os.remove('newfile')
     os.remove('newfile-f')
     os.remove('largefile')
+    os.remove('newfile-f-custom')
 
 if __name__ == "__main__":
     # Execute only if run as a script


### PR DESCRIPTION
We allow custom metadata to be set
in fput_object(). So we shall properly
return custom metadata back as requested
by the caller.

Fixes https://github.com/minio/minio/issues/4136