### PR TITLE
tests: Remove useless path append

### DIFF
--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -15,9 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-sys.path.append('/home/vadmeste/work/python/minio-py')
-
 import os
 import uuid
 import shutil


### PR DESCRIPTION
Path append was accidentally merged in the code, it was only helping me
to test locally.