### PR TITLE
Increase urllib3 connection pool size

### DIFF
--- a/minio/api.py
+++ b/minio/api.py
@@ -71,6 +71,7 @@ from .helpers import (get_target_url, is_non_empty_string,
                       get_s3_region_from_endpoint,
                       mkdir_p, dump_http)
 from .helpers import (MAX_MULTIPART_OBJECT_SIZE,
+                      MAX_POOL_SIZE,
                       MIN_PART_SIZE)
 from .signer import (sign_v4, presign_v4,
                      generate_credential_string,
@@ -168,6 +169,7 @@ class Minio(object):
         if not http_client:
             self._http = urllib3.PoolManager(
                 timeout=urllib3.Timeout.DEFAULT_TIMEOUT,
+                maxsize=MAX_POOL_SIZE,
                         cert_reqs='CERT_REQUIRED',
                         ca_certs=ca_certs,
                         retries=urllib3.Retry(

--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -46,6 +46,7 @@ from .error import (InvalidBucketError, InvalidEndpointError,
 # Constants
 MAX_MULTIPART_COUNT = 10000 # 10000 parts
 MAX_MULTIPART_OBJECT_SIZE = 5 * 1024 * 1024 * 1024 * 1024  # 5TiB
+MAX_POOL_SIZE = 10
 MIN_PART_SIZE = 5 * 1024 * 1024  # 5MiB
 
 _VALID_BUCKETNAME_REGEX = re.compile('^[a-z0-9][a-z0-9\\.\\-]+[a-z0-9]$')


### PR DESCRIPTION
Allows the connection pools to save 10 connections.

References:
- https://urllib3.readthedocs.io/en/1.4/pools.html#urllib3.connectionpool.HTTPConnectionPool