### PR TITLE
add parameter to skip SSL cert verification

### DIFF
--- a/minio/api.py
+++ b/minio/api.py
@@ -130,7 +130,8 @@ class Minio(object):
                  secret_key=None, secure=True,
                  region=None,
                  timeout=None,
-                 certificate_bundle=certifi.where()):
+                 certificate_bundle=certifi.where(),
+                 verify=True):
 
         # Validate endpoint.
         is_valid_endpoint(endpoint)
@@ -161,7 +162,7 @@ class Minio(object):
 
         self._http = urllib3.PoolManager(
             timeout=self._conn_timeout,
-            cert_reqs='CERT_REQUIRED',
+            cert_reqs='CERT_REQUIRED' if verify else 'CERT_NONE',
             ca_certs=certificate_bundle,
             retries=urllib3.Retry(
                 total=5,

--- a/minio/api.py
+++ b/minio/api.py
@@ -123,6 +123,7 @@ class Minio(object):
          location discovery.
     :param timeout: Set this value to control how long requests
          are allowed to run before being aborted.
+    :param verify: Set this to `True` to skip SSL Cert Verification
     :return: :class:`Minio <Minio>` object
     """
 


### PR DESCRIPTION
when minio servers is set up with self-signed cert. we may set this new parameter `verify` to `False` (just like the `requests` library) to skip the verification. Otherwise, a `SSLError` would be thrown.
