### PR TITLE
change encoding of x-amz-copy-source in copy_object

### DIFF
--- a/minio/api.py
+++ b/minio/api.py
@@ -864,10 +864,9 @@ class Minio(object):
             is_valid_sse_object(sse)
             headers.update(sse.marshal())
         
-        # Uri-encode everything but the '/' character
-        object_source = queryencode(object_source).replace('%2F', '/')
         # URI encoded, except '/' as per AWS S3 requirement
-        headers['X-Amz-Copy-Source'] = queryencode(object_source).replace('%2F', '/')
+        headers['X-Amz-Copy-Source'] = queryencode(
+            object_source).replace('%2F', '/')
 
         response = self._url_open('PUT',
                                   bucket_name=bucket_name,

--- a/minio/api.py
+++ b/minio/api.py
@@ -866,7 +866,8 @@ class Minio(object):
         
         # Uri-encode everything but the '/' character
         object_source = queryencode(object_source).replace('%2F', '/')
-        headers['X-Amz-Copy-Source'] = object_source
+        # URI encoded, except '/' as per AWS S3 requirement
+        headers['X-Amz-Copy-Source'] = queryencode(object_source).replace('%2F', '/')
 
         response = self._url_open('PUT',
                                   bucket_name=bucket_name,

--- a/minio/api.py
+++ b/minio/api.py
@@ -863,8 +863,12 @@ class Minio(object):
         if sse:
             is_valid_sse_object(sse)
             headers.update(sse.marshal())
+        
+        # Uri-encode everything but the '/' character
+        copy_src = [ queryencode(part) for part in object_source.split('/') ]
+        copy_src = '/'.join()
+        headers['X-Amz-Copy-Source'] = copy_src
 
-        headers['X-Amz-Copy-Source'] = queryencode(object_source)
         response = self._url_open('PUT',
                                   bucket_name=bucket_name,
                                   object_name=object_name,

--- a/minio/api.py
+++ b/minio/api.py
@@ -866,7 +866,7 @@ class Minio(object):
         
         # Uri-encode everything but the '/' character
         copy_src = [ queryencode(part) for part in object_source.split('/') ]
-        copy_src = '/'.join()
+        copy_src = '/'.join(copy_src)
         headers['X-Amz-Copy-Source'] = copy_src
 
         response = self._url_open('PUT',

--- a/minio/api.py
+++ b/minio/api.py
@@ -863,7 +863,6 @@ class Minio(object):
         if sse:
             is_valid_sse_object(sse)
             headers.update(sse.marshal())
-        
         # URI encoded, except '/' as per AWS S3 requirement
         headers['X-Amz-Copy-Source'] = queryencode(
             object_source).replace('%2F', '/')

--- a/minio/api.py
+++ b/minio/api.py
@@ -865,9 +865,8 @@ class Minio(object):
             headers.update(sse.marshal())
         
         # Uri-encode everything but the '/' character
-        copy_src = [ queryencode(part) for part in object_source.split('/') ]
-        copy_src = '/'.join(copy_src)
-        headers['X-Amz-Copy-Source'] = copy_src
+        object_source = queryencode(object_source).replace('%2F', '/')
+        headers['X-Amz-Copy-Source'] = object_source
 
         response = self._url_open('PUT',
                                   bucket_name=bucket_name,


### PR DESCRIPTION
Hello Minio Team,

Talked with @harshavardhana and it seems the encoding is a bit off for the minio python sdk. It seems the value of the `x-amz-copy-source` does not need to encode the individual `/` characters in a provided path.