### PR TITLE
Strip port 80/443 from host

### DIFF
--- a/minio/signer.py
+++ b/minio/signer.py
@@ -357,7 +357,13 @@ def generate_authorization_header(access_key, date, region,
     return ' '.join(auth_header)
 
 def remove_default_port(parsed_url):
-    if parsed_url.port is 80 or 443:
+    default_ports = {
+        'http': 80,
+        'https': 443
+    }
+    if any(parsed_url.scheme == scheme and parsed_url.port == port
+           for scheme, port in default_ports.items()):
+        # omit default port (i.e. 80 or 443)
         host = parsed_url.hostname
     else:
         host = parsed_url.netloc

--- a/minio/signer.py
+++ b/minio/signer.py
@@ -96,7 +96,7 @@ def presign_v4(method, url, access_key, secret_key, session_token=None,
 
     parsed_url = urlsplit(url)
     content_hash_hex = _UNSIGNED_PAYLOAD
-    host = parsed_url.netloc
+    host = remove_default_port(parsed_url)
     headers['Host'] = host
     iso8601Date = request_date.strftime("%Y%m%dT%H%M%SZ")
 
@@ -208,7 +208,7 @@ def sign_v4(method, url, region, headers=None,
         # with no payload, calculate sha256 for 0 length data.
         content_sha256 = get_sha256_hexdigest('')
 
-    host = parsed_url.netloc
+    host = remove_default_port(parsed_url)
     headers['Host'] = host
 
     date = datetime.utcnow()
@@ -355,3 +355,10 @@ def generate_authorization_header(access_key, date, region,
                    'SignedHeaders=' + signed_headers_string + ',',
                    'Signature=' + signature]
     return ' '.join(auth_header)
+
+def remove_default_port(parsed_url):
+    if parsed_url.port is 80 or 443:
+        host = parsed_url.hostname
+    else:
+        host = parsed_url.netloc
+    return host


### PR DESCRIPTION
Supplying port 80 or 443 with host (ex. `storage.googleapis.com:443`) fails in v4 signing. Remove these default ports to prevent signature matching failure.

Similar issue:
https://github.com/aws/aws-cli/issues/2883