### PR TITLE
Set prefix param even when empty

### DIFF
--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -255,20 +255,14 @@ def get_target_url(endpoint_url, bucket_name=None, object_name=None,
         ordered_query = collections.OrderedDict(sorted(query.items()))
         query_components = []
         for component_key in ordered_query:
-            if ordered_query[component_key] is not None:
-                if isinstance(ordered_query[component_key], list):
-                    for value in ordered_query[component_key]:
-                        query_components.append(component_key+'='+
-                                                queryencode(value))
-                else:
-                    query_components.append(
-                        component_key+'='+
-                        queryencode(
-                            ordered_query[component_key]
-                        )
-                    )
+            if isinstance(ordered_query[component_key], list):
+                for value in ordered_query[component_key]:
+                    query_components.append(component_key+'='+
+                                            queryencode(value))
             else:
-                query_components.append(component_key)
+                query_components.append(
+                    component_key+'='+
+                    queryencode(ordered_query.get(component_key, '')))
 
         query_string = '&'.join(query_components)
         if query_string:

--- a/minio/signer.py
+++ b/minio/signer.py
@@ -125,6 +125,8 @@ def presign_v4(method, url, access_key, secret_key, region=None,
                 single_component.append(
                     queryencode(ordered_query[component_key])
                 )
+            else:
+                single_component.append('=')
             query_components.append(''.join(single_component))
 
         query_string = '&'.join(query_components)

--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -392,7 +392,7 @@ def test_copy_object_with_metadata(client, log_output):
         KB_1 = 1024 # 1KiB.
         KB_1_reader = LimitedRandomReader(KB_1)
         client.put_object(bucket_name, object_source, KB_1_reader, KB_1)
-        
+
         # Perform a server side copy of an object
         client.copy_object(bucket_name, object_copy,
                            '/'+bucket_name+'/'+object_source,metadata=metadata)
@@ -411,7 +411,7 @@ def test_copy_object_with_metadata(client, log_output):
             raise Exception(err)
     # Test passes
     print(log_output.json_report())
-    
+
 def test_copy_object_etag_match(client, log_output):
     # default value for log_output.function attribute is;
     # log_output.function = "copy_object(bucket_name, object_name, object_source, conditions)"
@@ -578,7 +578,7 @@ def normalize_metadata(meta_data):
     norm_dict = {k.lower(): v for k, v in meta_data.items()}
     return norm_dict
 
-    
+
 def test_put_object(client, log_output, sse=None):
     # default value for log_output.function attribute is;
     # log_output.function = "put_object(bucket_name, object_name, data, length, content_type, metadata)"
@@ -907,7 +907,7 @@ def test_list_objects(client, log_output):
         client.put_object(bucket_name, object_name+"-2", MB_1_reader, MB_1)
         # List all object paths in bucket.
         log_output.args['recursive'] = is_recursive = True
-        objects = client.list_objects(bucket_name, None, is_recursive)
+        objects = client.list_objects(bucket_name, '', is_recursive)
         for obj in objects:
             _, _, _, _, _, _ = obj.bucket_name,\
                                obj.object_name,\
@@ -1081,7 +1081,7 @@ def test_list_objects_v2(client, log_output):
         client.put_object(bucket_name, object_name+"-2", MB_1_reader, MB_1)
         # List all object paths in bucket using V2 API.
         log_output.args['recursive'] = is_recursive = True
-        objects = client.list_objects_v2(bucket_name, None, is_recursive)
+        objects = client.list_objects_v2(bucket_name, '', is_recursive)
         for obj in objects:
             _, _, _, _, _, _ = obj.bucket_name,\
                                obj.object_name,\

--- a/tests/unit/list_incomplete_uploads_test.py
+++ b/tests/unit/list_incomplete_uploads_test.py
@@ -45,7 +45,7 @@ class ListIncompleteUploadsTest(TestCase):
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
             MockResponse('GET',
-                         'https://localhost:9000/bucket/?max-uploads=1000&uploads=',
+                         'https://localhost:9000/bucket/?max-uploads=1000&prefix=&uploads=',
                          {'User-Agent': _DEFAULT_USER_AGENT}, 200, content=mock_data))
         client = Minio('localhost:9000')
         upload_iter = client._list_incomplete_uploads('bucket', '', True, False)
@@ -102,7 +102,7 @@ class ListIncompleteUploadsTest(TestCase):
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
             MockResponse('GET',
-                         'https://localhost:9000/bucket/?delimiter=%2F&max-uploads=1000&uploads=',
+                         'https://localhost:9000/bucket/?delimiter=%2F&max-uploads=1000&prefix=&uploads=',
                          {'User-Agent': _DEFAULT_USER_AGENT},
                          200, content=mock_data))
 
@@ -203,7 +203,7 @@ class ListIncompleteUploadsTest(TestCase):
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
             MockResponse('GET',
-                         'https://localhost:9000/bucket/?max-uploads=1000&uploads=',
+                         'https://localhost:9000/bucket/?max-uploads=1000&prefix=&uploads=',
                          {'User-Agent': _DEFAULT_USER_AGENT}, 200, content=mock_data1))
 
         client = Minio('localhost:9000')
@@ -213,7 +213,7 @@ class ListIncompleteUploadsTest(TestCase):
             mock_server.mock_add_request(MockResponse('GET',
                                                       'https://localhost:9000/bucket/?'
                                                       'key-marker=keymarker&'
-                                                      'max-uploads=1000&'
+                                                      'max-uploads=1000&prefix=&'
                                                       'upload-id-marker=uploadidmarker&uploads=',
                                                       {'User-Agent': _DEFAULT_USER_AGENT}, 200, content=mock_data2))
             uploads.append(upload)

--- a/tests/unit/list_objects_test.py
+++ b/tests/unit/list_objects_test.py
@@ -40,7 +40,7 @@ class ListObjectsTest(TestCase):
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(MockResponse('GET',
-                                                  'https://localhost:9000/bucket/?max-keys=1000',
+                                                  'https://localhost:9000/bucket/?max-keys=1000&prefix=',
                                                   {'User-Agent': _DEFAULT_USER_AGENT}, 200, content=mock_data))
         client = Minio('localhost:9000')
         bucket_iter = client.list_objects('bucket', recursive=True)
@@ -87,7 +87,7 @@ class ListObjectsTest(TestCase):
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(MockResponse('GET',
-                                                  'https://localhost:9000/bucket/?delimiter=%2F&max-keys=1000',
+                                                  'https://localhost:9000/bucket/?delimiter=%2F&max-keys=1000&prefix=',
                                                   {'User-Agent': _DEFAULT_USER_AGENT}, 200, content=mock_data))
         client = Minio('localhost:9000')
         bucket_iter = client.list_objects('bucket')
@@ -95,7 +95,7 @@ class ListObjectsTest(TestCase):
         for bucket in bucket_iter:
             # cause an xml exception and fail if we try retrieving again
             mock_server.mock_add_request(MockResponse('GET',
-                                                      'https://localhost:9000/bucket/?delimiter=%2F&max-keys=1000',
+                                                      'https://localhost:9000/bucket/?delimiter=%2F&max-keys=1000&prefix=',
                                                       {'User-Agent': _DEFAULT_USER_AGENT}, 200, content=''))
             buckets.append(bucket)
 
@@ -172,13 +172,13 @@ class ListObjectsTest(TestCase):
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(MockResponse('GET',
-                                                  'https://localhost:9000/bucket/?max-keys=1000',
+                                                  'https://localhost:9000/bucket/?max-keys=1000&prefix=',
                                                   {'User-Agent': _DEFAULT_USER_AGENT}, 200, content=mock_data1))
         client = Minio('localhost:9000')
         bucket_iter = client.list_objects('bucket', recursive=True)
         buckets = []
         for bucket in bucket_iter:
-            url = 'https://localhost:9000/bucket/?marker=marker&max-keys=1000'
+            url = 'https://localhost:9000/bucket/?marker=marker&max-keys=1000&prefix='
             mock_server.mock_add_request(MockResponse('GET', url,
                                                       {'User-Agent': _DEFAULT_USER_AGENT}, 200,
                                                       content=mock_data2))

--- a/tests/unit/list_objects_v2_test.py
+++ b/tests/unit/list_objects_v2_test.py
@@ -39,7 +39,7 @@ class ListObjectsV2Test(TestCase):
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(MockResponse('GET',
-                                                  'https://localhost:9000/bucket/?list-type=2',
+                                                  'https://localhost:9000/bucket/?list-type=2&prefix=',
                                                   {'User-Agent': _DEFAULT_USER_AGENT}, 200, content=mock_data))
         client = Minio('localhost:9000')
         object_iter = client.list_objects_v2('bucket', recursive=True)
@@ -79,7 +79,7 @@ class ListObjectsV2Test(TestCase):
         mock_server.mock_add_request(
             MockResponse(
                 'GET',
-                'https://localhost:9000/bucket/?delimiter=%2F&list-type=2',
+                'https://localhost:9000/bucket/?delimiter=%2F&list-type=2&prefix=',
                 {'User-Agent': _DEFAULT_USER_AGENT}, 200,
                 content=mock_data
             )


### PR DESCRIPTION
We have never set values which are empty on the request
because they are perhaps not useful in the List query,
but this assumption is wrong when there are restricted
policies for a given user, because empty is actually
a valid value in IAM or Bucket policy conditions.

For example following condition would never work with our
ListObjects call and AWS cli would work fine.
```json
            "Condition": {
                "StringEquals": {
                    "s3:prefix": [
                        "",
                        "data/",
                        "data"
                    ],
                    "s3:delimiter": [
                        "/",
                        ""
                    ]
                }
            }
```

The reason is empty or not `prefix` and `delimiter` should be
added to the query param in List operation, such that server
can use the value to validate the policies for the incoming
request.

Refer https://github.com/minio/minio-go/pull/1064