### PR TITLE
Fix put_object documentation example

### DIFF
--- a/minio/api.py
+++ b/minio/api.py
@@ -750,7 +750,7 @@ class Minio(object):
         Examples:
          file_stat = os.stat('hello.txt')
          with open('hello.txt', 'rb') as data:
-             minio.put_object('foo', 'bar', data, file_stat.size, 'text/plain')
+             minio.put_object('foo', 'bar', data, file_stat.st_size, 'text/plain')
 
         - For length lesser than 5MB put_object automatically
           does single Put operation.


### PR DESCRIPTION
The example was using a reference to `size` instead of `st_size`