### PR TITLE
InvalidXMLError: message: "CompleteMultipartUploadResult" XML is not parsable

### DIFF
--- a/minio/parsers.py
+++ b/minio/parsers.py
@@ -69,7 +69,7 @@ class S3Element(object):
         :return: Returns an S3Element.
         """
         try:
-            return cls(root_name, cElementTree.fromstring(data))
+            return cls(root_name, cElementTree.fromstring(data.strip()))
         except _ETREE_EXCEPTIONS as error:
             raise InvalidXMLError(
                 '"{}" XML is not parsable. Message: {}'.format(


### PR DESCRIPTION
Minio sometimes responds with newlines before the XML declaration. The `data` variable holds something like this:

`b'\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r<?xml version="1.0" encoding="UTF-8"?>\n<CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Location>https://minio-api.example.com/storage/data.csv.gz</Location><Bucket>storage</Bucket><Key>data.csv.gz</Key><ETag>7c913063d32676ebb4356e68db88db20-3</ETag></CompleteMultipartUploadResult>'`

`xml.etree` can't parse such response with error `InvalidXMLError: message: "CompleteMultipartUploadResult" XML is not parsable. Message: XML or text declaration not at start of entity: line 32, column 0`. The solution is to strip white-space characters from the response.