### PR TITLE
tests: Fix functional tests for Python 3

### DIFF
--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -160,7 +160,7 @@ def main():
                        metadata={'x-amz-meta-testing': 'value'})
 
     stat = client.fget_object(bucket_name, object_name+'-f', newfile_f_custom)
-    if not stat.metadata.has_key('X-Amz-Meta-Testing'):
+    if 'X-Amz-Meta-Testing' not in stat.metadata:
         raise ValueError('Metadata key \'x-amz-meta-testing\' not found')
     value = stat.metadata['X-Amz-Meta-Testing']
     if value != 'value':


### PR DESCRIPTION
dict.has_key() is not supported in Python 3, replace
it with `if elem in dict:`

Fixes #533 