### PR TITLE
correct bucket_name to bucket.name

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -128,7 +128,7 @@ __Parameters__
 |Return   |Type   |Description   |
 |:---|:---|:---|
 |``bucketList``   |_function_ |List of all buckets. |
-|``bucket_name``   |_string_  |Bucket name. |
+|``bucket.name``   |_string_  |Bucket name. |
 |``bucket.creation_date`` |_time_   |Time: date when bucket was created. |
 
 __Example__


### PR DESCRIPTION
I had written something thinking it should be 
```
buckets = client.list_buckets()
bucket_set = set([bucket.bucket_name for bucket in buckets])
```

but I actually had to write
```
buckets = client.list_buckets()
bucket_set = set([bucket.name for bucket in buckets])
```