### PR TITLE
Validate underscores in host names successfully

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
 
 install:
   # We need wheel installed to build wheels
-  - "%PYTHON%\\python.exe -m pip install wheel faker nose"
+  - "%PYTHON%\\python.exe -m pip install wheel faker nose mock"
   - "%PYTHON%\\python.exe setup.py install"
 
 build: off

--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -53,7 +53,7 @@ DEFAULT_PART_SIZE = MIN_PART_SIZE # Currently its 5MiB
 
 _VALID_BUCKETNAME_REGEX = re.compile('^[a-z0-9][a-z0-9\\.\\-]+[a-z0-9]$')
 _ALLOWED_HOSTNAME_REGEX = re.compile(
-    '^((?!-)[A-Z\\d-]{1,63}(?<!-)\\.)*((?!-)[A-Z\\d-]{1,63}(?<!-))$',
+    '^((?!-)(?!_)[A-Z\_\\d-]{1,63}(?<!-)(?<!_)\\.)*((?!_)(?!-)[A-Z\_\\d-]{1,63}(?<!-)(?<!_))$',
     re.IGNORECASE)
 
 _EXTRACT_REGION_REGEX = re.compile('s3[.-]?(.+?).amazonaws.com')

--- a/tests/unit/get_s3_endpoint_test.py
+++ b/tests/unit/get_s3_endpoint_test.py
@@ -27,3 +27,6 @@ class GetS3Endpoint(TestCase):
     def test_is_valid_endpoint(self):
         eq_(True, is_valid_endpoint('s3.amazonaws.com'))
         eq_(True, is_valid_endpoint('s3.cn-north-1.amazonaws.com.cn'))
+        eq_(True, is_valid_endpoint('minio_server:9000'))
+        eq_(True, is_valid_endpoint('s3.server_1.amazonaws.com'))
+        


### PR DESCRIPTION
For eg, `minio_server` should be treated as valid hostnames.

Fixes #760