### PR TITLE
put_object: Limit tasks queue size to avoid reading the whole data

### DIFF
--- a/minio/thread_pool.py
+++ b/minio/thread_pool.py
@@ -67,7 +67,7 @@ class ThreadPool:
     def __init__(self, num_threads):
         self.results_queue = queue()
         self.exceptions_queue = queue()
-        self.tasks_queue = queue()
+        self.tasks_queue = queue(num_threads)
         self.num_threads = num_threads
 
     def add_task(self, func, *args, **kargs):


### PR DESCRIPTION
put_object() prepares parts much more faster than uploading them,
the thing which leads to load all the data, such as a local file, in
the memory, which by itself can lead to a OOM.

This PR will allow only `num_threads` parallel task preparation of
parts data before multipart uploading them.

Fixes #704 