### PR TITLE
Update MANIFEST.in to generate a complete sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,11 @@
 include LICENSE README*
 recursive-include docs *.md
 recursive-include examples *.py
-recursive-include tests *.py *.sh
-include minio/credentials/*.sample
+recursive-include tests *.py *.sh *.crt *.key
+recursive-include minio/credentials *.empty *.sample
+
+prune .github
+prune Makefile
+prune pylintrc
+prune CONTRIBUTING.md
+prune MAINTAINERS.md


### PR DESCRIPTION
We first include all files needed to run the tests from a sdist.
Previously, I get 4 errors and 4 failures due to files not found by
tests.

We also prune files which do not seem needed when using the sdist
package.

The correctness of the update MANIFEST.in can be verify using
check-manifest.