### PR TITLE
Fix: Missing space between words in error message

### DIFF
--- a/minio/api.py
+++ b/minio/api.py
@@ -663,13 +663,13 @@ class Minio(object):
 
             # Verify if we wrote data properly.
             if total_written < content_size:
-                msg = 'Data written {0} bytes is smaller than the' \
+                msg = 'Data written {0} bytes is smaller than the ' \
                       'specified size {1} bytes'.format(total_written,
                                                         content_size)
                 raise InvalidSizeError(msg)
 
             if total_written > content_size:
-                msg = 'Data written {0} bytes is in excess than the' \
+                msg = 'Data written {0} bytes is in excess than the ' \
                       'specified size {1} bytes'.format(total_written,
                                                         content_size)
                 raise InvalidSizeError(msg)


### PR DESCRIPTION
Improve error message.

current problem:

![image](https://user-images.githubusercontent.com/9464825/64915953-da169700-d7a5-11e9-923e-b6205d3253d4.png)
