### PR TITLE
Fix: raise InvalidArgumentError if access_key is not set

### DIFF
--- a/minio/signer.py
+++ b/minio/signer.py
@@ -174,7 +174,7 @@ def sign_v4(method, url, region, headers=None, access_key=None,
 
     # If no access key or secret key is provided return headers.
     if not access_key or not secret_key:
-        return headers
+        raise InvalidArgumentError('Invalid access_key and secret_key.')
 
     if headers is None:
         headers = FoldCaseDict()


### PR DESCRIPTION
Fixes #553 -  when access key and/or secret key is not set, SDK should give indication that credentials are missing. Currently, when list_buckets.py example is run against aws endpoint without setting credentials the server redirects to default AWS page and returns that as response, leading to xml parse error.

This PR adds a check to validate access key/ secret key before sending the request and raise InvalidArgumentError if  credentials are missing.