### PR TITLE
add support for AssumeRole provider

### DIFF
--- a/examples/assume_role.py
+++ b/examples/assume_role.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C) 2020 MinIO, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note: YOUR-ACCESSKEYID and YOUR-SECRETACCESSKEY are
+# dummy values, please replace them with original values.
+import io
+
+from minio import Minio
+from minio.credentials.assume_role import assume_role
+
+client = Minio('localhost:9000',
+              # access_key='YOUR-ACCESSKEYID',
+              # secret_key='YOUR-SECRETACCESSKEY')
+                access_key='newuser',
+               secret_key='newuser123', region='us-east-1', secure=False)
+
+restricted_upload_policy = """{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::uploads/2020/*"
+      ],
+      "Sid": "Upload-access-to-specific-bucket-only"
+    }
+  ]
+} 
+"""
+
+
+temp_creds = assume_role(client, Policy=restricted_upload_policy)
+
+print(temp_creds)
+print(temp_creds.get().secret_key)
+
+restricted_client = Minio('localhost:9000', credentials=temp_creds, region='us-east-1', secure=False)
+
+restricted_client.put_object('uploads', '2020/testobject', io.BytesIO(b'data'), length=4)
+

--- a/examples/assume_role.py
+++ b/examples/assume_role.py
@@ -13,18 +13,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Notes:
-#  - You cannot use root user credentials to call AssumeRole.
-#  - YOUR-ACCESSKEYID and YOUR-SECRETACCESSKEY are
-#    dummy values, please replace them with original values.
+#
+# AssumeRoleProvider will call the Simple Token Service (STS) to retrieve
+# temporary credentials.
+#
+# - You can't call AssumeRole as a root user on either MinIO or AWS.
+#   For MinIO add a non-root user using the minio client `mc`:
+#
+#     mc admin user add myminio YOUR-ACCESSKEYID YOUR-SECRETACCESSKEY
+#   On AWS you will need an IAM user with the sts:AssumeRole action allowed,
+#   and a target role.
+# - The credentials will be valid for between 15 minutes and 12 hours.
+# - An access policy can be applied to the temporary credentials. The
+#   resulting permissions are the intersection of the role's existing policy
+#   and the optionally provided policy. You cannot grant more permissions than
+#   those allowed by the policy of the role that is being assumed.
+# - YOUR-ACCESSKEYID and YOUR-SECRETACCESSKEY are
+#   dummy values, please replace them with original values.
+# - To use minio with AWS, the `Minio` client that is passed to the
+#   AssumeRoleProvider must have the endpoint 'sts.amazonaws.com', and the
+#   RoleARN argument must be provided.
 
 from minio import Minio
 from minio.credentials import AssumeRoleProvider, Credentials
 
 client = Minio('localhost:9000',
                access_key='YOUR-ACCESSKEYID',
-               secret_key='YOUR-SECRETACCESSKEY',
-               region='us-east-1', secure=False)
+               secret_key='YOUR-SECRETACCESSKEY'
+               )
 
 restricted_upload_policy = """{
   "Version": "2012-10-17",
@@ -52,4 +68,4 @@ print(temp_creds.get().access_key)
 print(temp_creds.get().secret_key)
 
 # Initialize Minio client with the temporary credentials
-restricted_client = Minio('localhost:9000', credentials=temp_creds, region='us-east-1', secure=False)
+restricted_client = Minio('localhost:9000', credentials=temp_creds)

--- a/examples/assume_role.py
+++ b/examples/assume_role.py
@@ -47,6 +47,8 @@ credentials_provider = AssumeRoleProvider(client, Policy=restricted_upload_polic
 temp_creds = Credentials(provider=credentials_provider)
 
 # User can access the credentials for e.g. serialization
+print("Retrieved temporary credentials:")
+print(temp_creds.get().access_key)
 print(temp_creds.get().secret_key)
 
 # Initialize Minio client with the temporary credentials

--- a/minio/compat.py
+++ b/minio/compat.py
@@ -40,7 +40,7 @@ if _is_py2:
     from Queue import Empty
     queue_empty = Empty
 
-    from urllib import quote, unquote
+    from urllib import quote, unquote, urlencode
 
     from urlparse import urlsplit, parse_qs
 
@@ -62,8 +62,9 @@ elif _is_py3:
     from queue import Empty
     queue_empty = Empty
 
-    from urllib.parse import quote, unquote, urlsplit, parse_qs
+    from urllib.parse import quote, unquote, urlsplit, parse_qs, urlencode
     unquote = unquote  # to get rid of F401
+    urlencode = urlencode  # to get rid of F401
     urlsplit = urlsplit  # to get rid of F401
     parse_qs = parse_qs  # to get rid of F401
 

--- a/minio/credentials/__init__.py
+++ b/minio/credentials/__init__.py
@@ -1,5 +1,5 @@
 from .static import Static
-from .credentials import Credentials
+from .credentials import Credentials, Value
 from .chain import Chain
 from .aws_iam import IamEc2MetaData
 from .env_aws import EnvAWS

--- a/minio/credentials/__init__.py
+++ b/minio/credentials/__init__.py
@@ -1,6 +1,7 @@
 from .static import Static
 from .credentials import Credentials, Value
 from .chain import Chain
+from .assume_role import AssumeRoleProvider
 from .aws_iam import IamEc2MetaData
 from .env_aws import EnvAWS
 from .env_minio import EnvMinio

--- a/minio/credentials/assume_role.py
+++ b/minio/credentials/assume_role.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C)
+# 2020 MinIO, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from datetime import datetime
+from urllib.parse import urlencode
+
+from minio import ResponseError
+from minio.credentials import Credentials, Static
+
+from minio.helpers import get_sha256_hexdigest
+from minio.parsers import parse_assume_role
+from minio.signer import sign_v4
+
+# TODO work out the final api that minio-py developers want
+# class AssumeRole(Credentials):
+#     def __init__(self, mc, RoleArn=None, RoleSessionName=None, Policy=None, DurationSeconds=None):
+
+
+def assume_role(mc, RoleArn=None, RoleSessionName=None, Policy=None, DurationSeconds=None):
+    """"
+    Generate temporary credentials using AssumeRole STS API.
+
+    API documentation:
+     - https://github.com/minio/minio/blob/master/docs/sts/assume-role.md
+     - https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
+
+    :param minio_client: Minio client needed to get endpoint, and credentials for the assume role request.
+    :param RoleArn:
+    :param RoleSessionName:
+    :param Policy: Optional policy dict.
+    :param DurationSeconds: Number of seconds the assume role credentials will remain valid.
+    :return Credentials
+    """
+    region = 'us-east-1'
+    method = 'POST'
+
+    query = {
+        "Action": "AssumeRole",
+        "Version": "2011-06-15",
+        "RoleArn": "arn:xxx:xxx:xxx:xxxx" if RoleArn is None else RoleArn,
+        "RoleSessionName": "anything" if RoleSessionName is None else RoleSessionName,
+    }
+
+    # Add optional elements to the request
+    if Policy is not None:
+        query["Policy"] = Policy
+
+    if DurationSeconds is not None:
+        query["DurationSeconds"] = str(DurationSeconds)
+
+    url = mc._endpoint_url + "/"
+    content = urlencode(query)
+    headers = {
+        'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+        'User-Agent': mc._user_agent
+    }
+
+    # Create signature headers
+    content_sha256_hex = get_sha256_hexdigest(content)
+
+    signed_headers = sign_v4(method, url, region, headers,
+                             mc._credentials,
+                             content_sha256=content_sha256_hex,
+                             request_datetime=datetime.utcnow(),
+                             service='sts'
+                             )
+
+    response = mc._http.urlopen(method, url, body=content, headers=signed_headers, preload_content=True)
+
+    if response.status != 200:
+        raise ResponseError(response, method).get_exception()
+
+    # Parse the XML Response - getting the credentials as something convinient
+    # Options include a credentials.Provider similar to Static, a Credentials instance, a Values instance.
+    # For now to keep the xml parser low level I return a Values instance
+    credentials_value, expiry = parse_assume_role(response.data)
+
+    # TODO obviously don't keep this closure as the final api
+    # need to work out what the api should actually be...
+    class ExpiringProvider(Static):
+        def is_expired(self):
+            return datetime.now() > expiry
+
+    credentials_provider = ExpiringProvider(access_key=credentials_value.access_key,
+                                            secret_key=credentials_value.secret_key, token=credentials_value.session_token)
+    return Credentials(provider=credentials_provider)
+

--- a/minio/credentials/assume_role.py
+++ b/minio/credentials/assume_role.py
@@ -14,18 +14,78 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from datetime import datetime
-from urllib.parse import urlencode
 
-from minio import ResponseError
-from minio.credentials import Credentials, Static
-
+from minio.compat import urlencode
+from minio.error import ResponseError
+from minio.credentials import Credentials
 from minio.helpers import get_sha256_hexdigest
-from minio.parsers import parse_assume_role
 from minio.signer import sign_v4
 
-# TODO work out the final api that minio-py developers want
-# class AssumeRole(Credentials):
-#     def __init__(self, mc, RoleArn=None, RoleSessionName=None, Policy=None, DurationSeconds=None):
+from .credentials import Expiry, Provider
+from .parsers import parse_assume_role
+
+
+class AssumeRoleProvider(Provider):
+    region = 'us-east-1'
+    method = 'POST'
+
+    def __init__(self, mc, RoleArn=None, RoleSessionName=None, Policy=None, DurationSeconds=None):
+        self._minio_client = mc
+        self._expiry = Expiry()
+        self._DurationSeconds = DurationSeconds
+        self._RoleArn = "arn:xxx:xxx:xxx:xxxx" if RoleArn is None else RoleArn
+        self._RoleSessionName = "anything" if RoleSessionName is None else RoleSessionName
+        self._Policy = Policy
+
+        super(Provider, self).__init__()
+
+    def retrieve(self):
+
+        query = {
+            "Action": "AssumeRole",
+            "Version": "2011-06-15",
+            "RoleArn": self._RoleArn,
+            "RoleSessionName": self._RoleSessionName,
+        }
+
+        # Add optional elements to the request
+        if self._Policy is not None:
+            query["Policy"] = self._Policy
+
+        if self._DurationSeconds is not None:
+            query["DurationSeconds"] = str(self._DurationSeconds)
+
+        url = self._minio_client._endpoint_url + "/"
+        content = urlencode(query)
+        headers = {
+            'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+            'User-Agent': self._minio_client._user_agent
+        }
+
+        # Create signature headers
+        content_sha256_hex = get_sha256_hexdigest(content)
+        signed_headers = sign_v4(self.method, url, self.region, headers,
+                                 self._minio_client._credentials,
+                                 content_sha256=content_sha256_hex,
+                                 request_datetime=datetime.utcnow(),
+                                 service='sts'
+                                 )
+        response = self._minio_client._http.urlopen(self.method, url,
+                                                    body=content,
+                                                    headers=signed_headers,
+                                                    preload_content=True)
+
+        if response.status != 200:
+            raise ResponseError(response, self.method).get_exception()
+
+        # Parse the XML Response - getting the credentials as a Values instance.
+        credentials_value, expiry = parse_assume_role(response.data)
+        self._expiry.set_expiration(expiry)
+
+        return credentials_value
+
+    def is_expired(self):
+        return self._expiry.is_expired()
 
 
 def assume_role(mc, RoleArn=None, RoleSessionName=None, Policy=None, DurationSeconds=None):
@@ -37,63 +97,12 @@ def assume_role(mc, RoleArn=None, RoleSessionName=None, Policy=None, DurationSec
      - https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
 
     :param minio_client: Minio client needed to get endpoint, and credentials for the assume role request.
-    :param RoleArn:
-    :param RoleSessionName:
+    :param RoleArn: RoleArn is ignored by MinIO, but is required by boto and AWS STS.
+    :param RoleSessionName: RoleSessionName is ignored by MinIO, but is required by boto and AWS STS.
     :param Policy: Optional policy dict.
     :param DurationSeconds: Number of seconds the assume role credentials will remain valid.
     :return Credentials
     """
-    region = 'us-east-1'
-    method = 'POST'
-
-    query = {
-        "Action": "AssumeRole",
-        "Version": "2011-06-15",
-        "RoleArn": "arn:xxx:xxx:xxx:xxxx" if RoleArn is None else RoleArn,
-        "RoleSessionName": "anything" if RoleSessionName is None else RoleSessionName,
-    }
-
-    # Add optional elements to the request
-    if Policy is not None:
-        query["Policy"] = Policy
-
-    if DurationSeconds is not None:
-        query["DurationSeconds"] = str(DurationSeconds)
-
-    url = mc._endpoint_url + "/"
-    content = urlencode(query)
-    headers = {
-        'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
-        'User-Agent': mc._user_agent
-    }
-
-    # Create signature headers
-    content_sha256_hex = get_sha256_hexdigest(content)
-
-    signed_headers = sign_v4(method, url, region, headers,
-                             mc._credentials,
-                             content_sha256=content_sha256_hex,
-                             request_datetime=datetime.utcnow(),
-                             service='sts'
-                             )
-
-    response = mc._http.urlopen(method, url, body=content, headers=signed_headers, preload_content=True)
-
-    if response.status != 200:
-        raise ResponseError(response, method).get_exception()
-
-    # Parse the XML Response - getting the credentials as something convinient
-    # Options include a credentials.Provider similar to Static, a Credentials instance, a Values instance.
-    # For now to keep the xml parser low level I return a Values instance
-    credentials_value, expiry = parse_assume_role(response.data)
-
-    # TODO obviously don't keep this closure as the final api
-    # need to work out what the api should actually be...
-    class ExpiringProvider(Static):
-        def is_expired(self):
-            return datetime.now() > expiry
-
-    credentials_provider = ExpiringProvider(access_key=credentials_value.access_key,
-                                            secret_key=credentials_value.secret_key, token=credentials_value.session_token)
+    credentials_provider = AssumeRoleProvider(mc, RoleArn, RoleSessionName, Policy, DurationSeconds)
     return Credentials(provider=credentials_provider)
 

--- a/minio/credentials/assume_role.py
+++ b/minio/credentials/assume_role.py
@@ -27,6 +27,11 @@ from .parsers import parse_assume_role
 
 class AssumeRoleProvider(Provider):
     region = 'us-east-1'
+
+    # AWS STS support GET and POST requests for all actions. That is, the API does not require you to
+    # use GET for some actions and POST for others. However, GET requests are subject to the limitation
+    # size of a URL; although this limit is browser dependent, a typical limit is 2048 bytes. Therefore,
+    # for Query API requests that require larger sizes, you must use a POST request.
     method = 'POST'
 
     def __init__(self, mc, RoleArn=None, RoleSessionName=None, Policy=None, DurationSeconds=None):

--- a/minio/credentials/assume_role.py
+++ b/minio/credentials/assume_role.py
@@ -68,7 +68,7 @@ class AssumeRoleProvider(Provider):
                                  self._minio_client._credentials,
                                  content_sha256=content_sha256_hex,
                                  request_datetime=datetime.utcnow(),
-                                 service='sts'
+                                 service_name='sts'
                                  )
         response = self._minio_client._http.urlopen(self.method, url,
                                                     body=content,
@@ -86,23 +86,4 @@ class AssumeRoleProvider(Provider):
 
     def is_expired(self):
         return self._expiry.is_expired()
-
-
-def assume_role(mc, RoleArn=None, RoleSessionName=None, Policy=None, DurationSeconds=None):
-    """"
-    Generate temporary credentials using AssumeRole STS API.
-
-    API documentation:
-     - https://github.com/minio/minio/blob/master/docs/sts/assume-role.md
-     - https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
-
-    :param minio_client: Minio client needed to get endpoint, and credentials for the assume role request.
-    :param RoleArn: RoleArn is ignored by MinIO, but is required by boto and AWS STS.
-    :param RoleSessionName: RoleSessionName is ignored by MinIO, but is required by boto and AWS STS.
-    :param Policy: Optional policy dict.
-    :param DurationSeconds: Number of seconds the assume role credentials will remain valid.
-    :return Credentials
-    """
-    credentials_provider = AssumeRoleProvider(mc, RoleArn, RoleSessionName, Policy, DurationSeconds)
-    return Credentials(provider=credentials_provider)
 

--- a/minio/credentials/credentials.py
+++ b/minio/credentials/credentials.py
@@ -17,6 +17,8 @@
 from abc import ABCMeta, abstractmethod
 from datetime import datetime
 
+import pytz
+
 
 class Value(object):
     def __init__(self, access_key=None, secret_key=None, session_token=None):
@@ -47,7 +49,8 @@ class Expiry(object):
             self._expiration = self._expiration + time_delta
 
     def is_expired(self):
-        return self._expiration < datetime.now() if self._expiration else True
+        utc_now = pytz.utc.localize(datetime.now())
+        return self._expiration < utc_now if self._expiration else True
 
 
 class Credentials(object):

--- a/minio/credentials/parsers.py
+++ b/minio/credentials/parsers.py
@@ -1,3 +1,19 @@
+# -*- coding: utf-8 -*-
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage, (C)
+# 2020 MinIO, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from xml.etree import ElementTree
 
 from .credentials import Value
@@ -20,7 +36,7 @@ def parse_iam_credentials(data):
         - a :class:`~minio.credentials.Value` instance with the temporary credentials.
         - A :class:`DateTime` instance of when the credentials expire.
     """
-    expiration = _iso8601_to_utc_datetime(data['Expiration'])
+    expiration = datetime.strptime(data['Expiration'], '%Y-%m-%dT%H:%M:%SZ')
     return Value(
         access_key=data['AccessKeyId'],
         secret_key=data['SecretAccessKey'],

--- a/minio/credentials/parsers.py
+++ b/minio/credentials/parsers.py
@@ -1,0 +1,51 @@
+from xml.etree import ElementTree
+
+from .credentials import Value
+from ..helpers import _iso8601_to_utc_datetime
+
+_XML_NS = {
+    's3': 'http://s3.amazonaws.com/doc/2006-03-01/',
+    'sts': 'https://sts.amazonaws.com/doc/2011-06-15/'
+}
+
+
+def parse_iam_credentials(data):
+    """
+    Parser for IAM Instance Metadata Security Credentials.
+
+    https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+
+    :param data: Dict containing the json response.
+    :return: A 2-tuple containing:
+        - a :class:`~minio.credentials.Value` instance with the temporary credentials.
+        - A :class:`DateTime` instance of when the credentials expire.
+    """
+    expiration = _iso8601_to_utc_datetime(data['Expiration'])
+    return Value(
+        access_key=data['AccessKeyId'],
+        secret_key=data['SecretAccessKey'],
+        session_token=data['Token']
+    ), expiration
+
+
+def parse_assume_role(data):
+    """
+    Parser for assume role response.
+
+    :param data: XML response data for STS assume role as a string.
+    :return: A 2-tuple containing:
+        - a :class:`~minio.credentials.Value` instance with the temporary credentials.
+        - A :class:`DateTime` instance of when the credentials expire.
+    """
+    root = ElementTree.fromstring(data)
+    credentials_elem = root.find("sts:AssumeRoleResult", _XML_NS).find("sts:Credentials", _XML_NS)
+
+    access_key = credentials_elem.find("sts:AccessKeyId", _XML_NS).text
+    secret_key = credentials_elem.find("sts:SecretAccessKey", _XML_NS).text
+    session_token = credentials_elem.find("sts:SessionToken", _XML_NS).text
+
+    expiry_str = credentials_elem.find("sts:Expiration", _XML_NS).text
+    expiry = _iso8601_to_utc_datetime(expiry_str)
+
+    return Value(access_key, secret_key, session_token), expiry
+

--- a/minio/credentials/parsers.py
+++ b/minio/credentials/parsers.py
@@ -36,7 +36,7 @@ def parse_iam_credentials(data):
         - a :class:`~minio.credentials.Value` instance with the temporary credentials.
         - A :class:`DateTime` instance of when the credentials expire.
     """
-    expiration = datetime.strptime(data['Expiration'], '%Y-%m-%dT%H:%M:%SZ')
+    expiration = _iso8601_to_utc_datetime(data['Expiration'])
     return Value(
         access_key=data['AccessKeyId'],
         secret_key=data['SecretAccessKey'],

--- a/minio/error.py
+++ b/minio/error.py
@@ -179,15 +179,18 @@ class ResponseError(MinioError):
             raise InvalidXMLError('"Error" XML is not parsable. '
                                   'Message: {0}'.format(error))
 
+        # Deal with namespaced response from sts
+        tag_prefix = '{https://sts.amazonaws.com/doc/2011-06-15/}' if root.tag == '{https://sts.amazonaws.com/doc/2011-06-15/}ErrorResponse' else ''
+
         attrDict = {
-            'Code': 'code',
-            'BucketName': 'bucket_name',
-            'Key': 'object_name',
-            'Message': 'message',
-            'RequestId': 'request_id',
-            'HostId': 'host_id'
+            tag_prefix + 'Code': 'code',
+            tag_prefix + 'BucketName': 'bucket_name',
+            tag_prefix + 'Key': 'object_name',
+            tag_prefix + 'Message': 'message',
+            tag_prefix + 'RequestId': 'request_id',
+            tag_prefix + 'HostId': 'host_id'
         }
-        for attribute in root:
+        for attribute in root.iter():
             attr = attrDict.get(attribute.tag)
             if attr:
                 setattr(self, attr, attribute.text)

--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -42,6 +42,9 @@ import re
 import os
 import errno
 import math
+from datetime import datetime
+
+import pytz
 
 from .compat import (urlsplit, _quote, queryencode,
                      str, bytes, basestring, _is_py3, _is_py2)
@@ -755,3 +758,22 @@ def is_supported_header(key):
 # returns true if header is a storage class header
 def is_storageclass_header(key):
     return key.lower() == "x-amz-storage-class"
+
+
+def _iso8601_to_utc_datetime(date_string):
+    """
+    Convert iso8601 date string into UTC time.
+
+    :param date_string: iso8601 formatted date string.
+    :return: :class:`datetime.datetime` with timezone set to UTC
+    """
+
+    # Handle timestamps with and without fractional seconds. Some non-AWS
+    # vendors (e.g. Dell EMC ECS) are not consistent about always providing
+    # fractional seconds.
+    try:
+        parsed_date = datetime.strptime(date_string, '%Y-%m-%dT%H:%M:%S.%fZ')
+    except ValueError:
+        parsed_date = datetime.strptime(date_string, '%Y-%m-%dT%H:%M:%SZ')
+    tz_aware_datetime = pytz.utc.localize(parsed_date)
+    return tz_aware_datetime

--- a/minio/signer.py
+++ b/minio/signer.py
@@ -336,7 +336,8 @@ def generate_credential_string(access_key, date, region, service_name=_DEFAULT_S
 
 
 def generate_authorization_header(access_key, date, region,
-                                  signed_headers, signature, service_name=_DEFAULT_SERVICE_NAME):
+                                  signed_headers, signature,
+                                  service_name=_DEFAULT_SERVICE_NAME):
     """
     Generate authorization header.
 


### PR DESCRIPTION
This PR adds a `assume_role` api to mino-py allowing users to generate temporary credentials using the `AssumeRole` STS API. It has to modify how signatures are generated to allow signing requests for other services e.g., `"sts"`.

I'm assuming the functional python API should be replaced - but let me know.

Further discussion original feature request in #871.

Server side API documentation:
- https://github.com/minio/minio/blob/master/docs/sts/assume-role.md
- https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html

