### PR TITLE
Replaces Minio refs with MinIO and minio.io links with min.io

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -49,7 +49,7 @@ EOF
 ```
 
 #### Sign
-Sign the release artifacts, this step requires you to have access to Minio's trusted private key.
+Sign the release artifacts, this step requires you to have access to MinIO's trusted private key.
 ```sh
 $ export GNUPGHOME=/media/${USER}/minio/trusted
 $ gpg --detach-sign -a dist/minio-2.2.5.tar.gz
@@ -64,7 +64,7 @@ $ twine upload dist/*
 ```
 
 ### Tag
-Tag and sign your release commit, additionally this step requires you to have access to Minio's trusted private key.
+Tag and sign your release commit, additionally this step requires you to have access to MinIO's trusted private key.
 ```
 $ export GNUPGHOME=/media/${USER}/minio/trusted
 $ git tag -s 2.2.5
@@ -73,7 +73,7 @@ $ git push --tags
 ```
 
 ### Announce
-Announce new release by adding release notes at https://github.com/minio/minio-py/releases from `trusted@minio.io` account. Release notes requires two sections `highlights` and `changelog`. Highlights is a bulleted list of salient features in this release and Changelog contains list of all commits since the last release.
+Announce new release by adding release notes at https://github.com/minio/minio-py/releases from `trusted@min.io` account. Release notes requires two sections `highlights` and `changelog`. Highlights is a bulleted list of salient features in this release and Changelog contains list of all commits since the last release.
 
 To generate `changelog`
 ```sh

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Minio Python Library for Amazon S3 Compatible Cloud Storage [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io)
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage [![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io)
 
-The Minio Python Client SDK provides simple APIs to access any Amazon S3 compatible object storage server.
+The MinIO Python Client SDK provides simple APIs to access any Amazon S3 compatible object storage server.
 
-This quickstart guide will show you how to install the client SDK and execute an example python program. For a complete list of APIs and examples, please take a look at the [Python Client API Reference](https://docs.minio.io/docs/python-client-api-reference) documentation.
+This quickstart guide will show you how to install the client SDK and execute an example python program. For a complete list of APIs and examples, please take a look at the [Python Client API Reference](https://docs.min.io/docs/python-client-api-reference) documentation.
 
 This document assumes that you have a working [Python](https://www.python.org/downloads/) setup in place.
 
@@ -30,9 +30,9 @@ cd minio-py
 python setup.py install
 ```
 
-## Initialize Minio Client
+## Initialize MinIO Client
 
-You need four items in order to connect to Minio object storage server.
+You need four items in order to connect to MinIO object storage server.
 
 | Params     | Description |
 | :------- | :---- |
@@ -45,7 +45,7 @@ You need four items in order to connect to Minio object storage server.
 from minio import Minio
 from minio.error import ResponseError
 
-minioClient = Minio('play.minio.io:9000',
+minioClient = Minio('play.min.io:9000',
                   access_key='Q3AM3UQ867SPQQA43P2F',
                   secret_key='zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG',
                   secure=True)
@@ -53,20 +53,20 @@ minioClient = Minio('play.minio.io:9000',
 
 
 ## Quick Start Example - File Uploader
-This example program connects to a Minio object storage server, makes a bucket on the server and then uploads a file to the bucket.
+This example program connects to a MinIO object storage server, makes a bucket on the server and then uploads a file to the bucket.
 
-We will use the Minio server running at [https://play.minio.io:9000](https://play.minio.io:9000) in this example. Feel free to use this service for testing and development. Access credentials shown in this example are open to the public.
+We will use the MinIO server running at [https://play.min.io:9000](https://play.min.io:9000) in this example. Feel free to use this service for testing and development. Access credentials shown in this example are open to the public.
 
 #### file-uploader.py
 
 ```py
-# Import Minio library.
+# Import MinIO library.
 from minio import Minio
 from minio.error import (ResponseError, BucketAlreadyOwnedByYou,
                          BucketAlreadyExists)
 
 # Initialize minioClient with an endpoint and access/secret keys.
-minioClient = Minio('play.minio.io:9000',
+minioClient = Minio('play.min.io:9000',
                     access_key='Q3AM3UQ867SPQQA43P2F',
                     secret_key='zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG',
                     secure=True)
@@ -100,51 +100,51 @@ mc ls play/maylogs/
 ## API Reference
 
 The full API Reference is available here.
-* [Complete API Reference](https://docs.minio.io/docs/python-client-api-reference)
+* [Complete API Reference](https://docs.min.io/docs/python-client-api-reference)
 
 ### API Reference : Bucket Operations
 
-* [`make_bucket`](https://docs.minio.io/docs/python-client-api-reference#make_bucket)
-* [`list_buckets`](https://docs.minio.io/docs/python-client-api-reference#list_buckets)
-* [`bucket_exists`](https://docs.minio.io/docs/python-client-api-reference#bucket_exists)
-* [`remove_bucket`](https://docs.minio.io/docs/python-client-api-reference#remove_bucket)
-* [`list_objects`](https://docs.minio.io/docs/python-client-api-reference#list_objects)
-* [`list_objects_v2`](https://docs.minio.io/docs/python-client-api-reference#list_objects_v2)
-* [`list_incomplete_uploads`](https://docs.minio.io/docs/python-client-api-reference#list_incomplete_uploads)
+* [`make_bucket`](https://docs.min.io/docs/python-client-api-reference#make_bucket)
+* [`list_buckets`](https://docs.min.io/docs/python-client-api-reference#list_buckets)
+* [`bucket_exists`](https://docs.min.io/docs/python-client-api-reference#bucket_exists)
+* [`remove_bucket`](https://docs.min.io/docs/python-client-api-reference#remove_bucket)
+* [`list_objects`](https://docs.min.io/docs/python-client-api-reference#list_objects)
+* [`list_objects_v2`](https://docs.min.io/docs/python-client-api-reference#list_objects_v2)
+* [`list_incomplete_uploads`](https://docs.min.io/docs/python-client-api-reference#list_incomplete_uploads)
 
 ### API Reference : Bucket policy Operations
 
-* [`get_bucket_policy`](https://docs.minio.io/docs/python-client-api-reference#get_bucket_policy)
-* [`set_bucket_policy`](https://docs.minio.io/docs/python-client-api-reference#set_bucket_policy)
+* [`get_bucket_policy`](https://docs.min.io/docs/python-client-api-reference#get_bucket_policy)
+* [`set_bucket_policy`](https://docs.min.io/docs/python-client-api-reference#set_bucket_policy)
 
 ### API Reference : Bucket notification Operations
 
-* [`set_bucket_notification`](https://docs.minio.io/docs/python-client-api-reference#set_bucket_notification)
-* [`get_bucket_notification`](https://docs.minio.io/docs/python-client-api-reference#get_bucket_notification)
-* [`remove_all_bucket_notification`](https://docs.minio.io/docs/python-client-api-reference#remove_all_bucket_notification)
-* [`listen_bucket_notification`](https://docs.minio.io/docs/python-client-api-reference#listen_bucket_notification)
+* [`set_bucket_notification`](https://docs.min.io/docs/python-client-api-reference#set_bucket_notification)
+* [`get_bucket_notification`](https://docs.min.io/docs/python-client-api-reference#get_bucket_notification)
+* [`remove_all_bucket_notification`](https://docs.min.io/docs/python-client-api-reference#remove_all_bucket_notification)
+* [`listen_bucket_notification`](https://docs.min.io/docs/python-client-api-reference#listen_bucket_notification)
 
 ### API Reference : File Object Operations
 
-* [`fput_object`](https://docs.minio.io/docs/python-client-api-reference#fput_object)
-* [`fget_object`](https://docs.minio.io/docs/python-client-api-reference#fget_object)
+* [`fput_object`](https://docs.min.io/docs/python-client-api-reference#fput_object)
+* [`fget_object`](https://docs.min.io/docs/python-client-api-reference#fget_object)
 
 ### API Reference : Object Operations
 
-* [`get_object`](https://docs.minio.io/docs/python-client-api-reference#get_object)
-* [`put_object`](https://docs.minio.io/docs/python-client-api-reference#put_object)
-* [`stat_object`](https://docs.minio.io/docs/python-client-api-reference#stat_object)
-* [`copy_object`](https://docs.minio.io/docs/python-client-api-reference#copy_object)
-* [`get_partial_object`](https://docs.minio.io/docs/python-client-api-reference#get_partial_object)
-* [`remove_object`](https://docs.minio.io/docs/python-client-api-reference#remove_object)
-* [`remove_objects`](https://docs.minio.io/docs/python-client-api-reference#remove_objects)
-* [`remove_incomplete_upload`](https://docs.minio.io/docs/python-client-api-reference#remove_incomplete_upload)
+* [`get_object`](https://docs.min.io/docs/python-client-api-reference#get_object)
+* [`put_object`](https://docs.min.io/docs/python-client-api-reference#put_object)
+* [`stat_object`](https://docs.min.io/docs/python-client-api-reference#stat_object)
+* [`copy_object`](https://docs.min.io/docs/python-client-api-reference#copy_object)
+* [`get_partial_object`](https://docs.min.io/docs/python-client-api-reference#get_partial_object)
+* [`remove_object`](https://docs.min.io/docs/python-client-api-reference#remove_object)
+* [`remove_objects`](https://docs.min.io/docs/python-client-api-reference#remove_objects)
+* [`remove_incomplete_upload`](https://docs.min.io/docs/python-client-api-reference#remove_incomplete_upload)
 
 ### API Reference : Presigned Operations
 
-* [`presigned_get_object`](https://docs.minio.io/docs/python-client-api-reference#presigned_get_object)
-* [`presigned_put_object`](https://docs.minio.io/docs/python-client-api-reference#presigned_put_object)
-* [`presigned_post_policy`](https://docs.minio.io/docs/python-client-api-reference#presigned_post_policy)
+* [`presigned_get_object`](https://docs.min.io/docs/python-client-api-reference#presigned_get_object)
+* [`presigned_put_object`](https://docs.min.io/docs/python-client-api-reference#presigned_put_object)
+* [`presigned_post_policy`](https://docs.min.io/docs/python-client-api-reference#presigned_post_policy)
 
 ## Full Examples
 
@@ -198,8 +198,8 @@ The full API Reference is available here.
 
 ## Explore Further
 
-* [Complete Documentation](https://docs.minio.io)
-* [Minio Python SDK API Reference](https://docs.minio.io/docs/python-client-api-reference)
+* [Complete Documentation](https://docs.min.io)
+* [MinIO Python SDK API Reference](https://docs.min.io/docs/python-client-api-reference)
 
 ## Contribute
 

--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,13 @@
-Minio Python Library for Amazon S3 Compatible Cloud Storage |Gitter|
+MinIO Python Library for Amazon S3 Compatible Cloud Storage |Gitter|
 ========
 
-The Minio Python Client SDK provides simple APIs to access any Amazon S3
+The MinIO Python Client SDK provides simple APIs to access any Amazon S3
 compatible object storage server.
 
 This quickstart guide will show you how to install the client SDK and
 execute an example python program. For a complete list of APIs and
 examples, please take a look at the `Python Client API
-Reference <https://docs.minio.io/docs/python-client-api-reference>`__
+Reference <https://docs.min.io/docs/python-client-api-reference>`__
 documentation.
 
 This document assumes that you have a working
@@ -29,10 +29,10 @@ Download from source
     $ cd minio-py
     $ python setup.py install
 
-Initialize Minio Client
+Initialize MinIO Client
 -----------------------
 
-You need four items in order to connect to Minio object storage server.
+You need four items in order to connect to MinIO object storage server.
 
 .. csv-table::
    :header: "Params", "Description"
@@ -49,7 +49,7 @@ You need four items in order to connect to Minio object storage server.
     from minio import Minio
     from minio.error import ResponseError
 
-    minioClient = Minio('play.minio.io:9000',
+    minioClient = Minio('play.min.io:9000',
                       access_key='Q3AM3UQ867SPQQA43P2F',
                       secret_key='zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG',
                       secure=True)
@@ -57,10 +57,10 @@ You need four items in order to connect to Minio object storage server.
 Quick Start Example - File Uploader
 -----------------------------------
 
-This example program connects to a Minio object storage server, makes a
+This example program connects to a MinIO object storage server, makes a
 bucket on the server and then uploads a file to the bucket.
 
-We will use the Minio server running at https://play.minio.io:9000 in
+We will use the MinIO server running at https://play.min.io:9000 in
 this example. Feel free to use this service for testing and development.
 Access credentials shown in this example are open to the public.
 
@@ -69,12 +69,12 @@ file-uploader.py
 
 .. code:: python
 
-    # Import Minio library.
+    # Import MinIO library.
     from minio import Minio
     from minio.error import ResponseError
 
     # Initialize minioClient with an endpoint and access/secret keys.
-    minioClient = Minio('play.minio.io:9000',
+    minioClient = Minio('play.min.io:9000',
                         access_key='Q3AM3UQ867SPQQA43P2F',
                         secret_key='zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG',
                         secure=True)
@@ -110,42 +110,42 @@ API Reference
 -------------
 
 The full API Reference is available here. `Complete API
-Reference <https://docs.minio.io/docs/python-client-api-reference>`__
+Reference <https://docs.min.io/docs/python-client-api-reference>`__
 
 API Reference : Bucket Operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  `make\_bucket <https://docs.minio.io/docs/python-client-api-reference#make_bucket>`__
--  `list\_buckets <https://docs.minio.io/docs/python-client-api-reference#list_buckets>`__
--  `bucket\_exists <https://docs.minio.io/docs/python-client-api-reference#bucket_exists>`__
--  `remove\_bucket <https://docs.minio.io/docs/python-client-api-reference#remove_bucket>`__
--  `list\_objects <https://docs.minio.io/docs/python-client-api-reference#list_objects>`__
--  `list\_incomplete\_uploads <https://docs.minio.io/docs/python-client-api-reference#list_incomplete_uploads>`__
--  `get\_bucket\_policy <https://docs.minio.io/docs/python-client-api-reference#get_bucket_policy>`__
--  `set\_bucket\_policy <https://docs.minio.io/docs/python-client-api-reference#set_bucket_policy>`__
+-  `make\_bucket <https://docs.min.io/docs/python-client-api-reference#make_bucket>`__
+-  `list\_buckets <https://docs.min.io/docs/python-client-api-reference#list_buckets>`__
+-  `bucket\_exists <https://docs.min.io/docs/python-client-api-reference#bucket_exists>`__
+-  `remove\_bucket <https://docs.min.io/docs/python-client-api-reference#remove_bucket>`__
+-  `list\_objects <https://docs.min.io/docs/python-client-api-reference#list_objects>`__
+-  `list\_incomplete\_uploads <https://docs.min.io/docs/python-client-api-reference#list_incomplete_uploads>`__
+-  `get\_bucket\_policy <https://docs.min.io/docs/python-client-api-reference#get_bucket_policy>`__
+-  `set\_bucket\_policy <https://docs.min.io/docs/python-client-api-reference#set_bucket_policy>`__
 
 API Reference : File Object Operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  `fput\_object <https://docs.minio.io/docs/python-client-api-reference#fput_object>`__
--  `fget\_object <https://docs.minio.io/docs/python-client-api-reference#fget_object>`__
+-  `fput\_object <https://docs.min.io/docs/python-client-api-reference#fput_object>`__
+-  `fget\_object <https://docs.min.io/docs/python-client-api-reference#fget_object>`__
 
 API Reference : Object Operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  `get\_object <https://docs.minio.io/docs/python-client-api-reference#get_object>`__
--  `get\_partial\_object <https://docs.minio.io/docs/python-client-api-reference#get_partial_object>`__
--  `put\_object <https://docs.minio.io/docs/python-client-api-reference#put_object>`__
--  `stat\_object <https://docs.minio.io/docs/python-client-api-reference#stat_object>`__
--  `remove\_object <https://docs.minio.io/docs/python-client-api-reference#remove_object>`__
--  `remove\_incomplete\_upload <https://docs.minio.io/docs/python-client-api-reference#remove_incomplete_upload>`__
+-  `get\_object <https://docs.min.io/docs/python-client-api-reference#get_object>`__
+-  `get\_partial\_object <https://docs.min.io/docs/python-client-api-reference#get_partial_object>`__
+-  `put\_object <https://docs.min.io/docs/python-client-api-reference#put_object>`__
+-  `stat\_object <https://docs.min.io/docs/python-client-api-reference#stat_object>`__
+-  `remove\_object <https://docs.min.io/docs/python-client-api-reference#remove_object>`__
+-  `remove\_incomplete\_upload <https://docs.min.io/docs/python-client-api-reference#remove_incomplete_upload>`__
 
 API Reference : Presigned Operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  `presigned\_get\_object <https://docs.minio.io/docs/python-client-api-reference#presigned_get_object>`__
--  `presigned\_put_object <https://docs.minio.io/docs/python-client-api-reference#presigned_put_object>`__
--  `presigned\_post\_policy <https://docs.minio.io/docs/python-client-api-reference#presigned_post_policy>`__
+-  `presigned\_get\_object <https://docs.min.io/docs/python-client-api-reference#presigned_get_object>`__
+-  `presigned\_put_object <https://docs.min.io/docs/python-client-api-reference#presigned_put_object>`__
+-  `presigned\_post\_policy <https://docs.min.io/docs/python-client-api-reference#presigned_post_policy>`__
 
 Full Examples
 -------------
@@ -186,9 +186,9 @@ Full Examples : Presigned Operations
 Explore Further
 ---------------
 
--  `Complete Documentation <https://docs.minio.io>`__
--  `Minio Python SDK API
-   Reference <https://docs.minio.io/docs/python-client-api-reference>`__
+-  `Complete Documentation <https://docs.min.io>`__
+-  `MinIO Python SDK API
+   Reference <https://docs.min.io/docs/python-client-api-reference>`__
 
 Contribute
 ----------
@@ -198,7 +198,7 @@ Contribute
 |PYPI| |Build Status| |Build status|
 
 .. |Gitter| image:: https://badges.gitter.im/Join%20Chat.svg
-   :target: https://gitter.im/Minio/minio?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+   :target: https://gitter.im/MinIO/minio?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 .. |PYPI| image:: https://img.shields.io/pypi/v/minio.svg
    :target: https://pypi.python.org/pypi/minio
 .. |Build Status| image:: https://travis-ci.org/minio/minio-py.svg

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -1,8 +1,8 @@
-# 适用于与Amazon S3兼容的云存储的Minio Python Library [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io)
+# 适用于与Amazon S3兼容的云存储的MinIO Python Library [![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io)
 
-Minio Python Client SDK提供简单的API来访问任何与Amazon S3兼容的对象存储服务。
+MinIO Python Client SDK提供简单的API来访问任何与Amazon S3兼容的对象存储服务。
 
-本文我们将学习如何安装Minio client SDK，并运行一个python的示例程序。对于完整的API以及示例，请参考[Python Client API Reference](https://docs.minio.io/docs/python-client-api-reference)。
+本文我们将学习如何安装MinIO client SDK，并运行一个python的示例程序。对于完整的API以及示例，请参考[Python Client API Reference](https://docs.min.io/docs/python-client-api-reference)。
 
 本文假设你已经有一个可运行的 [Python](https://www.python.org/downloads/)开发环境。
 
@@ -24,9 +24,9 @@ cd minio-py
 python setup.py install
 ```
 
-## 初始化Minio Client
+## 初始化MinIO Client
 
-Minio client需要以下4个参数来连接Minio对象存储服务。
+MinIO client需要以下4个参数来连接MinIO对象存储服务。
 
 | 参数     | 描述  |
 | :------- | :---- |
@@ -39,7 +39,7 @@ Minio client需要以下4个参数来连接Minio对象存储服务。
 from minio import Minio
 from minio.error import ResponseError
 
-minioClient = Minio('play.minio.io:9000',
+minioClient = Minio('play.min.io:9000',
                   access_key='Q3AM3UQ867SPQQA43P2F',
                   secret_key='zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG',
                   secure=True)
@@ -47,20 +47,20 @@ minioClient = Minio('play.minio.io:9000',
 
 
 ## 示例-文件上传
-本示例连接到一个Minio对象存储服务，创建一个存储桶并上传一个文件到存储桶中。
+本示例连接到一个MinIO对象存储服务，创建一个存储桶并上传一个文件到存储桶中。
 
-我们在本示例中使用运行在 [https://play.minio.io:9000](https://play.minio.io:9000) 上的Minio服务，你可以用这个服务来开发和测试。示例中的访问凭据是公开的。
+我们在本示例中使用运行在 [https://play.min.io:9000](https://play.min.io:9000) 上的MinIO服务，你可以用这个服务来开发和测试。示例中的访问凭据是公开的。
 
 #### file-uploader.py
 
 ```py
-# 引入Minio包。
+# 引入MinIO包。
 from minio import Minio
 from minio.error import (ResponseError, BucketAlreadyOwnedByYou,
                          BucketAlreadyExists)
 
 # 使用endpoint、access key和secret key来初始化minioClient对象。
-minioClient = Minio('play.minio.io:9000',
+minioClient = Minio('play.min.io:9000',
                     access_key='Q3AM3UQ867SPQQA43P2F',
                     secret_key='zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG',
                     secure=True)
@@ -93,51 +93,51 @@ mc ls play/maylogs/
 ## API文档
 
 完整的API文档在这里。
-* [完整API文档](https://docs.minio.io/docs/python-client-api-reference)
+* [完整API文档](https://docs.min.io/docs/python-client-api-reference)
 
 ### API文档 : 操作存储桶
 
-* [`make_bucket`](https://docs.minio.io/docs/python-client-api-reference#make_bucket)
-* [`list_buckets`](https://docs.minio.io/docs/python-client-api-reference#list_buckets)
-* [`bucket_exists`](https://docs.minio.io/docs/python-client-api-reference#bucket_exists)
-* [`remove_bucket`](https://docs.minio.io/docs/python-client-api-reference#remove_bucket)
-* [`list_objects`](https://docs.minio.io/docs/python-client-api-reference#list_objects)
-* [`list_objects_v2`](https://docs.minio.io/docs/python-client-api-reference#list_objects_v2)
-* [`list_incomplete_uploads`](https://docs.minio.io/docs/python-client-api-reference#list_incomplete_uploads)
+* [`make_bucket`](https://docs.min.io/docs/python-client-api-reference#make_bucket)
+* [`list_buckets`](https://docs.min.io/docs/python-client-api-reference#list_buckets)
+* [`bucket_exists`](https://docs.min.io/docs/python-client-api-reference#bucket_exists)
+* [`remove_bucket`](https://docs.min.io/docs/python-client-api-reference#remove_bucket)
+* [`list_objects`](https://docs.min.io/docs/python-client-api-reference#list_objects)
+* [`list_objects_v2`](https://docs.min.io/docs/python-client-api-reference#list_objects_v2)
+* [`list_incomplete_uploads`](https://docs.min.io/docs/python-client-api-reference#list_incomplete_uploads)
 
 ### API文档 : 存储桶策略
 
-* [`get_bucket_policy`](https://docs.minio.io/docs/python-client-api-reference#get_bucket_policy)
-* [`set_bucket_policy`](https://docs.minio.io/docs/python-client-api-reference#set_bucket_policy)
+* [`get_bucket_policy`](https://docs.min.io/docs/python-client-api-reference#get_bucket_policy)
+* [`set_bucket_policy`](https://docs.min.io/docs/python-client-api-reference#set_bucket_policy)
 
 ### API文档 : 存储桶通知
 
-* [`set_bucket_notification`](https://docs.minio.io/docs/python-client-api-reference#set_bucket_notification)
-* [`get_bucket_notification`](https://docs.minio.io/docs/python-client-api-reference#get_bucket_notification)
-* [`remove_all_bucket_notification`](https://docs.minio.io/docs/python-client-api-reference#remove_all_bucket_notification)
-* [`listen_bucket_notification`](https://docs.minio.io/docs/python-client-api-reference#listen_bucket_notification)
+* [`set_bucket_notification`](https://docs.min.io/docs/python-client-api-reference#set_bucket_notification)
+* [`get_bucket_notification`](https://docs.min.io/docs/python-client-api-reference#get_bucket_notification)
+* [`remove_all_bucket_notification`](https://docs.min.io/docs/python-client-api-reference#remove_all_bucket_notification)
+* [`listen_bucket_notification`](https://docs.min.io/docs/python-client-api-reference#listen_bucket_notification)
 
 ### API文档 : 操作文件对象
 
-* [`fput_object`](https://docs.minio.io/docs/python-client-api-reference#fput_object)
-* [`fget_object`](https://docs.minio.io/docs/python-client-api-reference#fget_object)
+* [`fput_object`](https://docs.min.io/docs/python-client-api-reference#fput_object)
+* [`fget_object`](https://docs.min.io/docs/python-client-api-reference#fget_object)
 
 ### API文档 : 操作对象
 
-* [`get_object`](https://docs.minio.io/docs/python-client-api-reference#get_object)
-* [`put_object`](https://docs.minio.io/docs/python-client-api-reference#put_object)
-* [`stat_object`](https://docs.minio.io/docs/python-client-api-reference#stat_object)
-* [`copy_object`](https://docs.minio.io/docs/python-client-api-reference#copy_object)
-* [`get_partial_object`](https://docs.minio.io/docs/python-client-api-reference#get_partial_object)
-* [`remove_object`](https://docs.minio.io/docs/python-client-api-reference#remove_object)
-* [`remove_objects`](https://docs.minio.io/docs/python-client-api-reference#remove_objects)
-* [`remove_incomplete_upload`](https://docs.minio.io/docs/python-client-api-reference#remove_incomplete_upload)
+* [`get_object`](https://docs.min.io/docs/python-client-api-reference#get_object)
+* [`put_object`](https://docs.min.io/docs/python-client-api-reference#put_object)
+* [`stat_object`](https://docs.min.io/docs/python-client-api-reference#stat_object)
+* [`copy_object`](https://docs.min.io/docs/python-client-api-reference#copy_object)
+* [`get_partial_object`](https://docs.min.io/docs/python-client-api-reference#get_partial_object)
+* [`remove_object`](https://docs.min.io/docs/python-client-api-reference#remove_object)
+* [`remove_objects`](https://docs.min.io/docs/python-client-api-reference#remove_objects)
+* [`remove_incomplete_upload`](https://docs.min.io/docs/python-client-api-reference#remove_incomplete_upload)
 
 ### API文档 : Presigned操作
 
-* [`presigned_get_object`](https://docs.minio.io/docs/python-client-api-reference#presigned_get_object)
-* [`presigned_put_object`](https://docs.minio.io/docs/python-client-api-reference#presigned_put_object)
-* [`presigned_post_policy`](https://docs.minio.io/docs/python-client-api-reference#presigned_post_policy)
+* [`presigned_get_object`](https://docs.min.io/docs/python-client-api-reference#presigned_get_object)
+* [`presigned_put_object`](https://docs.min.io/docs/python-client-api-reference#presigned_put_object)
+* [`presigned_post_policy`](https://docs.min.io/docs/python-client-api-reference#presigned_post_policy)
 
 ## 完整示例
 
@@ -186,8 +186,8 @@ mc ls play/maylogs/
 
 ## 了解更多
 
-* [完整文档](https://docs.minio.io)
-* [Minio Python SDK API文档](https://docs.minio.io/docs/python-client-api-reference)
+* [完整文档](https://docs.min.io)
+* [MinIO Python SDK API文档](https://docs.min.io/docs/python-client-api-reference)
 
 ## 贡献
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,14 +1,14 @@
-# Python Client API Reference [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io)
+# Python Client API Reference [![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io)
 
-## Initialize Minio Client object.
+## Initialize MinIO Client object.
 
-## Minio
+## MinIO
 
 ```py
 from minio import Minio
 from minio.error import ResponseError
 
-minioClient = Minio('play.minio.io:9000',
+minioClient = Minio('play.min.io:9000',
                   access_key='Q3AM3UQ867SPQQA43P2F',
                   secret_key='zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG',
                   secure=True)
@@ -43,7 +43,7 @@ s3Client = Minio('s3.amazonaws.com',
 
 ## 1. Constructor
 
-<a name="Minio"></a>
+<a name="MinIO"></a>
 ### Minio(endpoint, access_key=None, secret_key=None, secure=True, region=None, http_client=None)
 
 |   |
@@ -65,13 +65,13 @@ __Parameters__
 
 __Example__
 
-### Minio
+### MinIO
 
 ```py
 from minio import Minio
 from minio.error import ResponseError
 
-minioClient = Minio('play.minio.io:9000',
+minioClient = Minio('play.min.io:9000',
                     access_key='Q3AM3UQ867SPQQA43P2F',
                     secret_key='zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG')
 ```
@@ -571,7 +571,7 @@ minioClient.remove_all_bucket_notification('mybucket')
 
 Listen for notifications on a bucket. Additionally one can provide
 filters for prefix, suffix and events. There is no prior set bucket notification
-needed to use this API. This is an Minio extension API where unique identifiers
+needed to use this API. This is an MinIO extension API where unique identifiers
 are registered and unregistered by the server automatically based on incoming
 requests.
 
@@ -1103,6 +1103,6 @@ print(' '.join(curl_cmd))
 
 ## 5. Explore Further
 
-- [Minio Golang Client SDK Quickstart Guide](https://docs.minio.io/docs/golang-client-quickstart-guide)
-- [Minio Java Client SDK Quickstart Guide](https://docs.minio.io/docs/java-client-quickstart-guide)
-- [Minio JavaScript Client SDK Quickstart Guide](https://docs.minio.io/docs/javascript-client-quickstart-guide)
+- [MinIO Golang Client SDK Quickstart Guide](https://docs.min.io/docs/golang-client-quickstart-guide)
+- [MinIO Java Client SDK Quickstart Guide](https://docs.min.io/docs/java-client-quickstart-guide)
+- [MinIO JavaScript Client SDK Quickstart Guide](https://docs.min.io/docs/javascript-client-quickstart-guide)

--- a/docs/zh_CN/API.md
+++ b/docs/zh_CN/API.md
@@ -1,14 +1,14 @@
-# Python Client API文档 [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io)
+# Python Client API文档 [![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io)
 
-## 初使化Minio Client对象。
+## 初使化MinIO Client对象。
 
-## Minio
+## MinIO
 
 ```py
 from minio import Minio
 from minio.error import ResponseError
 
-minioClient = Minio('play.minio.io:9000',
+minioClient = Minio('play.min.io:9000',
                   access_key='Q3AM3UQ867SPQQA43P2F',
                   secret_key='zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG',
                   secure=True)
@@ -43,7 +43,7 @@ s3Client = Minio('s3.amazonaws.com',
 
 ## 1. 构造函数
 
-<a name="Minio"></a>
+<a name="MinIO"></a>
 ### Minio(endpoint, access_key=None, secret_key=None, secure=True, region=None, http_client=None)
 
 |   |
@@ -65,13 +65,13 @@ s3Client = Minio('s3.amazonaws.com',
 
 __示例__
 
-### Minio
+### MinIO
 
 ```py
 from minio import Minio
 from minio.error import ResponseError
 
-minioClient = Minio('play.minio.io:9000',
+minioClient = Minio('play.min.io:9000',
                     access_key='Q3AM3UQ867SPQQA43P2F',
                     secret_key='zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG')
 ```
@@ -532,7 +532,7 @@ minioClient.remove_all_bucket_notification('mybucket')
 <a name="listen_bucket_notification"></a>
 ### listen_bucket_notification(bucket_name, prefix, suffix, events)
 
-监听存储桶上的通知，可以额外提供前缀、后缀和时间类型来进行过滤。使用该API前不需要先设置存储桶通知。这是一个Minio的扩展API，Minio Server会基于过来的请求使用唯一标识符自动注册或者注销。
+监听存储桶上的通知，可以额外提供前缀、后缀和时间类型来进行过滤。使用该API前不需要先设置存储桶通知。这是一个MinIO的扩展API，MinIO Server会基于过来的请求使用唯一标识符自动注册或者注销。
 
 当通知发生时，产生事件，调用者需要遍历读取这些事件。
 
@@ -1044,6 +1044,6 @@ print(' '.join(curl_cmd))
 
 ## 5. 了解更多
 
-- [Minio Golang Client SDK快速入门](https://docs.minio.io/docs/golang-client-quickstart-guide)
-- [Minio Java Client SDK快速入门](https://docs.minio.io/docs/java-client-quickstart-guide)
-- [Minio JavaScript Client SDK快速入门](https://docs.minio.io/docs/javascript-client-quickstart-guide)
+- [MinIO Golang Client SDK快速入门](https://docs.min.io/docs/golang-client-quickstart-guide)
+- [MinIO Java Client SDK快速入门](https://docs.min.io/docs/java-client-quickstart-guide)
+- [MinIO JavaScript Client SDK快速入门](https://docs.min.io/docs/javascript-client-quickstart-guide)

--- a/examples/bucket_exists.py
+++ b/examples/bucket_exists.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/copy_object.py
+++ b/examples/copy_object.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2016 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2016 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/copy_object_with_metadata.py
+++ b/examples/copy_object_with_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2016,2017,2018 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2016,2017,2018 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/fget_object.py
+++ b/examples/fget_object.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/fput_object.py
+++ b/examples/fput_object.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/get_bucket_notification.py
+++ b/examples/get_bucket_notification.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage.
-# Copyright (C) 2016 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage.
+# Copyright (C) 2016 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/get_bucket_policy.py
+++ b/examples/get_bucket_policy.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage.
-# Copyright (C) 2016 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage.
+# Copyright (C) 2016 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/get_object.py
+++ b/examples/get_object.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/get_partial_object.py
+++ b/examples/get_partial_object.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/list_buckets.py
+++ b/examples/list_buckets.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/list_incomplete_uploads.py
+++ b/examples/list_incomplete_uploads.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/list_objects.py
+++ b/examples/list_objects.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/listen_notification.py
+++ b/examples/listen_notification.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage.
-# Copyright (C) 2016 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage.
+# Copyright (C) 2016 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 from minio import Minio
 
-client = Minio('play.minio.io:9000',
+client = Minio('play.min.io:9000',
                access_key='Q3AM3UQ867SPQQA43P2F',
                secret_key='zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG')
 

--- a/examples/make_bucket.py
+++ b/examples/make_bucket.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/presigned_get_object.py
+++ b/examples/presigned_get_object.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/presigned_post_policy.py
+++ b/examples/presigned_post_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/presigned_put_object.py
+++ b/examples/presigned_put_object.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/progress.py
+++ b/examples/progress.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 """
-This module implements a progress printer while communicate minio server
+This module implements a progress printer while communicating with MinIO server
 
 :copyright: (c) 2018 by MinIO, Inc.
 :license: Apache 2.0, see LICENSE for more details.

--- a/examples/progress.py
+++ b/examples/progress.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C)
-# 2018 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C)
+# 2018 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 """
 This module implements a progress printer while communicate minio server
 
-:copyright: (c) 2018 by Minio, Inc.
+:copyright: (c) 2018 by MinIO, Inc.
 :license: Apache 2.0, see LICENSE for more details.
 
 """

--- a/examples/put_and_get_object_sse-c.py
+++ b/examples/put_and_get_object_sse-c.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2018 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2018 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/put_object.py
+++ b/examples/put_object.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/put_object_sse-kms.py
+++ b/examples/put_object_sse-kms.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2018 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2018 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/put_object_sse-s3.py
+++ b/examples/put_object_sse-s3.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2018 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2018 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/remove_all_bucket_notification.py
+++ b/examples/remove_all_bucket_notification.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage.
-# Copyright (C) 2016 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage.
+# Copyright (C) 2016 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/remove_bucket.py
+++ b/examples/remove_bucket.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/remove_incomplete_upload.py
+++ b/examples/remove_incomplete_upload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/remove_object.py
+++ b/examples/remove_object.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/remove_objects.py
+++ b/examples/remove_objects.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/set_bucket_notification.py
+++ b/examples/set_bucket_notification.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage.
-# Copyright (C) 2016 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage.
+# Copyright (C) 2016 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/set_bucket_policy.py
+++ b/examples/set_bucket_policy.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage.
-# Copyright (C) 2016 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage.
+# Copyright (C) 2016 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/stat_object.py
+++ b/examples/stat_object.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/minio/__init__.py
+++ b/minio/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage,
-# (C) 2015, 2016, 2017 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage,
+# (C) 2015, 2016, 2017 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 """
-minio - Minio Python Library for Amazon S3 Compatible Cloud Storage
+minio - MinIO Python Library for Amazon S3 Compatible Cloud Storage
 ~~~~~~~~~~~~~~~~~~~~~
 
    >>> import minio
@@ -23,15 +23,15 @@ minio - Minio Python Library for Amazon S3 Compatible Cloud Storage
    >>> for bucket in minio.list_buckets():
    ...     print(bucket.name)
 
-:copyright: (c) 2015, 2016, 2017 by Minio, Inc.
+:copyright: (c) 2015, 2016, 2017 by MinIO, Inc.
 :license: Apache 2.0, see LICENSE for more details.
 """
 
 __title__ = 'minio-py'
-__author__ = 'Minio, Inc.'
+__author__ = 'MinIO, Inc.'
 __version__ = '4.0.14'
 __license__ = 'Apache 2.0'
-__copyright__ = 'Copyright 2015, 2016, 2017 Minio, Inc.'
+__copyright__ = 'Copyright 2015, 2016, 2017 MinIO, Inc.'
 
 from .api import Minio
 from .error import ResponseError

--- a/minio/api.py
+++ b/minio/api.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C)
-# 2015, 2016, 2017 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C)
+# 2015, 2016, 2017 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ minio.api
 
 This module implements the API.
 
-:copyright: (c) 2015, 2016, 2017 by Minio, Inc.
+:copyright: (c) 2015, 2016, 2017 by MinIO, Inc.
 :license: Apache 2.0, see LICENSE for more details.
 
 """
@@ -99,8 +99,8 @@ _COMMENTS = '({0}; {1})'
 # App info format.
 _APP_INFO = '{0}/{1}'
 
-# Minio (OS; ARCH) LIB/VER APP/VER .
-_DEFAULT_USER_AGENT = 'Minio {0} {1}'.format(
+# MinIO (OS; ARCH) LIB/VER APP/VER .
+_DEFAULT_USER_AGENT = 'MinIO {0} {1}'.format(
     _COMMENTS.format(platform.system(),
                      platform.machine()),
     _APP_INFO.format(__title__,
@@ -114,16 +114,16 @@ _MAX_EXPIRY_TIME = 604800 # 7 days in seconds
 _PARALLEL_UPLOADERS = 3
 
 
-class Minio(object):
+class MinIO(object):
     """
-    Constructs a :class:`Minio <Minio>`.
+    Constructs a :class:`MinIO <MinIO>`.
 
     Examples:
-        client = Minio('play.minio.io:9000')
+        client = Minio('play.min.io:9000')
         client = Minio('s3.amazonaws.com', 'ACCESS_KEY', 'SECRET_KEY')
 
         # To override auto bucket location discovery.
-        client = Minio('play.minio.io:9000', 'ACCESS_KEY', 'SECRET_KEY',
+        client = Minio('play.min.io:9000', 'ACCESS_KEY', 'SECRET_KEY',
                        region='us-east-1')
 
     :param endpoint: Hostname of the cloud storage server.
@@ -136,7 +136,7 @@ class Minio(object):
          location discovery.
     :param timeout: Set this value to control how long requests
          are allowed to run before being aborted.
-    :return: :class:`Minio <Minio>` object
+    :return: :class:`MinIO <MinIO>` object
     """
     def __init__(self, endpoint, access_key=None,
                  secret_key=None,
@@ -201,7 +201,7 @@ class Minio(object):
         Sets your application name and version to
         default user agent in the following format.
 
-              Minio (OS; ARCH) LIB/VER APP/VER
+              MinIO (OS; ARCH) LIB/VER APP/VER
 
         Example:
             client.set_app_info('my_app', '1.0.2')
@@ -360,7 +360,7 @@ class Minio(object):
 
         try:
             self._url_open('HEAD', bucket_name=bucket_name)
-        # If the bucket has not been created yet, Minio will return a "NoSuchBucket" error.
+        # If the bucket has not been created yet, MinIO will return a "NoSuchBucket" error.
         except NoSuchBucket:
             return False
         except ResponseError:
@@ -518,7 +518,7 @@ class Minio(object):
         url_components = urlsplit(self._endpoint_url)
         if url_components.hostname == 's3.amazonaws.com':
             raise InvalidArgumentError(
-                'Listening for event notifications on a bucket is a Minio '
+                'Listening for event notifications on a bucket is a MinIO '
                 'specific extension to bucket notification API. It is not '
                 'supported by Amazon S3')
 

--- a/minio/api.py
+++ b/minio/api.py
@@ -114,9 +114,9 @@ _MAX_EXPIRY_TIME = 604800 # 7 days in seconds
 _PARALLEL_UPLOADERS = 3
 
 
-class MinIO(object):
+class Minio(object):
     """
-    Constructs a :class:`MinIO <MinIO>`.
+    Constructs a :class:`Minio <Minio>`.
 
     Examples:
         client = Minio('play.min.io:9000')
@@ -136,7 +136,7 @@ class MinIO(object):
          location discovery.
     :param timeout: Set this value to control how long requests
          are allowed to run before being aborted.
-    :return: :class:`MinIO <MinIO>` object
+    :return: :class:`Minio <Minio>` object
     """
     def __init__(self, endpoint, access_key=None,
                  secret_key=None,

--- a/minio/compat.py
+++ b/minio/compat.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage,
-# (C) 2015, 2016 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage,
+# (C) 2015, 2016 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ minio.compat
 
 This module implements python 2.x and 3.x compatibility layer.
 
-:copyright: (c) 2015, 2016 by Minio, Inc.
+:copyright: (c) 2015, 2016 by MinIO, Inc.
 :license: Apache 2.0, see LICENSE for more details.
 
 """

--- a/minio/copy_conditions.py
+++ b/minio/copy_conditions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2016 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2016 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ minio.copy_conditions
 
 This module contains :class:`CopyConditions <CopyConditions>` implementation.
 
-:copyright: (c) 2016 by Minio, Inc.
+:copyright: (c) 2016 by MinIO, Inc.
 :license: Apache 2.0, see LICENSE for more details.
 
 """

--- a/minio/definitions.py
+++ b/minio/definitions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@
 minio.definitions
 ~~~~~~~~~~~~~~~
 
-This module contains the primary objects that power Minio.
+This module contains the primary objects that power MinIO.
 
-:copyright: (c) 2015 by Minio, Inc.
+:copyright: (c) 2015 by MinIO, Inc.
 :license: Apache 2.0, see LICENSE for more details.
 
 """

--- a/minio/error.py
+++ b/minio/error.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage,
-# (C) 2015, 2016, 2017 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage,
+# (C) 2015, 2016, 2017 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,10 +18,10 @@
 minio.error
 ~~~~~~~~~~~~~~~~~~~
 
-This module provides custom exception classes for Minio library
+This module provides custom exception classes for MinIO library
 and API specific errors.
 
-:copyright: (c) 2015, 2016, 2017 by Minio, Inc.
+:copyright: (c) 2015, 2016, 2017 by MinIO, Inc.
 :license: Apache 2.0, see LICENSE for more details.
 
 """

--- a/minio/fold_case_dict.py
+++ b/minio/fold_case_dict.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C)
-# 2017 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C)
+# 2017 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ minio.fold_case_dict
 
 This module implements a case insensitive dictionary.
 
-:copyright: (c) 2017 by Minio, Inc.
+:copyright: (c) 2017 by MinIO, Inc.
 :license: Apache 2.0, see LICENSE for more details.
 
 """

--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C)
-# 2015, 2016, 2017 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C)
+# 2015, 2016, 2017 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ minio.helpers
 
 This module implements all helper functions.
 
-:copyright: (c) 2015, 2016, 2017 by Minio, Inc.
+:copyright: (c) 2015, 2016, 2017 by MinIO, Inc.
 :license: Apache 2.0, see LICENSE for more details.
 
 """

--- a/minio/parsers.py
+++ b/minio/parsers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ minio.parsers
 
 This module contains core API parsers.
 
-:copyright: (c) 2015 by Minio, Inc.
+:copyright: (c) 2015 by MinIO, Inc.
 :license: Apache 2.0, see LICENSE for more details.
 
 """

--- a/minio/post_policy.py
+++ b/minio/post_policy.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C)
-# 2015, 2016 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C)
+# 2015, 2016 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ minio.post_policy
 
 This module contains :class:`PostPolicy <PostPolicy>` implementation.
 
-:copyright: (c) 2015 by Minio, Inc.
+:copyright: (c) 2015 by MinIO, Inc.
 :license: Apache 2.0, see LICENSE for more details.
 
 """

--- a/minio/signer.py
+++ b/minio/signer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ minio.signer
 
 This module implements all helpers for AWS Signature version '4' support.
 
-:copyright: (c) 2015 by Minio, Inc.
+:copyright: (c) 2015 by MinIO, Inc.
 :license: Apache 2.0, see LICENSE for more details.
 
 """

--- a/minio/sse.py
+++ b/minio/sse.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2018 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2018 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ minio.sse
 
 This module contains core API parsers.
 
-:copyright: (c) 2018 by Minio, Inc.
+:copyright: (c) 2018 by MinIO, Inc.
 :license: Apache 2.0, see LICENSE for more details.
 
 """

--- a/minio/thread_pool.py
+++ b/minio/thread_pool.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C)
-# 2017 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C)
+# 2017 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ minio.thread_pool
 This module implements a thread pool API to run several tasks
 in parallel. Tasks results can also be retrieved.
 
-:copyright: (c) 2017 by Minio, Inc.
+:copyright: (c) 2017 by MinIO, Inc.
 :license: Apache 2.0, see LICENSE for more details.
 
 """

--- a/minio/xml_marshal.py
+++ b/minio/xml_marshal.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ minio.xml_marshal
 
 This module contains the simple wrappers for XML marshaller's.
 
-:copyright: (c) 2015 by Minio, Inc.
+:copyright: (c) 2015 by MinIO, Inc.
 :license: Apache 2.0, see LICENSE for more details.
 
 """

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -54,11 +54,11 @@ tests_requires = [
 
 setup(
     name='minio',
-    description='Minio Python Library for Amazon S3 Compatible Cloud Storage for Python',
-    author='Minio, Inc.',
+    description='MinIO Python Library for Amazon S3 Compatible Cloud Storage for Python',
+    author='MinIO, Inc.',
     url='https://github.com/minio/minio-py',
     download_url='https://github.com/minio/minio-py',
-    author_email='dev@minio.io',
+    author_email='dev@min.io',
     version=version,
     package_dir={'minio': 'minio'},
     packages=packages,

--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage,
-# (C) 2015, 2016, 2017, 2018 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage,
+# (C) 2015, 2016, 2017, 2018 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -1731,14 +1731,14 @@ def main():
         access_key = os.getenv('ACCESS_KEY', 'Q3AM3UQ867SPQQA43P2F')
         secret_key = os.getenv('SECRET_KEY',
                                'zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG')
-        server_endpoint = os.getenv('SERVER_ENDPOINT', 'play.minio.io:9000')
+        server_endpoint = os.getenv('SERVER_ENDPOINT', 'play.min.io:9000')
         secure = os.getenv('ENABLE_HTTPS', '1') == '1'
-        if server_endpoint == 'play.minio.io:9000':
+        if server_endpoint == 'play.min.io:9000':
             access_key = 'Q3AM3UQ867SPQQA43P2F'
             secret_key = 'zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG'
             secure = True
 
-        client = Minio(server_endpoint, access_key, secret_key, secure=secure)
+        client = MinIO(server_endpoint, access_key, secret_key, secure=secure)
         # Check if we are running in the mint environment.
         data_dir = os.getenv('DATA_DIR')
         if data_dir is None:

--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -1738,7 +1738,7 @@ def main():
             secret_key = 'zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG'
             secure = True
 
-        client = MinIO(server_endpoint, access_key, secret_key, secure=secure)
+        client = Minio(server_endpoint, access_key, secret_key, secure=secure)
         # Check if we are running in the mint environment.
         data_dir = os.getenv('DATA_DIR')
         if data_dir is None:

--- a/tests/functional_test.sh
+++ b/tests/functional_test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/bucket_exist_test.py
+++ b/tests/unit/bucket_exist_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/copy_object_test.py
+++ b/tests/unit/copy_object_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage,
-# (C) 2015, 2016 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage,
+# (C) 2015, 2016 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/generate_xml_test.py
+++ b/tests/unit/generate_xml_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/get_bucket_policy_test.py
+++ b/tests/unit/get_bucket_policy_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/get_object_test.py
+++ b/tests/unit/get_object_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/get_s3_endpoint_test.py
+++ b/tests/unit/get_s3_endpoint_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/header_value_test.py
+++ b/tests/unit/header_value_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage,
-# (C) 2018 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage,
+# (C) 2018 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/list_buckets_test.py
+++ b/tests/unit/list_buckets_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/list_incomplete_uploads_test.py
+++ b/tests/unit/list_incomplete_uploads_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage,
-# (C) 2015, 2016 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage,
+# (C) 2015, 2016 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/list_objects_test.py
+++ b/tests/unit/list_objects_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage,
-# (C) 2015, 2016 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage,
+# (C) 2015, 2016 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/list_objects_v2_test.py
+++ b/tests/unit/list_objects_v2_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/list_uploaded_parts_test.py
+++ b/tests/unit/list_uploaded_parts_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage,
-# (C) 2015, 2016 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage,
+# (C) 2015, 2016 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/make_bucket_test.py
+++ b/tests/unit/make_bucket_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/minio_mocks.py
+++ b/tests/unit/minio_mocks.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage,
-# (C) 2015,2016 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage,
+# (C) 2015,2016 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/minio_test.py
+++ b/tests/unit/minio_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage,
-# (C) 2015, 2016, 2017 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage,
+# (C) 2015, 2016, 2017 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/optimal_part_test.py
+++ b/tests/unit/optimal_part_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage,
-# (C) 2015, 2016 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage,
+# (C) 2015, 2016 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/presigned_get_object_test.py
+++ b/tests/unit/presigned_get_object_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/presigned_put_object_test.py
+++ b/tests/unit/presigned_put_object_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage,
-# (C) 2015, 2016 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage,
+# (C) 2015, 2016 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/put_object_test.py
+++ b/tests/unit/put_object_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/remove_bucket_test.py
+++ b/tests/unit/remove_bucket_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/remove_object_test.py
+++ b/tests/unit/remove_object_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/tests/unit/remove_objects_test.py
+++ b/tests/unit/remove_objects_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2016 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2016 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/tests/unit/set_bucket_notification_test.py
+++ b/tests/unit/set_bucket_notification_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/sign_test.py
+++ b/tests/unit/sign_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/tests/unit/stat_object_test.py
+++ b/tests/unit/stat_object_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/tests/unit/trace_test.py
+++ b/tests/unit/trace_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Minio Python Library for Amazon S3 Compatible Cloud Storage,
-# (C) 2015, 2016 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage,
+# (C) 2015, 2016 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit_test.sh
+++ b/tests/unit_test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Minio Python Library for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.


### PR DESCRIPTION
Replace minio.io with min.io and Minio with MinIO

PR is based on https://github.com/minio/minio-py/pull/749

