### PR TITLE
test: Content type by default can also be binary/octet-stream

### DIFF
--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -678,9 +678,10 @@ def validate_stat_data(st_obj, expected_size, expected_meta):
     if not received_etag or received_etag == '':
         raise ValueError('No Etag value is returned.')
 
-    if received_content_type != 'application/octet-stream':
+    # content_type by default can be either application/octet-stream or binary/octet-stream
+    if received_content_type != 'application/octet-stream' and received_content_type != 'binary/octet-stream':
         raise ValueError('Incorrect content type. Expected: ',
-                         "'application/octet-stream', received: ",
+                         "'application/octet-stream' or 'binary/octet-stream', received: ",
                           received_content_type)
 
     if received_size != expected_size:


### PR DESCRIPTION
If copy object call is made with the option of replacing metadata,
and content type is not set, then the default content type can be either
binary/octet-stream or application/octet-stream.

Test should treat both as same.

Fixes https://github.com/minio/minio/issues/7238