### PR TITLE
adds support for string policy

### DIFF
--- a/minio/api.py
+++ b/minio/api.py
@@ -72,7 +72,7 @@ from .helpers import (get_target_url, is_non_empty_string,
                       get_sha256_hexdigest, get_md5_base64digest, Hasher,
                       optimal_part_info,
                       is_valid_bucket_name, PartMetadata, read_full,
-                      is_valid_bucket_notification_config,
+                      is_valid_bucket_notification_config, is_valid_policy_type,
                       get_s3_region_from_endpoint,
                       mkdir_p, dump_http, amzprefix_user_metadata,
                       is_supported_header,is_amz_header)
@@ -387,8 +387,10 @@ class Minio(object):
         Set bucket policy of given bucket name.
 
         :param bucket_name: Bucket name.
-        :param policy: Access policy/ies in JSON format.
+        :param policy: Access policy/ies in string format.
         """
+        is_valid_policy_type(policy)
+
         is_valid_bucket_name(bucket_name)
 
         headers = {

--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -39,7 +39,7 @@ import errno
 import math
 
 from .compat import (urlsplit, urlencode, queryencode,
-                     str, bytes, basestring)
+                     str, bytes, basestring, _is_py3, _is_py2)
 from .error import (InvalidBucketError, InvalidEndpointError,
                     InvalidArgumentError)
 
@@ -375,6 +375,25 @@ def is_non_empty_string(input_string):
 
     return True
 
+def is_valid_policy_type(policy):
+    """
+    Validate if policy is type str
+
+    :param policy: S3 style Bucket policy.
+    :return: True if policy parameter is of a valid type, 'string'.
+    Raise :exc:`TypeError` otherwise.
+    """
+    if _is_py3:
+        string_type = str,
+    elif _is_py2:
+        string_type = basestring
+
+    if not isinstance(policy, string_type):
+        raise TypeError('policy can only be of type str')
+
+    is_non_empty_string(policy)
+
+    return True
 
 def is_valid_bucket_notification_config(notifications):
     """


### PR DESCRIPTION
Fixes #681

Ensure that policy is always of type string when passed into set_bucket_policy api.