### PR TITLE
Adds missing file close logic

### DIFF
--- a/examples/put_object.py
+++ b/examples/put_object.py
@@ -27,17 +27,18 @@ client = Minio('s3.amazonaws.com',
 
 # Put a file with default content-type.
 try:
-    file_stat = os.stat('my-testfile')
-    file_data = open('my-testfile', 'rb')
-    client.put_object('my-bucketname', 'my-objectname', file_data, file_stat.st_size)
+    with open('my-testfile', 'rb') as file_data:
+        file_stat = os.stat('my-testfile')
+        client.put_object('my-bucketname', 'my-objectname',
+                          file_data, file_stat.st_size)
 except ResponseError as err:
     print(err)
 
 # Put a file with 'application/csv'
 try:
-    file_stat = os.stat('my-testfile.csv')
-    file_data = open('my-testfile.csv', 'rb')
-    client.put_object('my-bucketname', 'my-objectname', file_data,
-                      file_stat.st_size, content_type='application/csv')
+    with open('my-testfile.csv', 'rb') as file_data:
+        file_stat = os.stat('my-testfile.csv')
+        client.put_object('my-bucketname', 'my-objectname', file_data,
+                          file_stat.st_size, content_type='application/csv')
 except ResponseError as err:
     print(err)

--- a/minio/api.py
+++ b/minio/api.py
@@ -534,11 +534,10 @@ class Minio(object):
         """
 
         # Open file in 'read' mode.
-        file_data = io.open(file_path, mode='rb')
-        file_size = os.stat(file_path).st_size
-
-        return self.put_object(bucket_name, object_name, file_data, file_size,
-                content_type, metadata)
+        with open(file_path, 'rb') as file_data:
+            file_size = os.stat(file_path).st_size
+            return self.put_object(bucket_name, object_name, file_data,
+                                   file_size, content_type, metadata)
 
     def fget_object(self, bucket_name, object_name, file_path, request_headers=None):
         """


### PR DESCRIPTION
Fixes #673 

Adds the missing `with open` construct block to automatically close the opened files. 
Also updated the examples for `put_object` command.