### PR TITLE
Allow building minio without nose package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 - ARCH=i686
 
 install:
-- pip install urllib3 certifi pytz pyflakes faker
+- pip install urllib3 certifi pytz pyflakes faker nose
 
 script:
 - pyflakes minio/*.py || true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
 
 install:
   # We need wheel installed to build wheels
-  - "%PYTHON%\\python.exe -m pip install wheel faker"
+  - "%PYTHON%\\python.exe -m pip install wheel faker nose"
   - "%PYTHON%\\python.exe setup.py install"
 
 build: off

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ setup(
     packages=packages,
     install_requires=requires,
     tests_require=tests_requires,
-    setup_requires=['nose>=1.0'],
     license='Apache License 2.0',
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
nose is a testing framework, however it is currently required to build Minio package.
This commit will disable this requirement.

Fixes #643 