### PR TITLE
Fix detecting a valid endpoint with new Python versions

### DIFF
--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -302,7 +302,7 @@ def is_valid_endpoint(endpoint):
         if u.scheme:
             raise InvalidEndpointError('Hostname cannot have a scheme.')
 
-        hostname = u.netloc.split(':')[0]
+        hostname = u.hostname
         if hostname is None:
             raise InvalidEndpointError('Hostname cannot be empty.')
 

--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -288,10 +288,21 @@ def is_valid_endpoint(endpoint):
        otherwise.
     """
     try:
-        if urlsplit(endpoint).scheme:
+        if not '//' in endpoint:
+            # Having '//' in the beginning of the endpoint enforce
+            # urlsplit to consider the endpoint as a netloc according
+            # to this quote in docs.python.org/3/library/urllib.parse.html:
+            #    Following the syntax specifications in RFC 1808, urlparse
+            #    recognizes a netloc only if it is properly introduced by ‘//’.
+            #    Otherwise the input is presumed to be a relative URL and thus
+            #    to start with a path component.
+            endpoint = '//' + endpoint
+
+        u = urlsplit(endpoint)
+        if u.scheme:
             raise InvalidEndpointError('Hostname cannot have a scheme.')
 
-        hostname = endpoint.split(':')[0]
+        hostname = u.netloc.split(':')[0]
         if hostname is None:
             raise InvalidEndpointError('Hostname cannot be empty.')
 


### PR DESCRIPTION
Fixes #835 

In newer versions of Python, such as 3.7.6, the standard urlparse does not parse endpoint 'media:9004' as it is used to be.

```
Python 3.7.6 (default, Dec 20 2019, 22:50:33) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import urllib.parse
>>> urlsplit = urllib.parse.urlsplit
>>> urlsplit('media:9000')
SplitResult(scheme='media', netloc='', path='9000', query='', fragment='')
```

The new Python documentation states that we need to add '//' to enforce parsing media as a hostname, which is done in this PR.

