### PR TITLE
Do not need to set max-keys, max-uploads and max-parts

### DIFF
--- a/minio/api.py
+++ b/minio/api.py
@@ -924,7 +924,6 @@ class Minio(object):
 
         # Initialize query parameters.
         query = {
-            'max-keys': '1000',
             'prefix': prefix
         }
 
@@ -1218,7 +1217,6 @@ class Minio(object):
         # Initialize query parameters.
         query = {
             'uploads': '',
-            'max-uploads': '1000',
             'prefix': prefix
         }
 
@@ -1275,7 +1273,6 @@ class Minio(object):
 
         query = {
             'uploadId': upload_id,
-            'max-parts': '1000'
         }
 
         is_truncated = True

--- a/tests/unit/list_incomplete_uploads_test.py
+++ b/tests/unit/list_incomplete_uploads_test.py
@@ -45,7 +45,7 @@ class ListIncompleteUploadsTest(TestCase):
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
             MockResponse('GET',
-                         'https://localhost:9000/bucket/?max-uploads=1000&prefix=&uploads=',
+                         'https://localhost:9000/bucket/?prefix=&uploads=',
                          {'User-Agent': _DEFAULT_USER_AGENT}, 200, content=mock_data))
         client = Minio('localhost:9000')
         upload_iter = client._list_incomplete_uploads('bucket', '', True, False)
@@ -102,7 +102,7 @@ class ListIncompleteUploadsTest(TestCase):
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
             MockResponse('GET',
-                         'https://localhost:9000/bucket/?delimiter=%2F&max-uploads=1000&prefix=&uploads=',
+                         'https://localhost:9000/bucket/?delimiter=%2F&prefix=&uploads=',
                          {'User-Agent': _DEFAULT_USER_AGENT},
                          200, content=mock_data))
 
@@ -203,7 +203,7 @@ class ListIncompleteUploadsTest(TestCase):
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
             MockResponse('GET',
-                         'https://localhost:9000/bucket/?max-uploads=1000&prefix=&uploads=',
+                         'https://localhost:9000/bucket/?prefix=&uploads=',
                          {'User-Agent': _DEFAULT_USER_AGENT}, 200, content=mock_data1))
 
         client = Minio('localhost:9000')
@@ -213,7 +213,7 @@ class ListIncompleteUploadsTest(TestCase):
             mock_server.mock_add_request(MockResponse('GET',
                                                       'https://localhost:9000/bucket/?'
                                                       'key-marker=keymarker&'
-                                                      'max-uploads=1000&prefix=&'
+                                                      'prefix=&'
                                                       'upload-id-marker=uploadidmarker&uploads=',
                                                       {'User-Agent': _DEFAULT_USER_AGENT}, 200, content=mock_data2))
             uploads.append(upload)

--- a/tests/unit/list_objects_test.py
+++ b/tests/unit/list_objects_test.py
@@ -40,7 +40,7 @@ class ListObjectsTest(TestCase):
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(MockResponse('GET',
-                                                  'https://localhost:9000/bucket/?max-keys=1000&prefix=',
+                                                  'https://localhost:9000/bucket/?prefix=',
                                                   {'User-Agent': _DEFAULT_USER_AGENT}, 200, content=mock_data))
         client = Minio('localhost:9000')
         bucket_iter = client.list_objects('bucket', recursive=True)
@@ -87,7 +87,7 @@ class ListObjectsTest(TestCase):
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(MockResponse('GET',
-                                                  'https://localhost:9000/bucket/?delimiter=%2F&max-keys=1000&prefix=',
+                                                  'https://localhost:9000/bucket/?delimiter=%2F&prefix=',
                                                   {'User-Agent': _DEFAULT_USER_AGENT}, 200, content=mock_data))
         client = Minio('localhost:9000')
         bucket_iter = client.list_objects('bucket')
@@ -95,7 +95,7 @@ class ListObjectsTest(TestCase):
         for bucket in bucket_iter:
             # cause an xml exception and fail if we try retrieving again
             mock_server.mock_add_request(MockResponse('GET',
-                                                      'https://localhost:9000/bucket/?delimiter=%2F&max-keys=1000&prefix=',
+                                                      'https://localhost:9000/bucket/?delimiter=%2F&prefix=',
                                                       {'User-Agent': _DEFAULT_USER_AGENT}, 200, content=''))
             buckets.append(bucket)
 
@@ -172,13 +172,13 @@ class ListObjectsTest(TestCase):
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(MockResponse('GET',
-                                                  'https://localhost:9000/bucket/?max-keys=1000&prefix=',
+                                                  'https://localhost:9000/bucket/?prefix=',
                                                   {'User-Agent': _DEFAULT_USER_AGENT}, 200, content=mock_data1))
         client = Minio('localhost:9000')
         bucket_iter = client.list_objects('bucket', recursive=True)
         buckets = []
         for bucket in bucket_iter:
-            url = 'https://localhost:9000/bucket/?marker=marker&max-keys=1000&prefix='
+            url = 'https://localhost:9000/bucket/?marker=marker&prefix='
             mock_server.mock_add_request(MockResponse('GET', url,
                                                       {'User-Agent': _DEFAULT_USER_AGENT}, 200,
                                                       content=mock_data2))

--- a/tests/unit/list_uploaded_parts_test.py
+++ b/tests/unit/list_uploaded_parts_test.py
@@ -51,7 +51,7 @@ class ListPartsTest(TestCase):
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
             MockResponse('GET',
-                         'https://localhost:9000/bucket/key?max-parts=1000&uploadId=upload_id',
+                         'https://localhost:9000/bucket/key?uploadId=upload_id',
                          {'User-Agent': _DEFAULT_USER_AGENT}, 200, content=mock_data))
 
         client = Minio('localhost:9000')
@@ -98,7 +98,7 @@ class ListPartsTest(TestCase):
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(MockResponse('GET',
-                                                  'https://localhost:9000/bucket/key?max-parts=1000&uploadId=upload_id',
+                                                  'https://localhost:9000/bucket/key?uploadId=upload_id',
                                                   {'User-Agent': _DEFAULT_USER_AGENT}, 200,
                                                   content=mock_data))
         client = Minio('localhost:9000')
@@ -179,7 +179,7 @@ class ListPartsTest(TestCase):
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
             MockResponse('GET',
-                         'https://localhost:9000/bucket/key?max-parts=1000&uploadId=upload_id',
+                         'https://localhost:9000/bucket/key?uploadId=upload_id',
                          {'User-Agent': _DEFAULT_USER_AGENT}, 200, content=mock_data1))
 
 
@@ -190,7 +190,7 @@ class ListPartsTest(TestCase):
         for part in part_iter:
             mock_server.mock_add_request(
                 MockResponse('GET',
-                             'https://localhost:9000/bucket/key?max-parts=1000&part-number-marker=2&uploadId=upload_id',
+                             'https://localhost:9000/bucket/key?part-number-marker=2&uploadId=upload_id',
                              {'User-Agent': _DEFAULT_USER_AGENT}, 200, content=mock_data2))
             parts.append(part)
         eq_(4, len(parts))


### PR DESCRIPTION
MinIO server supports now 10k elements in the list output,
there is no reason for client to limit itself let the
default set of keys be returned and limited by server
implementation