### PR TITLE
list-objects-v2: Add start_after parameter

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -249,6 +249,7 @@ __Parameters__
 |``bucket_name`` | _string_ | Name of the bucket.|
 |``prefix``| _string_ |The prefix of the objects that should be listed.  Optional, default is None.|
 |``recursive``   | _bool_ |``True`` indicates recursive style listing and ``False`` indicates directory style listing delimited by '/'. Optional, default is False.|
+|``start_after``| _string_ | Starting listing after the specified path.  Optional, default is None.|
 
 __Return Value__
 
@@ -270,7 +271,7 @@ __Example__
 ```py
 # List all object paths in bucket that begin with my-prefixname.
 objects = minioClient.list_objects_v2('mybucket', prefix='my-prefixname',
-                              recursive=True)
+                          recursive=True, start_after='start-after-this-prefix')
 for obj in objects:
     print(obj.bucket_name, obj.object_name.encode('utf-8'), obj.last_modified,
           obj.etag, obj.size, obj.content_type)

--- a/minio/api.py
+++ b/minio/api.py
@@ -907,7 +907,7 @@ class Minio(object):
             for obj in objects:
                 yield obj
 
-    def list_objects_v2(self, bucket_name, prefix='', recursive=False):
+    def list_objects_v2(self, bucket_name, prefix='', recursive=False, start_after=''):
         """
         List objects in the given bucket using the List objects V2 API.
 
@@ -939,6 +939,13 @@ class Minio(object):
             # hello/world/1
             # hello/world/2
 
+
+            objects = minio.list_objects_v2('foo', recursive=True,
+                                          start_after='hello/world/1')
+            for current_object in objects:
+                print(current_object)
+            # hello/world/2
+
         :param bucket_name: Bucket to list objects from
         :param prefix: String specifying objects returned must begin with
         :param recursive: If yes, returns all objects for a specified prefix
@@ -950,9 +957,13 @@ class Minio(object):
         if prefix is None:
             prefix = ''
 
+        if start_after is None:
+            start_after = ''
+
         # Initialize query parameters.
         query = {
             'list-type': '2',
+            'start-after': start_after,
             'prefix': prefix
         }
 

--- a/tests/unit/list_objects_v2_test.py
+++ b/tests/unit/list_objects_v2_test.py
@@ -39,7 +39,7 @@ class ListObjectsV2Test(TestCase):
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(MockResponse('GET',
-                                                  'https://localhost:9000/bucket/?list-type=2&prefix=',
+                                                  'https://localhost:9000/bucket/?list-type=2&prefix=&start-after=',
                                                   {'User-Agent': _DEFAULT_USER_AGENT}, 200, content=mock_data))
         client = Minio('localhost:9000')
         object_iter = client.list_objects_v2('bucket', recursive=True)
@@ -79,7 +79,7 @@ class ListObjectsV2Test(TestCase):
         mock_server.mock_add_request(
             MockResponse(
                 'GET',
-                'https://localhost:9000/bucket/?delimiter=%2F&list-type=2&prefix=',
+                'https://localhost:9000/bucket/?delimiter=%2F&list-type=2&prefix=&start-after=',
                 {'User-Agent': _DEFAULT_USER_AGENT}, 200,
                 content=mock_data
             )


### PR DESCRIPTION
When listing a bucket or a prefix which contains a lot of files,
it is not possible to pause/resume listing using list-objects-v2
API, adding start_after will help the developer listing from a
starting point without having to list everything again from the
beginning.

Fix #718 