### PR TITLE
fix calculate optimal part size bug

### DIFF
--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -25,6 +25,9 @@ This module implements all helper functions.
 """
 
 from __future__ import absolute_import
+# if math.ceil returns an integer and devide two integers returns a float, calculate
+# part size will cause errors, so make sure division integers returns a float.
+from __future__ import division
 import io
 
 import collections

--- a/tests/unit/optimal_part_test.py
+++ b/tests/unit/optimal_part_test.py
@@ -17,21 +17,27 @@
 from nose.tools import eq_, raises
 from unittest import TestCase
 
-from minio.helpers import optimal_part_info
+from minio.helpers import optimal_part_info, MAX_MULTIPART_OBJECT_SIZE
 from minio.error import InvalidArgumentError
 
 class TraceTest(TestCase):
     @raises(InvalidArgumentError)
     def test_input_size_wrong(self):
-        optimal_part_info(5000000000000000000)
+        optimal_part_info(MAX_MULTIPART_OBJECT_SIZE + 1)
 
     def test_input_size_valid_maximum(self):
-        total_parts_count, part_size, last_part_size = optimal_part_info(5497558138880)
+        total_parts_count, part_size, last_part_size = optimal_part_info(MAX_MULTIPART_OBJECT_SIZE)
         eq_(total_parts_count, 9987)
         eq_(part_size, 550502400)
         eq_(last_part_size, 241172480)
 
     def test_input_size_valid(self):
+        total_parts_count, part_size, last_part_size = optimal_part_info(MAX_MULTIPART_OBJECT_SIZE/1024)
+        eq_(total_parts_count, 1024)
+        eq_(part_size, 5242880)
+        eq_(last_part_size, 5242880)
+
+    def test_input_size_is_special_value(self):
         total_parts_count, part_size, last_part_size = optimal_part_info(-1)
         eq_(total_parts_count, 9987)
         eq_(part_size, 550502400)


### PR DESCRIPTION
```
In [4]: optimal_part_info(549755813)
---------------------------------------------------------------------------
ZeroDivisionError                         Traceback (most recent call last)
<ipython-input-4-9348e40232c0> in <module>()
----> 1 optimal_part_info(549755813)

/data/apps/ecoboost-backend/ecoboost/eggs/minio-2.2.6-py2.7.egg/minio/helpers.py in optimal_part_info(length)
    592                        * MIN_PART_SIZE)
    593     # Total parts count.
--> 594     total_parts_count = int(math.ceil(length/part_size_float))
    595     # Part size.
    596     part_size = int(part_size_float)

ZeroDivisionError: integer division or modulo by zero
```

Uploaded failed when length larger than 5MB put_object.

env:

python version: 2.7.5
minio version: 2.2.6