### PR TITLE
API: stat_object returns time.time instead of secs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -819,7 +819,7 @@ __Return Value__
 |``obj.size``|_int_  |size of the object. |
 |``obj.etag``|_string_|etag of the object.|
 |``obj.content_type``|_string_  | Content-Type of the object.|
-|``obj.last_modified``|_time.time_  |modified time stamp.|
+|``obj.last_modified``|_time.time_  | modified time in UTC.|
 |``obj.metadata`` |_dict_ | Contains any additional metadata on the object. |
 
 

--- a/minio/api.py
+++ b/minio/api.py
@@ -939,7 +939,7 @@ class Minio(object):
 
         if last_modified:
             http_time_format = "%a, %d %b %Y %H:%M:%S GMT"
-            last_modified = mktime(strptime(last_modified, http_time_format))
+            last_modified = strptime(last_modified, http_time_format)
         return Object(bucket_name, object_name, last_modified, etag, size,
                       content_type=content_type, metadata=custom_metadata)
 


### PR DESCRIPTION
stat_object was returning seconds in float in last_modified field,
replace it by a time.time object.

Fixes #557 