### PR TITLE
fix set_bucket_notification filter

### DIFF
--- a/minio/xml_marshal.py
+++ b/minio/xml_marshal.py
@@ -185,7 +185,7 @@ def _add_notification_config_to_xml(node, element_name, configs):
             event_node = s3_xml.SubElement(config_node, 'Event')
             event_node.text = event
 
-        filter_rules = config_node.get('Filter', {}).get(
+        filter_rules = config.get('Filter', {}).get(
             'Key', {}).get('FilterRules', [])
         if filter_rules:
             filter_node = s3_xml.SubElement(config_node, 'Filter')

--- a/tests/unit/set_bucket_notification_test.py
+++ b/tests/unit/set_bucket_notification_test.py
@@ -305,9 +305,9 @@ class SetBucketNotificationTest(TestCase):
                 'PUT',
                 'https://localhost:9000/my-test-bucket/?notification=',
                 {
-                    'Content-Md5': 'AGCNfbD5OuiyIJFd+r67MA==',
+                    'Content-Md5': 'k97dHBBUq9MR7ZViy7oUsw==',
                     'User-Agent': _DEFAULT_USER_AGENT,
-                    'Content-Length': '206',
+                    'Content-Length': '300',
                 },
                 200, content=""
             )
@@ -345,8 +345,8 @@ class SetBucketNotificationTest(TestCase):
                 'PUT',
                 'https://localhost:9000/my-test-bucket/?notification=',
                 {
-                    'Content-Length': '206',
-                    'Content-Md5': 'AGCNfbD5OuiyIJFd+r67MA==',
+                    'Content-Length': '300',
+                    'Content-Md5': '2aIwAt1lAd5JShphHCD4GA==',
                     'User-Agent': _DEFAULT_USER_AGENT,
                 },
                 200, content=""


### PR DESCRIPTION
```python 

....

notification = {
    'QueueConfigurations': [
        {
            'Id': '1',
            'Arn': 'arn:minio:sqs::1:amqp',
            'Events': ['s3:ObjectRemoved:*', 's3:ObjectCreated:*'],
            'Filter': {
                'Key': {
                    'FilterRules': [
                        {
                            'Name': 'prefix',
                            'Value': 'foo'
                        },
                        {
                            'Name': 'suffix',
                            'Value': 'bar'
                        }
                    ]
                }
            }
        }
    ]    
}

client.set_bucket_notification('api', notification)
```

before change:

```xml
<NotificationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
  <QueueConfiguration>
    <Id>1</Id>
    <Queue>arn:minio:sqs::1:amqp</Queue>
    <Event>s3:ObjectRemoved:*</Event>
    <Event>s3:ObjectCreated:*</Event>
  </QueueConfiguration>
</NotificationConfiguration>
```

```sh
mc events list local/api
arn:minio:sqs::1:amqp   s3:ObjectRemoved:*,s3:ObjectCreated:*   Filter:
```


after change:

```xml
<NotificationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
  <QueueConfiguration>
    <Queue>arn:minio:sqs::1:amqp</Queue>
    <Event>s3:ObjectRemoved:*</Event>
    <Event>s3:ObjectCreated:*</Event>
    <Filter />
    <Filter>
      <S3Key>
        <FilterRule>
          <Name>prefix</Name>
          <Value>foo</Value>
        </FilterRule>
        <FilterRule>
          <Name>suffix</Name>
          <Value>bar</Value>
        </FilterRule>
      </S3Key>
    </Filter>
  </QueueConfiguration>
</NotificationConfiguration>
```


```sh
mc events list local/api
arn:minio:sqs::1:amqp   s3:ObjectRemoved:*,s3:ObjectCreated:*   Filter: prefix="foo"suffix="bar"
```

