### PR TITLE
support aliyun OSS api

### DIFF
--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -325,8 +325,9 @@ def is_virtual_host(endpoint_url, bucket_name):
     # such buckets.
     if 'https' in parsed_url.scheme and '.' in bucket_name:
         return False
-    if 's3.amazonaws.com' in parsed_url.netloc:
-        return True
+    for host in ['s3.amazonaws.com', 'aliyuncs.com']:
+        if host in parsed_url.netloc:
+            return True
     return False
 
 def is_valid_bucket_name(bucket_name):


### PR DESCRIPTION
Hi I see you set two url schemes here: https://github.com/minio/minio-py/blob/3b6e49c0e3a4a05640865065637033bfc5f9166d/minio/helpers.py#L240

But from `is_virtual_host` only in amazon s3 returns True. I think the first url scheme is the most common one. And [Aliyun OSS ](https://help.aliyun.com/document_detail/31978.html?spm=a2c4g.11186623.6.897.d0LvWt) only support the first url scheme.

Hope this can be merged ASAP.