### PR TITLE
make_bucket: Use correct region when signing requests

### DIFF
--- a/minio/api.py
+++ b/minio/api.py
@@ -248,9 +248,11 @@ class Minio(object):
         """
         is_valid_bucket_name(bucket_name)
 
-        ## Region already set in constructor, validate if
-        ## caller requested bucket location is same.
+        # Default region for all requests.
+        region = 'us-east-1'
         if self._region:
+            region = self._region
+            # Validate if caller requested bucket location is same as current region
             if self._region != location:
                 raise InvalidArgumentError("Configured region {0}, requested"
                                            " {1}".format(self._region,
@@ -279,7 +281,7 @@ class Minio(object):
         url = self._endpoint_url + '/' + bucket_name + '/'
 
         # Get signature headers if any.
-        headers = sign_v4(method, url, location,
+        headers = sign_v4(method, url, region,
                           headers, self._access_key,
                           self._secret_key, content_sha256_hex)
 


### PR DESCRIPTION
make_bucket() uses new bucket location to sign make bucket requests,
however region should be used instead, and 'us-east-1' if no region
is specified.

Fixes #712 