### PR TITLE
Example: Fix curl command for presigned post

### DIFF
--- a/examples/presigned_post_policy.py
+++ b/examples/presigned_post_policy.py
@@ -45,8 +45,8 @@ try:
     for field in signed_form_data:
         curl_cmd.append('-F {0}={1}'.format(field, signed_form_data[field]))
 
-        # print curl command to upload files.
-        curl_cmd.append('-F file=@<FILE>')
-        print(' '.join(curl_cmd))
+    # print curl command to upload files.
+    curl_cmd.append('-F file=@<FILE>')
+    print(' '.join(curl_cmd))
 except ResponseError as err:
     print(err)


### PR DESCRIPTION
Indentation was off in the curl command - it ends up appending file to every field in the form.