### PR TITLE
Fix parsing failure for list_buckets with s3 endpoint

### DIFF
--- a/minio/api.py
+++ b/minio/api.py
@@ -48,7 +48,7 @@ from . import __title__, __version__
 from .compat import (urlsplit, queryencode,
                      range, basestring)
 from .error import (KnownResponseError, ResponseError, NoSuchBucket,
-                    InvalidArgumentError, InvalidSizeError, NoSuchBucketPolicy)
+                    InvalidArgumentError, InvalidSizeError, InvalidXMLError, NoSuchBucketPolicy)
 from .definitions import Object, UploadPart
 from .parsers import (parse_list_buckets,
                       parse_list_objects,
@@ -298,8 +298,11 @@ class Minio(object):
 
         if response.status != 200:
             raise ResponseError(response, method).get_exception()
-
-        return parse_list_buckets(response.data)
+        try:
+            return parse_list_buckets(response.data)
+        except InvalidXMLError:
+            if self._endpoint_url.endswith("s3.amazonaws.com"):
+                raise InvalidArgumentError('Invalid access_key and secret_key.')
 
     def bucket_exists(self, bucket_name):
         """

--- a/minio/api.py
+++ b/minio/api.py
@@ -47,7 +47,7 @@ import certifi
 from . import __title__, __version__
 from .compat import (urlsplit, queryencode,
                      range, basestring)
-from .error import (KnownResponseError, ResponseError, NoSuchBucket,
+from .error import (KnownResponseError, ResponseError, NoSuchBucket, AccessDenied,
                     InvalidArgumentError, InvalidSizeError, InvalidXMLError, NoSuchBucketPolicy)
 from .definitions import Object, UploadPart
 from .parsers import (parse_list_buckets,
@@ -276,7 +276,6 @@ class Minio(object):
 
         method = 'GET'
         url = get_target_url(self._endpoint_url)
-
         # Set user agent once before the request.
         headers = {'User-Agent': self._user_agent}
 
@@ -301,8 +300,8 @@ class Minio(object):
         try:
             return parse_list_buckets(response.data)
         except InvalidXMLError:
-            if self._endpoint_url.endswith("s3.amazonaws.com"):
-                raise InvalidArgumentError('Invalid access_key and secret_key.')
+            if self._endpoint_url.endswith("s3.amazonaws.com") and (not self._access_key or not self._secret_key):
+                raise AccessDenied(response)
 
     def bucket_exists(self, bucket_name):
         """


### PR DESCRIPTION
Fixes #553.

When list_buckets call is invoked without credentials on s3.amazonaws.com , AWS redirects to its home page and returns RC 200 with html content instead of Xml with ListBucketsResult node. The minio-py SDK treats this as XML parsing issue instead of raising an error indicating bad credentials.

Raise InvalidArgumentError when credentials are missing. 