### PR TITLE
Convert bytes to str before parsing json in listen_bucket_notification

### DIFF
--- a/minio/api.py
+++ b/minio/api.py
@@ -514,6 +514,8 @@ class Minio(object):
             try:
                 for line in response.stream():
                     if line.strip():
+                        if hasattr(line, 'decode'):
+                            line = line.decode('utf-8')
                         event = json.loads(line)
                         if event['Records'] is not None:
                             yield event


### PR DESCRIPTION
`listen_bucket_notification` fails when receiving event in Python3

```
app_1              | Traceback (most recent call last):
app_1              |   File "/opt/project/app.py", line 70, in <module>
app_1              |     listen_on_new_files(mc, BUCKET_NAME, INPUT_PREFIX)
app_1              |   File "/opt/project/minio_utils/events.py", line 12, in listen_on_new_files
app_1              |     next(events_it)
app_1              |   File "/usr/local/lib/python3.5/site-packages/minio/api.py", line 515, in listen_bucket_notification
app_1              |     event = json.loads(line)
app_1              |   File "/usr/local/lib/python3.5/json/__init__.py", line 312, in loads
app_1              |     s.__class__.__name__))
app_1              | TypeError: the JSON object must be str, not 'bytes'
```

Using `hasattr` should allow this to work on both python 2 and 3.
I'm also open to using:
```
if type(line).__name__ == 'bytes':
    line = line.decode('utf-8')
```