### PR TITLE
Fix get_bucket_policy crash for TypeError

### DIFF
--- a/minio/api.py
+++ b/minio/api.py
@@ -365,6 +365,8 @@ class Minio(object):
         if not policy_dict:
             return policy.Policy.NONE
 
+        if policy_dict.get('Statement') is None:
+            raise ValueError("None Policy statement")
         # Normalize statements.
         statements = []
         policy._append_statements(statements, policy_dict.get('Statement', []))


### PR DESCRIPTION
Fixes #558 
get_bucket_policy  function crashes with TypeError when azure gateway returns null statements in Policy
{"Version":"2012-10-17","Statement":null}. Check value returned before appending to statements list.
