### PR TITLE
ObjectAccessed with Get and Head methods

### DIFF
--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -437,6 +437,9 @@ def is_valid_bucket_notification_config(notifications):
     ])
 
     NOTIFICATION_EVENTS = set([
+        's3:ObjectAccessed:*',
+        's3:ObjectAccessed:Get',
+        's3:ObjectAccessed:Head',
         's3:ReducedRedundancyLostObject',
         's3:ObjectCreated:*',
         's3:ObjectCreated:Put',


### PR DESCRIPTION
In Minio Server documentation there are such Supported Event Types:
s3:ObjectAccessed:Get
s3:ObjectAccessed:Head

Using minio-py I can't set this type of notification event, because when is_valid_bucket_notification_config(notifications) checks notifications there are no such events.

I added new events

 NOTIFICATION_EVENTS = {
        's3:ObjectAccessed:*',
        's3:ObjectAccessed:Get',
        's3:ObjectAccessed:Head',
        ...
    }
