### PR TITLE
Allow copy_object an optional url_encode parameter

### DIFF
--- a/minio/api.py
+++ b/minio/api.py
@@ -824,7 +824,8 @@ class Minio(object):
                                         sse=sse)
 
     def copy_object(self, bucket_name, object_name, object_source,
-                    conditions=None, source_sse=None, sse=None, metadata=None):
+                    conditions=None, source_sse=None, sse=None, metadata=None,
+                    url_encode=True):
         """
         Copy a source object on object storage server to a new object.
 
@@ -839,6 +840,8 @@ class Minio(object):
         supported CopyObject conditions.
         :param metadata: Any user-defined metadata to be copied along with
         destination object.
+        :param url_encode: A flag that defines whether or not the
+        object_source should be url encoded.
         """
         is_valid_bucket_name(bucket_name, False)
         is_non_empty_string(object_name)
@@ -864,7 +867,11 @@ class Minio(object):
             is_valid_sse_object(sse)
             headers.update(sse.marshal())
 
-        headers['X-Amz-Copy-Source'] = queryencode(object_source)
+        if url_encode:
+            headers['X-Amz-Copy-Source'] = queryencode(object_source)
+        else:
+            headers['X-Amz-Copy-Source'] = object_source
+
         response = self._url_open('PUT',
                                   bucket_name=bucket_name,
                                   object_name=object_name,


### PR DESCRIPTION
Hello,

I am currently using the minio python sdk for both a private minio instance and another s3 compatible service. Unfortunately the other service does not allow url-encoded values in the `x-amz-copy-source` http header. This pull request allows an optional flag to be included in `copy_object` that defines whether or not the value should be url encoded.

Thanks,
John