### PR TITLE
Adds missing 'minio/credentials/*.sample' files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include LICENSE README*
 recursive-include docs *.md
 recursive-include examples *.py
 recursive-include tests *.py *.sh
+include minio/credentials/*.sample


### PR DESCRIPTION
Fixes #865 

Added the missing `minio/credentials/*.sample` files into the tarball python package generation process.
I've also tested and checked the content of the generated tarball to make sure the missing files are included.

