### PR TITLE
use optimal part size only when client did not configure part size

### DIFF
--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -632,11 +632,15 @@ def optimal_part_info(length, part_size):
         raise InvalidArgumentError('Input content size is bigger '
                                    ' than allowed maximum of 5TiB.')
 
-    # Use floats for part size for all calculations to avoid
-    # overflows during float64 to int64 conversions.
-    part_size_float = math.ceil(length/MAX_MULTIPART_COUNT)
-    part_size_float = (math.ceil(part_size_float/part_size)
-                       * part_size)
+    # honor user configured size
+    if part_size != MIN_PART_SIZE:
+        part_size_float = float(part_size)
+    else:
+        # Use floats for part size for all calculations to avoid
+        # overflows during float64 to int64 conversions.
+        part_size_float = math.ceil(length/MAX_MULTIPART_COUNT)
+        part_size_float = (math.ceil(part_size_float/part_size)
+                        * part_size)
     # Total parts count.
     total_parts_count = int(math.ceil(length/part_size_float))
     # Part size.

--- a/tests/unit/optimal_part_test.py
+++ b/tests/unit/optimal_part_test.py
@@ -22,22 +22,40 @@ from minio.error import InvalidArgumentError
 
 class TraceTest(TestCase):
     @raises(InvalidArgumentError)
-    def test_input_size_wrong(self):
+    def test_input_size_wrong_default(self):
         optimal_part_info(MAX_MULTIPART_OBJECT_SIZE + 1, MIN_PART_SIZE)
 
-    def test_input_size_valid_maximum(self):
+    def test_configured_input_size_valid_maximum(self):
+        total_parts_count, part_size, last_part_size = optimal_part_info(MAX_MULTIPART_OBJECT_SIZE, 1024*1024*1000)
+        eq_(total_parts_count, 5243)
+        eq_(part_size, 1048576000)
+        eq_(last_part_size, 922746880)
+
+    def test_configured_input_size_valid(self):
+        total_parts_count, part_size, last_part_size = optimal_part_info(MAX_MULTIPART_OBJECT_SIZE/1024, 64*1024*1024)
+        eq_(total_parts_count, 80)
+        eq_(part_size, 67108864)
+        eq_(last_part_size, 67108864)
+
+    def test_configured_input_size_is_special_value(self):
+        total_parts_count, part_size, last_part_size = optimal_part_info(-1, 1024*1024*1000)
+        eq_(total_parts_count, 5243)
+        eq_(part_size, 1048576000)
+        eq_(last_part_size, 922746880)
+
+    def test_input_size_valid_maximum_default(self):
         total_parts_count, part_size, last_part_size = optimal_part_info(MAX_MULTIPART_OBJECT_SIZE, MIN_PART_SIZE)
         eq_(total_parts_count, 9987)
         eq_(part_size, 550502400)
         eq_(last_part_size, 241172480)
 
-    def test_input_size_valid(self):
+    def test_input_size_valid_default(self):
         total_parts_count, part_size, last_part_size = optimal_part_info(MAX_MULTIPART_OBJECT_SIZE/1024, MIN_PART_SIZE)
         eq_(total_parts_count, 1024)
         eq_(part_size, 5242880)
         eq_(last_part_size, 5242880)
 
-    def test_input_size_is_special_value(self):
+    def test_input_size_is_special_value_default(self):
         total_parts_count, part_size, last_part_size = optimal_part_info(-1, MIN_PART_SIZE)
         eq_(total_parts_count, 9987)
         eq_(part_size, 550502400)


### PR DESCRIPTION
Use optimal part size determined by SDK only when client did not configure a part size.
Currently, the code still reverts to using optimal part size even though user configured a part size in the put_object call