### PR TITLE
signv4: Strip port 80 & 443 from url

### DIFF
--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -190,10 +190,16 @@ def get_target_url(endpoint_url, bucket_name=None, object_name=None,
     parsed_url = urlsplit(endpoint_url)
 
     # Get new host, scheme.
+    scheme = parsed_url.scheme
     host = parsed_url.netloc
+
+    # Strip 80/443 ports since curl & browsers do not
+    # send them in Host header.
+    if parsed_url.port == 80 or parsed_url.port == 443:
+        host = parsed_url.hostname
+
     if 's3.amazonaws.com' in host:
         host = get_s3_endpoint(bucket_region)
-    scheme = parsed_url.scheme
 
     url = scheme + '://' + host
     if bucket_name:


### PR DESCRIPTION
curl & browsers strip port 80 and 443 from host header when a user tries
to open a presigned urls, the thing that leads to a signature mismatch error.
This PR strips port 80/443 by default.

Fixes #527 