### PR TITLE
Allow capitalisation inside minio bucket

### DIFF
--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -49,7 +49,7 @@ MAX_MULTIPART_OBJECT_SIZE = 5 * 1024 * 1024 * 1024 * 1024  # 5TiB
 MAX_POOL_SIZE = 10
 MIN_PART_SIZE = 5 * 1024 * 1024  # 5MiB
 
-_VALID_BUCKETNAME_REGEX = re.compile('^[a-z0-9][a-z0-9\\.\\-]+[a-z0-9]$')
+_VALID_BUCKETNAME_REGEX = re.compile('^[a-zA-Z0-9][a-zA-Z0-9\\.\\-]+[a-z0-9]$')
 _ALLOWED_HOSTNAME_REGEX = re.compile(
     '^((?!-)[A-Z\\d-]{1,63}(?<!-)\\.)*((?!-)[A-Z\\d-]{1,63}(?<!-))$',
     re.IGNORECASE)

--- a/tests/unit/minio_test.py
+++ b/tests/unit/minio_test.py
@@ -26,7 +26,6 @@ from minio.helpers import (get_target_url, is_valid_bucket_name,
                            get_s3_region_from_endpoint)
 
 class ValidBucketName(TestCase):
-    @raises(InvalidBucketError)
     def test_bucket_name(self):
         is_valid_bucket_name('bucketName')
 


### PR DESCRIPTION
It was discussed in [#7401](https://github.com/minio/minio/issues/7401) to add support for capitalisation inside minio buckets, as Minio server supports this now as well.

Example:
Previously accepted: `logfiles`
Merging this would accept: `logfiles`, `LogFiles`, or any variation inbetween, as long as the _n_-th letter would be lowercase, i.e. `logfileS` would not be accepted.