### PR TITLE
cElementTree has been deprecated since Python 3.3 and removed in Python 3.9

### DIFF
--- a/minio/compat.py
+++ b/minio/compat.py
@@ -61,9 +61,6 @@ if _is_py2:
 
     ## Add missing imports
     basestring = basestring
-
-    from xml.etree import cElementTree
-    from xml.etree.cElementTree import ParseError
 elif _is_py3:
     from queue import Queue
     queue = Queue
@@ -93,9 +90,6 @@ elif _is_py3:
     bytes = bytes
     range = range
     str = str
-
-    from xml.etree import ElementTree as cElementTree
-    from xml.etree.ElementTree import ParseError
 
 numeric_types = (int, long, float)
 

--- a/minio/compat.py
+++ b/minio/compat.py
@@ -61,6 +61,9 @@ if _is_py2:
 
     ## Add missing imports
     basestring = basestring
+
+    from xml.etree import cElementTree
+    from xml.etree.cElementTree import ParseError
 elif _is_py3:
     from queue import Queue
     queue = Queue
@@ -90,6 +93,9 @@ elif _is_py3:
     bytes = bytes
     range = range
     str = str
+
+    from xml.etree import ElementTree as cElementTree
+    from xml.etree.ElementTree import ParseError
 
 numeric_types = (int, long, float)
 

--- a/minio/error.py
+++ b/minio/error.py
@@ -25,8 +25,7 @@ and API specific errors.
 :license: Apache 2.0, see LICENSE for more details.
 
 """
-from xml.etree import cElementTree
-from xml.etree.cElementTree import ParseError
+from .compat import cElementTree, ParseError
 
 if hasattr(cElementTree, 'ParseError'):
     ETREE_EXCEPTIONS = (ParseError, AttributeError, ValueError, TypeError)

--- a/minio/error.py
+++ b/minio/error.py
@@ -25,10 +25,10 @@ and API specific errors.
 :license: Apache 2.0, see LICENSE for more details.
 
 """
-from xml.etree import cElementTree
-from xml.etree.cElementTree import ParseError
+from xml.etree import ElementTree
+from xml.etree.ElementTree import ParseError
 
-if hasattr(cElementTree, 'ParseError'):
+if hasattr(ElementTree, 'ParseError'):
     ETREE_EXCEPTIONS = (ParseError, AttributeError, ValueError, TypeError)
 else:
     ETREE_EXCEPTIONS = (SyntaxError, AttributeError, ValueError, TypeError)
@@ -172,7 +172,7 @@ class ResponseError(MinioError):
         if len(self._response.data) == 0:
             raise ValueError('response data has no body.')
         try:
-            root = cElementTree.fromstring(self._response.data)
+            root = ElementTree.fromstring(self._response.data)
         except ETREE_EXCEPTIONS as error:
             raise InvalidXMLError('"Error" XML is not parsable. '
                                   'Message: {0}'.format(error))

--- a/minio/error.py
+++ b/minio/error.py
@@ -25,7 +25,8 @@ and API specific errors.
 :license: Apache 2.0, see LICENSE for more details.
 
 """
-from .compat import cElementTree, ParseError
+from xml.etree import cElementTree
+from xml.etree.cElementTree import ParseError
 
 if hasattr(cElementTree, 'ParseError'):
     ETREE_EXCEPTIONS = (ParseError, AttributeError, ValueError, TypeError)

--- a/minio/parsers.py
+++ b/minio/parsers.py
@@ -25,8 +25,8 @@ This module contains core API parsers.
 """
 
 # standard.
-from xml.etree import cElementTree
-from xml.etree.cElementTree import ParseError
+from xml.etree import ElementTree
+from xml.etree.ElementTree import ParseError
 
 from datetime import datetime
 
@@ -47,7 +47,7 @@ _S3_NS = {'s3' : 'http://s3.amazonaws.com/doc/2006-03-01/'}
 
 class S3Element(object):
     """S3 aware XML parsing class. Wraps a root element name and
-    cElementTree.Element instance. Provides S3 namespace aware parsing
+    ElementTree.Element instance. Provides S3 namespace aware parsing
     functions.
 
     """
@@ -64,7 +64,7 @@ class S3Element(object):
         :return: Returns an S3Element.
         """
         try:
-            return cls(root_name, cElementTree.fromstring(data.strip()))
+            return cls(root_name, ElementTree.fromstring(data.strip()))
         except ETREE_EXCEPTIONS as error:
             raise InvalidXMLError(
                 '"{}" XML is not parsable. Message: {}'.format(

--- a/minio/parsers.py
+++ b/minio/parsers.py
@@ -25,9 +25,6 @@ This module contains core API parsers.
 """
 
 # standard.
-from xml.etree import cElementTree
-from xml.etree.cElementTree import ParseError
-
 from datetime import datetime
 
 # dependencies.
@@ -35,7 +32,7 @@ import pytz
 
 # minio specific.
 from .error import (ETREE_EXCEPTIONS, InvalidXMLError, MultiDeleteError)
-from .compat import urldecode
+from .compat import cElementTree, ParseError, urldecode
 from .definitions import (Object, Bucket, IncompleteUpload,
                           UploadPart, MultipartUploadResult,
                           CopyObjectResult)

--- a/minio/parsers.py
+++ b/minio/parsers.py
@@ -25,6 +25,9 @@ This module contains core API parsers.
 """
 
 # standard.
+from xml.etree import cElementTree
+from xml.etree.cElementTree import ParseError
+
 from datetime import datetime
 
 # dependencies.
@@ -32,7 +35,7 @@ import pytz
 
 # minio specific.
 from .error import (ETREE_EXCEPTIONS, InvalidXMLError, MultiDeleteError)
-from .compat import cElementTree, ParseError, urldecode
+from .compat import urldecode
 from .definitions import (Object, Bucket, IncompleteUpload,
                           UploadPart, MultipartUploadResult,
                           CopyObjectResult)

--- a/minio/select/reader.py
+++ b/minio/select/reader.py
@@ -31,8 +31,6 @@ import io
 import sys
 
 from binascii import crc32
-from xml.etree import cElementTree
-from xml.etree.cElementTree import ParseError
 
 from .helpers import (EVENT_RECORDS, EVENT_PROGRESS,
                       EVENT_STATS, EVENT_CONT,
@@ -41,6 +39,7 @@ from .helpers import (EVENT_RECORDS, EVENT_PROGRESS,
 
 from .helpers import (validate_crc, calculate_crc, byte_int)
 from .errors import (SelectMessageError, SelectCRCValidationError)
+from ..compat import cElementTree, ParseError
 
 def _extract_header(header_bytes):
     """

--- a/minio/select/reader.py
+++ b/minio/select/reader.py
@@ -31,6 +31,8 @@ import io
 import sys
 
 from binascii import crc32
+from xml.etree import cElementTree
+from xml.etree.cElementTree import ParseError
 
 from .helpers import (EVENT_RECORDS, EVENT_PROGRESS,
                       EVENT_STATS, EVENT_CONT,
@@ -39,7 +41,6 @@ from .helpers import (EVENT_RECORDS, EVENT_PROGRESS,
 
 from .helpers import (validate_crc, calculate_crc, byte_int)
 from .errors import (SelectMessageError, SelectCRCValidationError)
-from ..compat import cElementTree, ParseError
 
 def _extract_header(header_bytes):
     """

--- a/minio/select/reader.py
+++ b/minio/select/reader.py
@@ -31,8 +31,8 @@ import io
 import sys
 
 from binascii import crc32
-from xml.etree import cElementTree
-from xml.etree.cElementTree import ParseError
+from xml.etree import ElementTree
+from xml.etree.ElementTree import ParseError
 
 from .helpers import (EVENT_RECORDS, EVENT_PROGRESS,
                       EVENT_STATS, EVENT_CONT,
@@ -76,7 +76,7 @@ def _parse_stats(stats):
     Parses stats XML and populates the stat dict.
     """
     stat = {}
-    for attribute in cElementTree.fromstring(stats):
+    for attribute in ElementTree.fromstring(stats):
         if attribute.tag == 'BytesScanned':
             stat['BytesScanned'] = attribute.text
         elif attribute.tag == 'BytesProcessed':


### PR DESCRIPTION
Fixes #863 