### PR TITLE
Closes issue 665 by adding support for Windows OS

### DIFF
--- a/minio/api.py
+++ b/minio/api.py
@@ -599,7 +599,12 @@ class Minio(object):
                 raise InvalidSizeError(msg)
 
         # Rename with destination file.
-        os.rename(file_part_path, file_path)
+        if !os.path.exists(file_path):
+             os.rename(file_part_path, file_path)
+        else:
+            #if file already exists, need to remove it for Windows OS compatibility
+            os.remove(file_path)
+            os.rename(file_part_path, file_path)
 
         # Return the stat
         return stat


### PR DESCRIPTION
Adds support for preexisting files in a directory when using fget_object on a Windows OS