### PR TITLE
Support for specifying custom presign request date

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -979,7 +979,7 @@ except ResponseError as err:
 ## 4. Presigned operations
 
 <a name="presigned_get_object"></a>
-### presigned_get_object(bucket_name, object_name, expiry=timedelta(days=7))
+### presigned_get_object(bucket_name, object_name, expires=timedelta(days=7))
 Generates a presigned URL for HTTP GET operations. Browsers/Mobile clients may point to this URL to directly download objects even if the bucket is private. This presigned URL can have an associated expiration time in seconds after which it is no longer operational. The default expiry is set to 7 days.
 
 __Parameters__
@@ -988,8 +988,9 @@ __Parameters__
 |:---|:---|:---|
 |``bucket_name``   |_string_   |Name of the bucket.   |
 |``object_name``   |_string_    |Name of the object.   |
-|``expiry``   | _datetime.datetime_    |Expiry in seconds. Default expiry is set to 7 days.    |
+|``expires``   | _datetime.timedelta_    |Expires in timedelta. Default expiry is set to 7 days.    |
 |``response_headers``   | _dictionary_    |Additional headers to include (e.g. `response-content-type` or `response-content-disposition`)     |
+|``request_date``   | _datetime.datetime_    |Optional datetime to specify a different request date. Expiry is relative to the request date. Default is current date.     |
 
 __Example__
 

--- a/minio/api.py
+++ b/minio/api.py
@@ -1179,7 +1179,8 @@ class Minio(object):
                     bucket_name,
                     object_name,
                     expires=timedelta(days=7),
-                    response_headers=None):
+                    response_headers=None,
+                    request_date=None):
         """
         Presigns a method on an object and provides a url
 
@@ -1199,6 +1200,9 @@ class Minio(object):
         :params response_headers: Optional response_headers argument to
                                   specify response fields like date, size,
                                   type of file, data about server, etc.
+        :params request_date: Optional request_date argument to
+                              specify a different request date. Default is
+                              current date.
         :return: Presigned put object url.
         """
         is_valid_bucket_name(bucket_name)
@@ -1221,11 +1225,13 @@ class Minio(object):
                           self._secret_key,
                           region=region,
                           expires=int(expires.total_seconds()),
-                          response_headers=response_headers)
+                          response_headers=response_headers,
+                          request_date=request_date)
 
     def presigned_get_object(self, bucket_name, object_name,
                              expires=timedelta(days=7),
-                             response_headers=None):
+                             response_headers=None,
+                             request_date=None):
         """
         Presigns a get object request and provides a url
 
@@ -1242,13 +1248,20 @@ class Minio(object):
         :param object_name: Object for which presigned url is generated.
         :param expires: Optional expires argument to specify timedelta.
            Defaults to 7days.
+        :params response_headers: Optional response_headers argument to
+                                  specify response fields like date, size,
+                                  type of file, data about server, etc.
+        :params request_date: Optional request_date argument to
+                              specify a different request date. Default is
+                              current date.
         :return: Presigned url.
         """
         return self.presigned_url('GET',
                                   bucket_name,
                                   object_name,
                                   expires,
-                                  response_headers=response_headers)
+                                  response_headers=response_headers,
+                                  request_date=request_date)
 
     def presigned_put_object(self, bucket_name, object_name,
                              expires=timedelta(days=7)):


### PR DESCRIPTION
This allows the request date used for presigning the request to be
configurable.

I want to make the request date configurable because I want to specify a custom
request date that is not datetime.utcnow(). For example, I want to make the
presign link to stay unchanged for a certain time period, which makes browser
caching easier.

I understand that this might not be what you guys want but I am going to try
my luck anyway :)

PS: `minio-js` has support for custom request date too, but that parameter is not exposed in exported function.