### PR TITLE
Increment build number

### DIFF
--- a/minio/__init__.py
+++ b/minio/__init__.py
@@ -29,7 +29,7 @@ minio - MinIO Python Library for Amazon S3 Compatible Cloud Storage
 
 __title__ = 'minio-py'
 __author__ = 'MinIO, Inc.'
-__version__ = '5.0.2'
+__version__ = '5.0.3'
 __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright 2015, 2016, 2017, 2018, 2019 MinIO, Inc.'
 


### PR DESCRIPTION
Possibly, previous incomplete build has some files with the same name in the repository
causing builds to fail.