### PR TITLE
FIX: AttributeError at error.message #801

### DIFF
--- a/minio/error.py
+++ b/minio/error.py
@@ -29,14 +29,9 @@ from xml.etree import cElementTree
 from xml.etree.cElementTree import ParseError
 
 if hasattr(cElementTree, 'ParseError'):
-    ## ParseError seems to not have .message like other
-    ## exceptions. Add dynamically new attribute carrying
-    ## value from message.
-    if not hasattr(ParseError, 'message'):
-        setattr(ParseError, 'message', ParseError.msg)
-    _ETREE_EXCEPTIONS = (ParseError, AttributeError, ValueError, TypeError)
+    ETREE_EXCEPTIONS = (ParseError, AttributeError, ValueError, TypeError)
 else:
-    _ETREE_EXCEPTIONS = (SyntaxError, AttributeError, ValueError, TypeError)
+    ETREE_EXCEPTIONS = (SyntaxError, AttributeError, ValueError, TypeError)
 
 
 class MinioError(Exception):
@@ -178,9 +173,9 @@ class ResponseError(MinioError):
             raise ValueError('response data has no body.')
         try:
             root = cElementTree.fromstring(self._response.data)
-        except _ETREE_EXCEPTIONS as error:
+        except ETREE_EXCEPTIONS as error:
             raise InvalidXMLError('"Error" XML is not parsable. '
-                                  'Message: {0}'.format(error.message))
+                                  'Message: {0}'.format(error))
         for attribute in root:
             if attribute.tag == 'Code':
                 self.code = attribute.text

--- a/minio/parsers.py
+++ b/minio/parsers.py
@@ -34,18 +34,13 @@ from datetime import datetime
 import pytz
 
 # minio specific.
-from .error import (InvalidXMLError, MultiDeleteError)
+from .error import (ETREE_EXCEPTIONS, InvalidXMLError, MultiDeleteError)
 from .compat import urldecode
 from .definitions import (Object, Bucket, IncompleteUpload,
                           UploadPart, MultipartUploadResult,
                           CopyObjectResult)
 from .xml_marshal import (NOTIFICATIONS_ARN_FIELDNAME_MAP)
 
-
-if hasattr(cElementTree, 'ParseError'):
-    _ETREE_EXCEPTIONS = (ParseError, AttributeError, ValueError, TypeError)
-else:
-    _ETREE_EXCEPTIONS = (SyntaxError, AttributeError, ValueError, TypeError)
 
 _S3_NS = {'s3' : 'http://s3.amazonaws.com/doc/2006-03-01/'}
 
@@ -70,10 +65,10 @@ class S3Element(object):
         """
         try:
             return cls(root_name, cElementTree.fromstring(data.strip()))
-        except _ETREE_EXCEPTIONS as error:
+        except ETREE_EXCEPTIONS as error:
             raise InvalidXMLError(
                 '"{}" XML is not parsable. Message: {}'.format(
-                    root_name, error.message
+                    root_name, error
                 )
             )
 
@@ -102,10 +97,10 @@ class S3Element(object):
         if strict:
             try:
                 return self.element.find('s3:{}'.format(name), _S3_NS).text
-            except _ETREE_EXCEPTIONS as error:
+            except ETREE_EXCEPTIONS as error:
                 raise InvalidXMLError(
                     ('Invalid XML provided for "{}" - erroring tag <{}>. '
-                     'Message: {}').format(self.root_name, name, error.message)
+                     'Message: {}').format(self.root_name, name, error)
                 )
         else:
             return self.element.findtext('s3:{}'.format(name), None, _S3_NS)


### PR DESCRIPTION
https://github.com/minio/minio-py/issues/801

As discussed in given issue, some Python packages do not support `message` attribute in exceptions, so it is safer to use string representation of them instead.

Please review and merge. :-)