### PR TITLE
Add support for Amazon S3 Transfer Acceleration for presigned urls

### DIFF
--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -342,7 +342,9 @@ def is_virtual_host(endpoint_url, bucket_name):
     # such buckets.
     if 'https' in parsed_url.scheme and '.' in bucket_name:
         return False
-    for host in ['s3.amazonaws.com', 'aliyuncs.com']:
+    for host in [
+        's3-accelerate.amazonaws.com', 's3.amazonaws.com', 'aliyuncs.com'
+    ]:
         if host in parsed_url.netloc:
             return True
     return False


### PR DESCRIPTION
This PR add support for Amazon S3 Transfer Acceleration.

Acceleration is enable by using `client.use_s3_accelerate(True)`. This function is a noop is the `endpoint_url` is not point to `s3.amazonaws.com`.

When presigned generators are called eg. `client.presigned_get_object` internally i am checking the following.
- if S3 Accelerate is enable using `self._enable_s3_accelerate`
- if the bucket has accelerate configured using `self.is_bucket_acclerate_configured`
If both the conditions are satisfied i switch the endpoint_url (pass to `get_target_url`) to `://s3-accelerate.amazonaws.com`