### PR TITLE
Fix parse_new_multipart_upload

### DIFF
--- a/minio/parsers.py
+++ b/minio/parsers.py
@@ -331,7 +331,7 @@ def parse_new_multipart_upload(data):
     :param data: Response data for new multipart upload.
     :return: Returns a upload id.
     """
-    root = S3Element.fromstring('NewMultipartUploadResult', data)
+    root = S3Element.fromstring('InitiateMultipartUploadResult', data)
     return root.get_child_text('UploadId')
 
 def parse_location_constraint(data):


### PR DESCRIPTION
I believe it should be `InitiateMultipartUploadResult`

https://github.com/minio/minio/blob/3dc13323e51dc7038232f5f02f55b37b388c59c2/cmd/api-response.go#L228-L234