### PR TITLE
Add support for ISO time with and without fractional seconds.

### DIFF
--- a/minio/parsers.py
+++ b/minio/parsers.py
@@ -360,6 +360,10 @@ def _iso8601_to_localized_time(date_string):
     :param date_string: iso8601 formatted date string.
     :return: :class:`datetime.datetime`
     """
+
+    # Handle timestamps with and without fractional seconds. Some non-AWS
+    # vendors (e.g. Dell EMC ECS) are not consistent about always providing
+    # fractional seconds.
     try:
         parsed_date = datetime.strptime(date_string, '%Y-%m-%dT%H:%M:%S.%fZ')
     except ValueError:

--- a/minio/parsers.py
+++ b/minio/parsers.py
@@ -360,7 +360,10 @@ def _iso8601_to_localized_time(date_string):
     :param date_string: iso8601 formatted date string.
     :return: :class:`datetime.datetime`
     """
-    parsed_date = datetime.strptime(date_string, '%Y-%m-%dT%H:%M:%S.%fZ')
+    try:
+        parsed_date = datetime.strptime(date_string, '%Y-%m-%dT%H:%M:%S.%fZ')
+    except ValueError:
+        parsed_date = datetime.strptime(date_string, '%Y-%m-%dT%H:%M:%SZ')
     localized_time = pytz.utc.localize(parsed_date)
     return localized_time
 


### PR DESCRIPTION
Some non Amazon S3 implementations are not consistent about including fractional seconds in the timestamp. The change allows parsing of both `2019-07-10T14:23:39.231Z` and `2019-07-10T14:23:39Z`.