### PR TITLE
fix: relax bucket_name validation for existing buckets

### DIFF
--- a/minio/api.py
+++ b/minio/api.py
@@ -249,7 +249,7 @@ class Minio(object):
         :param object_name: Name of object to read
         :param options: Options for select object
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
         is_non_empty_string(object_name)
 
         content = xml_marshal_select(opts)
@@ -292,7 +292,7 @@ class Minio(object):
         :param bucket_name: Bucket to create on server
         :param location: Location to create bucket on
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, True)
 
         # Default region for all requests.
         region = 'us-east-1'
@@ -396,7 +396,7 @@ class Minio(object):
         :param bucket_name: To test the existence and user access.
         :return: True on success.
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
 
         try:
             self._url_open('HEAD', bucket_name=bucket_name)
@@ -413,7 +413,7 @@ class Minio(object):
 
         :param bucket_name: Bucket to remove
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
         self._url_open('DELETE', bucket_name=bucket_name)
 
         # Make sure to purge bucket_name from region cache.
@@ -425,7 +425,7 @@ class Minio(object):
 
         :param bucket_name: Bucket name.
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
 
         response = self._url_open("GET",
                                   bucket_name=bucket_name,
@@ -446,7 +446,7 @@ class Minio(object):
         """
         is_valid_policy_type(policy)
 
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
 
         headers = {
             'Content-Length': str(len(policy)),
@@ -466,7 +466,7 @@ class Minio(object):
 
         :param bucket_name: Bucket name.
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
 
         response = self._url_open(
             "GET",
@@ -483,7 +483,7 @@ class Minio(object):
         :param bucket_name: Bucket name.
         :param notifications: Notifications structure
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
         is_valid_bucket_notification_config(notifications)
 
         content = xml_marshal_bucket_notifications(notifications)
@@ -511,7 +511,7 @@ class Minio(object):
 
         :param bucket_name: Bucket name.
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
 
         content_bytes = xml_marshal_bucket_notifications({})
         headers = {
@@ -545,7 +545,7 @@ class Minio(object):
         :param events: Enables notifications for specific event types.
              of events.
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
 
         # If someone explicitly set prefix to None convert it to empty string.
         if prefix is None:
@@ -622,7 +622,7 @@ class Minio(object):
         :param file_path: Local file path to save the object.
         :param request_headers: Any additional headers to be added with GET request.
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
         is_non_empty_string(object_name)
 
         stat = self.stat_object(bucket_name, object_name, sse)
@@ -703,7 +703,7 @@ class Minio(object):
         :return: :class:`urllib3.response.HTTPResponse` object.
 
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
         is_non_empty_string(object_name)
 
         return self._get_partial_object(bucket_name,
@@ -736,7 +736,7 @@ class Minio(object):
         :return: :class:`urllib3.response.HTTPResponse` object.
 
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
         is_non_empty_string(object_name)
 
         return self._get_partial_object(bucket_name,
@@ -762,7 +762,7 @@ class Minio(object):
         :param metadata: Any user-defined metadata to be copied along with
         destination object.
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
         is_non_empty_string(object_name)
         is_non_empty_string(object_source)
 
@@ -827,7 +827,7 @@ class Minio(object):
         """
 
         is_valid_sse_object(sse)
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
         is_non_empty_string(object_name)
 
         if progress:
@@ -914,7 +914,7 @@ class Minio(object):
         :param recursive: If yes, returns all objects for a specified prefix
         :return: An iterator of objects in alphabetical order.
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
 
         # If someone explicitly set prefix to None convert it to empty string.
         if prefix is None:
@@ -990,7 +990,7 @@ class Minio(object):
         :param recursive: If yes, returns all objects for a specified prefix
         :return: An iterator of objects in alphabetical order.
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
 
         # If someone explicitly set prefix to None convert it to empty string.
         if prefix is None:
@@ -1039,7 +1039,7 @@ class Minio(object):
             is_valid_sse_c_object(sse=sse)
             headers.update(sse.marshal())
 
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
         is_non_empty_string(object_name)
 
         response = self._url_open('HEAD', bucket_name=bucket_name,
@@ -1069,7 +1069,7 @@ class Minio(object):
         :param object_name: Name of object to remove
         :return: None
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
         is_non_empty_string(object_name)
 
         # No reason to store successful response, for errors
@@ -1115,7 +1115,7 @@ class Minio(object):
         object that had a delete error.
 
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
         if isinstance(objects_iter, basestring):
             raise TypeError(
                 'objects_iter cannot be `str` or `bytes` instance. It must be '
@@ -1194,7 +1194,7 @@ class Minio(object):
            a specified prefix.
         :return: An generator of incomplete uploads in alphabetical order.
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
 
         return self._list_incomplete_uploads(bucket_name, prefix, recursive)
 
@@ -1208,7 +1208,7 @@ class Minio(object):
         :param recursive: If yes, returns all incomplete objects for a specified prefix.
         :return: An generator of incomplete uploads in alphabetical order.
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
 
         # If someone explicitly set prefix to None convert it to empty string.
         if prefix is None:
@@ -1267,7 +1267,7 @@ class Minio(object):
         :param object_name: Object name to list parts for.
         :param upload_id: Upload id of the previously uploaded object name.
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
         is_non_empty_string(object_name)
         is_non_empty_string(upload_id)
 
@@ -1303,7 +1303,7 @@ class Minio(object):
         :param object_name: Name of object to remove incomplete uploads
         :return: None
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
         is_non_empty_string(object_name)
 
         recursive = True
@@ -1345,7 +1345,7 @@ class Minio(object):
                               current date.
         :return: Presigned put object url.
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
         is_non_empty_string(object_name)
 
         if expires.total_seconds() < 1 or \
@@ -1512,7 +1512,7 @@ class Minio(object):
 
         """
         is_valid_sse_c_object(sse=sse)
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
         is_non_empty_string(object_name)
 
         headers = {}
@@ -1550,7 +1550,7 @@ class Minio(object):
            with your object.
         :param progress: A progress object
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
         is_non_empty_string(object_name)
 
         # Accept only bytes - otherwise we need to know how to encode
@@ -1631,7 +1631,7 @@ class Minio(object):
         :param progress: A progress object
         :param part_size: Multipart part size
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
         is_non_empty_string(object_name)
         if not callable(getattr(data, 'read')):
             raise ValueError(
@@ -1741,7 +1741,7 @@ class Minio(object):
         :param metadata: Additional new metadata for the new object.
         :return: Returns an upload id.
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
         is_non_empty_string(object_name)
 
         headers = {}
@@ -1767,7 +1767,7 @@ class Minio(object):
         :param upload_id: Upload id of the active multipart request.
         :param uploaded_parts: Key, Value dictionary of uploaded parts.
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
         is_non_empty_string(object_name)
         is_non_empty_string(upload_id)
 

--- a/minio/post_policy.py
+++ b/minio/post_policy.py
@@ -88,7 +88,7 @@ class PostPolicy(object):
 
         :param bucket_name: set bucket name.
         """
-        is_valid_bucket_name(bucket_name)
+        is_valid_bucket_name(bucket_name, False)
 
         self.policies.append(('eq', '$bucket', bucket_name))
         self.form_data['bucket'] = bucket_name

--- a/tests/unit/bucket_exist_test.py
+++ b/tests/unit/bucket_exist_test.py
@@ -38,11 +38,11 @@ class BucketExists(TestCase):
     @raises(InvalidBucketError)
     def test_bucket_exists_invalid_name(self):
         client = Minio('localhost:9000')
-        client.bucket_exists('ABCD')
+        client.bucket_exists('AB*CD')
 
     @mock.patch('urllib3.PoolManager')
     @raises(ResponseError)
-    def test_bucket_exists_works(self, mock_connection):
+    def test_bucket_exists_bad_request(self, mock_connection):
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(MockResponse('HEAD',
@@ -50,7 +50,7 @@ class BucketExists(TestCase):
                                                   {'User-Agent': _DEFAULT_USER_AGENT},
                                                   400))
         client = Minio('localhost:9000')
-        result = client.bucket_exists('hello')
+        client.bucket_exists('hello')
 
     @mock.patch('urllib3.PoolManager')
     def test_bucket_exists_works(self, mock_connection):

--- a/tests/unit/minio_test.py
+++ b/tests/unit/minio_test.py
@@ -28,23 +28,23 @@ from minio.helpers import (get_target_url, is_valid_bucket_name,
 class ValidBucketName(TestCase):
     @raises(InvalidBucketError)
     def test_bucket_name(self):
-        is_valid_bucket_name('bucketName')
+        is_valid_bucket_name('bucketName=', False)
 
     @raises(InvalidBucketError)
     def test_bucket_name_invalid_characters(self):
-        is_valid_bucket_name('$$$bcuket')
+        is_valid_bucket_name('$$$bcuket', False)
 
     @raises(InvalidBucketError)
     def test_bucket_name_length(self):
-        is_valid_bucket_name('dd')
+        is_valid_bucket_name('dd', False)
 
     @raises(InvalidBucketError)
     def test_bucket_name_periods(self):
-        is_valid_bucket_name('dd..mybucket')
+        is_valid_bucket_name('dd..mybucket', False)
 
     @raises(InvalidBucketError)
     def test_bucket_name_begins_period(self):
-        is_valid_bucket_name('.ddmybucket')
+        is_valid_bucket_name('.ddmybucket', False)
 
 class GetURLTests(TestCase):
     def test_get_target_url_works(self):

--- a/tests/unit/remove_bucket_test.py
+++ b/tests/unit/remove_bucket_test.py
@@ -38,7 +38,7 @@ class RemoveBucket(TestCase):
     @raises(InvalidBucketError)
     def test_remove_bucket_invalid_name(self):
         client = Minio('localhost:9000')
-        client.remove_bucket('ABCD')
+        client.remove_bucket('AB*CD')
 
     @mock.patch('urllib3.PoolManager')
     def test_remove_bucket_works(self, mock_connection):

--- a/tests/unit/remove_object_test.py
+++ b/tests/unit/remove_object_test.py
@@ -38,7 +38,7 @@ class StatObject(TestCase):
     @raises(InvalidBucketError)
     def test_remove_bucket_invalid_name(self):
         client = Minio('localhost:9000')
-        client.remove_object('ABCD', 'world')
+        client.remove_object('AB*CD', 'world')
 
     @mock.patch('urllib3.PoolManager')
     def test_remove_object_works(self, mock_connection):

--- a/tests/unit/remove_objects_test.py
+++ b/tests/unit/remove_objects_test.py
@@ -47,7 +47,7 @@ class RemoveObjectsTest(TestCase):
     @raises(InvalidBucketError)
     def test_bucket_invalid_name(self):
         client = Minio('localhost:9000')
-        for err in client.remove_objects('ABCD', 'world'):
+        for err in client.remove_objects('AB&CD', 'world'):
             print(err)
 
     @mock.patch('urllib3.PoolManager')

--- a/tests/unit/stat_object_test.py
+++ b/tests/unit/stat_object_test.py
@@ -38,7 +38,7 @@ class StatObject(TestCase):
     @raises(InvalidBucketError)
     def test_stat_object_invalid_name(self):
         client = Minio('localhost:9000')
-        client.stat_object('ABCD', 'world')
+        client.stat_object('AB#CD', 'world')
 
     @mock.patch('urllib3.PoolManager')
     def test_stat_object_works(self, mock_connection):


### PR DESCRIPTION
Fixes #838.

To fix this issue, the implementation difference between minio-go and minio-py is needed to be addressed. 
With the fix, just like in minio-go, dev-engineers are now able to call strict or looser bucket name validation depending on the api.
Strict validation is only used for `make_bucket` api, and looser bucket name validation is used for the rest.
The relaxation accomplished with the new approach is listed below:

- Capital letters of English alphabet
- underscore character, `_`
- colon character, `:`

Now, they are also valid characters.