### PR TITLE
Run tests with both python2 and python3

### DIFF
--- a/tests/functional_test.sh
+++ b/tests/functional_test.sh
@@ -59,5 +59,6 @@ main () {
 }
 
 # invoke the script
-
+# Move to the directory which contains this script and invoke it
+cd $(dirname $(realpath $0)) ; \
 main "$@"

--- a/tests/functional_test.sh
+++ b/tests/functional_test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#!/usr/bin/expect -f
+#
+#  Minio Cloud Storage, (C) 2017 Minio, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# Flag to set python2 / python3
+py2flag=0
+
+build() {
+    echo "building..."
+    cd ../
+    if [[ $py2flag = 1 ]]; then
+        sudo python setup.py install
+    else
+        sudo python3 setup.py install
+    fi
+    cd tests
+}
+
+run() {
+    echo "running..."
+    if [[ $py2flag = 1 ]]; then
+	    python ./functional/tests.py 
+    else
+        python3 ./functional/tests.py
+    fi 
+}
+
+main () {
+    if [[ $# -lt 1 ]]; then 
+        echo "Usage: ./functional_test.sh [py2|py3|all]"
+    fi
+    # Build test file binary
+    if [[ $1 == "py2" || $1 == "all" ]]; then 
+        py2flag=1
+        echo "Running python2 tests..."
+        build
+        run
+    fi
+    if [[ $1 == "py3" || $1 == "all" ]]; then
+        py2flag=0
+        echo "Running python3 tests..."
+        build
+        run
+    fi
+
+}
+
+# invoke the script
+
+main "$@"

--- a/tests/functional_test.sh
+++ b/tests/functional_test.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-#!/usr/bin/expect -f
 #
-#  Minio Cloud Storage, (C) 2017 Minio, Inc.
+# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -33,7 +32,7 @@ build() {
 run() {
     echo "running..."
     if [[ $py2flag = 1 ]]; then
-	    python ./functional/tests.py 
+	python ./functional/tests.py 
     else
         python3 ./functional/tests.py
     fi 

--- a/tests/unit_test.sh
+++ b/tests/unit_test.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-#!/usr/bin/expect -f
 #
-#  Minio Cloud Storage, (C) 2017 Minio, Inc.
+# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -14,13 +13,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-#
-
-#Make sure following packages are installed on your computer:
-#pip install nosetests
-#pip install mock
-#pip3 install nosetests
-#pip3 install mock
 
 echo "Running unit tests on python2... " && nosetests 
 echo "Running unit tests on python3... " && nosetests3 

--- a/tests/unit_test.sh
+++ b/tests/unit_test.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#!/usr/bin/expect -f
+#
+#  Minio Cloud Storage, (C) 2017 Minio, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+#Make sure following packages are installed on your computer:
+#pip install nosetests
+#pip install mock
+#pip3 install nosetests
+#pip3 install mock
+
+echo "Running unit tests on python2... " && nosetests 
+echo "Running unit tests on python3... " && nosetests3 


### PR DESCRIPTION
Fixes #532 

This is just a convenience script for developers to ensure that unit tests and functional tests pass with both python2 and python3

Commit  	2c2046e is identical to fix by @vadmeste for #533