### PR TITLE
Avoiding continuous polling in listen_bucket_notification 

### DIFF
--- a/minio/api.py
+++ b/minio/api.py
@@ -507,9 +507,10 @@ class Minio(object):
                                       query=query, preload_content=False)
             try:
                 for line in response.stream():
-                    event = json.loads(line)
-                    if event['Records'] is not None:
-                        yield event
+                    if line.strip():
+                        event = json.loads(line)
+                        if event['Records'] is not None:
+                            yield event
             except JSONDecodeError:
                 response.close()
                 continue


### PR DESCRIPTION
The server streams an empty string (" ") until an action hits the bucket, 
In this case `JSONEncodeError` exception is thrown for every `json.loads(" ")` , So the loop continues here and polls the request for every catch .