### PR TITLE
Add object version-ID support

### DIFF
--- a/minio/definitions.py
+++ b/minio/definitions.py
@@ -56,8 +56,12 @@ class Object:
     :param metadata: Optional parameter contains all the custom metadata.
     """
 
-    def __init__(self, bucket_name, object_name, last_modified, etag, size,
-                 content_type=None, is_dir=False, metadata=None):
+    def __init__(self, bucket_name,  # pylint: disable=too-many-arguments
+                 object_name,
+                 last_modified=None, etag='',
+                 size=0, content_type=None, is_dir=False, metadata=None,
+                 version_id=None, is_latest=None, storage_class=None,
+                 owner_id=None, owner_name=None, delete_marker=False):
         self.bucket_name = bucket_name
         self.object_name = object_name
         self.last_modified = last_modified
@@ -66,18 +70,37 @@ class Object:
         self.content_type = content_type
         self.is_dir = is_dir
         self.metadata = metadata
+        self.version_id = version_id
+        self.is_latest = is_latest
+        self.storage_class = storage_class
+        self.owner_id = owner_id
+        self.owner_name = owner_name
+        self.delete_marker = delete_marker
 
     def __str__(self):
-        string_format = ("<Object: bucket_name: {0} object_name: {1}"
-                         " last_modified: {2} etag: {3} size: {4}"
-                         " content_type: {5}, is_dir: {6}, metadata: {7}>")
-        return string_format.format(self.bucket_name,
-                                    self.object_name.encode("utf-8"),
-                                    self.last_modified,
-                                    self.etag, self.size,
-                                    self.content_type,
-                                    self.is_dir,
-                                    self.metadata)
+        return (
+            "<Object: "
+            "bucket_name: {bucket_name} "
+            "object_name: {object_name} "
+            "version_id: {version_id} "
+            "last_modified: {last_modified} "
+            "etag: {etag} "
+            "size: {size} "
+            "content_type: {content_type} "
+            "is_dir: {is_dir} "
+            "metadata: {metadata} "
+            ">"
+        ).format(
+            bucket_name=self.bucket_name,
+            object_name=self.object_name.encode("utf-8"),
+            version_id=self.version_id,
+            last_modified=self.last_modified,
+            etag=self.etag,
+            size=self.size,
+            content_type=self.content_type,
+            is_dir=self.is_dir,
+            metadata=self.metadata,
+        )
 
 
 class MultipartUploadResult:

--- a/minio/xml_marshal.py
+++ b/minio/xml_marshal.py
@@ -31,6 +31,8 @@ import io
 from collections import defaultdict
 from xml.etree import ElementTree as ET
 
+from .compat import basestring
+
 _S3_NAMESPACE = 'http://s3.amazonaws.com/doc/2006-03-01/'
 
 
@@ -382,7 +384,7 @@ def _add_notification_config_to_xml(node, element_name, configs):
     return node
 
 
-def xml_marshal_delete_objects(object_names):
+def xml_marshal_delete_objects(keys):
     """
     Marshal Multi-Object Delete request body from object names.
 
@@ -397,7 +399,15 @@ def xml_marshal_delete_objects(object_names):
     SubElement(root, 'Quiet', "true")
 
     # add each object to the request.
-    for object_name in object_names:
-        SubElement(SubElement(root, 'Object'), 'Key', object_name)
+    for key in keys:
+        version_id = None
+        if not isinstance(key, basestring):
+            version_id = key[1]
+            key = key[0]
+
+        element = SubElement(root, "Object")
+        SubElement(element, "Key", key)
+        if version_id:
+            SubElement(element, "VersionId", version_id)
 
     return _get_xml_data(root)

--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -409,7 +409,7 @@ def test_fput_object_with_content_type(  # pylint: disable=invalid-name
     _test_fput_object(bucket_name, object_name, _TEST_FILE, metadata, None)
 
 
-def _validate_stat(st_obj, expected_size, expected_meta):
+def _validate_stat(st_obj, expected_size, expected_meta, version_id=None):
     """Validate stat information."""
 
     received_modification_time = st_obj.last_modified
@@ -425,6 +425,13 @@ def _validate_stat(st_obj, expected_size, expected_meta):
 
     if not received_etag:
         raise ValueError('No Etag value is returned.')
+
+    if st_obj.version_id != version_id:
+        raise ValueError(
+            "version-id mismatch. expected={0}, got={1}".format(
+                version_id, st_obj.version_id,
+            ),
+        )
 
     # content_type by default can be either application/octet-stream or
     # binary/octet-stream
@@ -769,7 +776,7 @@ def test_negative_put_object_with_path_segment(  # pylint: disable=invalid-name
         _CLIENT.remove_bucket(bucket_name)
 
 
-def test_stat_object(log_entry, sse=None):
+def _test_stat_object(log_entry, sse=None, version_check=False):
     """Test stat_object()."""
 
     if sse:
@@ -787,12 +794,21 @@ def test_stat_object(log_entry, sse=None):
         "data": "LimitedRandomReader(1 * MB)"
     }
 
+    version_id1 = None
+    version_id2 = None
+
+    _CLIENT.make_bucket(bucket_name)
     try:
-        _CLIENT.make_bucket(bucket_name)
+        if version_check:
+            _CLIENT.enable_bucket_versioning(bucket_name)
         # Put/Upload a streaming object of 1 MiB
         reader = LimitedRandomReader(length)
-        _CLIENT.put_object(bucket_name, object_name, reader, length, sse=sse)
-        _CLIENT.stat_object(bucket_name, object_name, sse=sse)
+        _, version_id1 = _CLIENT.put_object(
+            bucket_name, object_name, reader, length, sse=sse,
+        )
+        _CLIENT.stat_object(
+            bucket_name, object_name, sse=sse, version_id=version_id1,
+        )
 
         # Put/Upload a streaming object of 11 MiB
         log_entry["args"]["length"] = length = 11 * MB
@@ -803,22 +819,40 @@ def test_stat_object(log_entry, sse=None):
         log_entry["args"]["content_type"] = content_type = (
             "application/octet-stream")
         log_entry["args"]["object_name"] = object_name + "-metadata"
-        _CLIENT.put_object(bucket_name, object_name + "-metadata", reader,
-                           length, content_type, metadata, sse=sse)
+        _, version_id2 = _CLIENT.put_object(
+            bucket_name, object_name + "-metadata", reader,
+            length, content_type, metadata, sse=sse,
+        )
         # Stat on the uploaded object to check if it exists
         # Fetch saved stat metadata on a previously uploaded object with
         # metadata.
-        st_obj = _CLIENT.stat_object(bucket_name, object_name + "-metadata",
-                                     sse=sse)
+        st_obj = _CLIENT.stat_object(
+            bucket_name, object_name + "-metadata",
+            sse=sse, version_id=version_id2,
+        )
         # Verify the collected stat data.
-        _validate_stat(st_obj, length, FoldCaseDict(metadata))
+        _validate_stat(
+            st_obj, length, FoldCaseDict(metadata), version_id=version_id2,
+        )
     finally:
-        _CLIENT.remove_object(bucket_name, object_name)
-        _CLIENT.remove_object(bucket_name, object_name+'-metadata')
+        _CLIENT.remove_object(bucket_name, object_name, version_id=version_id1)
+        _CLIENT.remove_object(
+            bucket_name, object_name+'-metadata', version_id=version_id2,
+        )
         _CLIENT.remove_bucket(bucket_name)
 
 
-def test_remove_object(log_entry):
+def test_stat_object(log_entry, sse=None):
+    """Test stat_object()."""
+    _test_stat_object(log_entry, sse)
+
+
+def test_stat_object_version(log_entry, sse=None):
+    """Test stat_object() of versioned object."""
+    _test_stat_object(log_entry, sse, version_check=True)
+
+
+def _test_remove_object(log_entry, version_check=False):
     """Test remove_object()."""
 
     # Get a unique bucket_name and object_name
@@ -833,14 +867,27 @@ def test_remove_object(log_entry):
 
     _CLIENT.make_bucket(bucket_name)
     try:
-        _CLIENT.put_object(bucket_name, object_name,
-                           LimitedRandomReader(length), length)
-        _CLIENT.remove_object(bucket_name, object_name)
+        if version_check:
+            _CLIENT.enable_bucket_versioning(bucket_name)
+        _, version_id = _CLIENT.put_object(
+            bucket_name, object_name, LimitedRandomReader(length), length,
+        )
+        _CLIENT.remove_object(bucket_name, object_name, version_id=version_id)
     finally:
         _CLIENT.remove_bucket(bucket_name)
 
 
-def test_get_object(log_entry, sse=None):
+def test_remove_object(log_entry):
+    """Test remove_object()."""
+    _test_remove_object(log_entry)
+
+
+def test_remove_object_version(log_entry):
+    """Test remove_object() of versioned object."""
+    _test_remove_object(log_entry, version_check=True)
+
+
+def _test_get_object(log_entry, sse=None, version_check=False):
     """Test get_object()."""
 
     if sse:
@@ -857,21 +904,38 @@ def test_get_object(log_entry, sse=None):
     }
 
     _CLIENT.make_bucket(bucket_name)
+    version_id = None
     try:
-        _CLIENT.put_object(bucket_name, object_name,
-                           LimitedRandomReader(length), length, sse=sse)
+        if version_check:
+            _CLIENT.enable_bucket_versioning(bucket_name)
+        _, version_id = _CLIENT.put_object(
+            bucket_name, object_name, LimitedRandomReader(length),
+            length, sse=sse,
+        )
         # Get/Download a full object, iterate on response to save to disk
-        object_data = _CLIENT.get_object(bucket_name, object_name, sse=sse)
+        object_data = _CLIENT.get_object(
+            bucket_name, object_name, sse=sse, version_id=version_id,
+        )
         newfile = 'newfile جديد'
         with open(newfile, 'wb') as file_data:
             shutil.copyfileobj(object_data, file_data)
         os.remove(newfile)
     finally:
-        _CLIENT.remove_object(bucket_name, object_name)
+        _CLIENT.remove_object(bucket_name, object_name, version_id=version_id)
         _CLIENT.remove_bucket(bucket_name)
 
 
-def test_fget_object(log_entry, sse=None):
+def test_get_object(log_entry, sse=None):
+    """Test get_object()."""
+    _test_get_object(log_entry, sse)
+
+
+def test_get_object_version(log_entry, sse=None):
+    """Test get_object() for versioned object."""
+    _test_get_object(log_entry, sse, version_check=True)
+
+
+def _test_fget_object(log_entry, sse=None, version_check=False):
     """Test fget_object()."""
 
     if sse:
@@ -891,15 +955,32 @@ def test_fget_object(log_entry, sse=None):
     }
 
     _CLIENT.make_bucket(bucket_name)
+    version_id = None
     try:
-        _CLIENT.put_object(bucket_name, object_name,
-                           LimitedRandomReader(length), length, sse=sse)
+        if version_check:
+            _CLIENT.enable_bucket_versioning(bucket_name)
+        _, version_id = _CLIENT.put_object(
+            bucket_name, object_name, LimitedRandomReader(length),
+            length, sse=sse,
+        )
         # Get/Download a full object and save locally at path
-        _CLIENT.fget_object(bucket_name, object_name, tmpfile, sse=sse)
+        _CLIENT.fget_object(
+            bucket_name, object_name, tmpfile, sse=sse, version_id=version_id,
+        )
         os.remove(tmpfile)
     finally:
-        _CLIENT.remove_object(bucket_name, object_name)
+        _CLIENT.remove_object(bucket_name, object_name, version_id=version_id)
         _CLIENT.remove_bucket(bucket_name)
+
+
+def test_fget_object(log_entry, sse=None):
+    """Test fget_object()."""
+    _test_fget_object(log_entry, sse)
+
+
+def test_fget_object_version(log_entry, sse=None):
+    """Test fget_object() of versioned object."""
+    _test_fget_object(log_entry, sse, version_check=True)
 
 
 def test_get_partial_object_with_default_length(  # pylint: disable=invalid-name
@@ -983,7 +1064,7 @@ def test_get_partial_object(log_entry, sse=None):
         _CLIENT.remove_bucket(bucket_name)
 
 
-def test_list_objects(log_entry):
+def _test_list_objects(log_entry, version2=False, version_check=False):
     """Test list_objects()."""
 
     # Get a unique bucket_name and object_name
@@ -998,21 +1079,54 @@ def test_list_objects(log_entry):
     }
 
     _CLIENT.make_bucket(bucket_name)
+    version_id1 = None
+    version_id2 = None
     try:
+        if version_check:
+            _CLIENT.enable_bucket_versioning(bucket_name)
         size = 1 * KB
-        _CLIENT.put_object(bucket_name, object_name + "-1",
-                           LimitedRandomReader(size), size)
-        _CLIENT.put_object(bucket_name, object_name + "-2",
-                           LimitedRandomReader(size), size)
+        _, version_id1 = _CLIENT.put_object(
+            bucket_name, object_name + "-1", LimitedRandomReader(size), size,
+        )
+        _, version_id2 = _CLIENT.put_object(
+            bucket_name, object_name + "-2", LimitedRandomReader(size), size,
+        )
         # List all object paths in bucket.
-        objects = _CLIENT.list_objects(bucket_name, '', is_recursive)
+        if version2:
+            objects = _CLIENT.list_objects_v2(
+                bucket_name, '', is_recursive, include_version=version_check,
+            )
+        else:
+            objects = _CLIENT.list_objects(
+                bucket_name, '', is_recursive, include_version=version_check,
+            )
         for obj in objects:
             _ = (obj.bucket_name, obj.object_name, obj.last_modified,
                  obj.etag, obj.size, obj.content_type)
+            if obj.version_id not in [version_id1, version_id2]:
+                raise ValueError(
+                    "version ID mismatch. expected=any{0}, got:{1}".format(
+                        [version_id1, version_id2], obj.verion_id,
+                    )
+                )
     finally:
-        _CLIENT.remove_object(bucket_name, object_name + "-1")
-        _CLIENT.remove_object(bucket_name, object_name + "-2")
+        _CLIENT.remove_object(
+            bucket_name, object_name + "-1", version_id=version_id1,
+        )
+        _CLIENT.remove_object(
+            bucket_name, object_name + "-2", version_id=version_id2,
+        )
         _CLIENT.remove_bucket(bucket_name)
+
+
+def test_list_objects(log_entry):
+    """Test list_objects()."""
+    _test_list_objects(log_entry)
+
+
+def test_list_object_versions(log_entry):
+    """Test list_objects()."""
+    _test_list_objects(log_entry, version_check=True)
 
 
 def _test_list_objects_api(bucket_name, expected_no, *argv):
@@ -1154,34 +1268,12 @@ def test_list_objects_with_1001_files(  # pylint: disable=invalid-name
 
 def test_list_objects_v2(log_entry):
     """Test list_objects_v2()."""
+    _test_list_objects(log_entry, version2=True)
 
-    # Get a unique bucket_name and object_name
-    bucket_name = _gen_bucket_name()
-    object_name = "{0}".format(uuid4())
-    is_recursive = True
 
-    log_entry["args"] = {
-        "bucket_name": bucket_name,
-        "object_name": object_name,
-        "recursive": is_recursive,
-    }
-
-    _CLIENT.make_bucket(bucket_name)
-    try:
-        size = 1 * KB
-        _CLIENT.put_object(bucket_name, object_name + "-1",
-                           LimitedRandomReader(size), size)
-        _CLIENT.put_object(bucket_name, object_name + "-2",
-                           LimitedRandomReader(size), size)
-        # List all object paths in bucket.
-        objects = _CLIENT.list_objects_v2(bucket_name, '', is_recursive)
-        for obj in objects:
-            _ = (obj.bucket_name, obj.object_name, obj.last_modified,
-                 obj.etag, obj.size, obj.content_type)
-    finally:
-        _CLIENT.remove_object(bucket_name, object_name + "-1")
-        _CLIENT.remove_object(bucket_name, object_name + "-2")
-        _CLIENT.remove_bucket(bucket_name)
+def test_list_object_versions_v2(log_entry):
+    """Test list_objects_v2() of versioned object."""
+    _test_list_objects(log_entry, version2=True, version_check=True)
 
 
 def _create_upload_ids(bucket_name, object_name, count):
@@ -1381,6 +1473,41 @@ def test_presigned_get_object_response_headers(  # pylint: disable=invalid-name
                                 object_name).get_exception()
     finally:
         _CLIENT.remove_object(bucket_name, object_name)
+        _CLIENT.remove_bucket(bucket_name)
+
+
+def test_presigned_get_object_version(  # pylint: disable=invalid-name
+        log_entry):
+    """Test presigned_get_object() of versioned object."""
+
+    # Get a unique bucket_name and object_name
+    bucket_name = _gen_bucket_name()
+    object_name = "{0}".format(uuid4())
+
+    log_entry["args"] = {
+        "bucket_name": bucket_name,
+        "object_name": object_name,
+    }
+
+    _CLIENT.make_bucket(bucket_name)
+    version_id = None
+    try:
+        _CLIENT.enable_bucket_versioning(bucket_name)
+        size = 1 * KB
+        _, version_id = _CLIENT.put_object(
+            bucket_name, object_name, LimitedRandomReader(size), size,
+        )
+        presigned_get_object_url = _CLIENT.presigned_get_object(
+            bucket_name, object_name, version_id=version_id,
+        )
+        response = HTTP.urlopen('GET', presigned_get_object_url)
+        if response.status != 200:
+            raise ResponseError(response,
+                                'GET',
+                                bucket_name,
+                                object_name).get_exception()
+    finally:
+        _CLIENT.remove_object(bucket_name, object_name, version_id=version_id)
         _CLIENT.remove_bucket(bucket_name)
 
 
@@ -1710,7 +1837,7 @@ def test_set_bucket_policy_readwrite(  # pylint: disable=invalid-name
         _CLIENT.remove_bucket(bucket_name)
 
 
-def test_remove_objects(log_entry):
+def _test_remove_objects(log_entry, version_check=False):
     """Test remove_objects()."""
 
     # Get a unique bucket_name
@@ -1720,15 +1847,20 @@ def test_remove_objects(log_entry):
     }
 
     _CLIENT.make_bucket(bucket_name)
+    object_names = []
     try:
+        if version_check:
+            _CLIENT.enable_bucket_versioning(bucket_name)
         size = 1 * KB
-        object_names = []
         # Upload some new objects to prepare for multi-object delete test.
         for i in range(10):
             object_name = "prefix-{0}".format(i)
-            _CLIENT.put_object(bucket_name, object_name,
-                               LimitedRandomReader(size), size)
-            object_names.append(object_name)
+            _, version_id = _CLIENT.put_object(
+                bucket_name, object_name, LimitedRandomReader(size), size,
+            )
+            object_names.append(
+                (object_name, version_id) if version_check else object_name,
+            )
         log_entry["args"]["objects_iter"] = object_names
 
         # delete the objects in a single library call.
@@ -1739,6 +1871,16 @@ def test_remove_objects(log_entry):
         for err in _CLIENT.remove_objects(bucket_name, object_names):
             raise ValueError("Remove objects err: {}".format(err))
         _CLIENT.remove_bucket(bucket_name)
+
+
+def test_remove_objects(log_entry):
+    """Test remove_objects()."""
+    _test_remove_objects(log_entry)
+
+
+def test_remove_object_versions(log_entry):
+    """Test remove_objects()."""
+    _test_remove_objects(log_entry, version_check=True)
 
 
 def test_remove_bucket(log_entry):
@@ -1833,18 +1975,24 @@ def main():
             test_put_object: {"sse": ssec} if ssec else None,
             test_negative_put_object_with_path_segment: None,
             test_stat_object: {"sse": ssec} if ssec else None,
+            test_stat_object_version: {"sse": ssec} if ssec else None,
             test_get_object: {"sse": ssec} if ssec else None,
+            test_get_object_version: {"sse": ssec} if ssec else None,
             test_fget_object: {"sse": ssec} if ssec else None,
+            test_fget_object_version: {"sse": ssec} if ssec else None,
             test_get_partial_object_with_default_length: None,
             test_get_partial_object: {"sse": ssec} if ssec else None,
             test_list_objects: None,
+            test_list_object_versions: None,
             test_list_objects_with_prefix: None,
             test_list_objects_with_1001_files: None,
             test_remove_incomplete_upload: None,
             test_list_objects_v2: None,
+            test_list_object_versions_v2: None,
             test_presigned_get_object_default_expiry: None,
             test_presigned_get_object_expiry: None,
             test_presigned_get_object_response_headers: None,
+            test_presigned_get_object_version: None,
             test_presigned_put_object_default_expiry: None,
             test_presigned_put_object_expiry: None,
             test_presigned_post_policy: None,
@@ -1861,7 +2009,9 @@ def main():
             test_list_buckets: None,
             test_put_object: {"sse": ssec} if ssec else None,
             test_stat_object: {"sse": ssec} if ssec else None,
+            test_stat_object_version: {"sse": ssec} if ssec else None,
             test_get_object: {"sse": ssec} if ssec else None,
+            test_get_object_version: {"sse": ssec} if ssec else None,
             test_list_objects: None,
             test_remove_incomplete_upload: None,
             test_presigned_get_object_default_expiry: None,
@@ -1878,7 +2028,9 @@ def main():
     tests.update(
         {
             test_remove_object: None,
+            test_remove_object_version: None,
             test_remove_objects: None,
+            test_remove_object_versions: None,
             test_remove_bucket: None,
         },
     )

--- a/tests/unit/list_objects_test.py
+++ b/tests/unit/list_objects_test.py
@@ -40,10 +40,14 @@ class ListObjectsTest(TestCase):
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
-            MockResponse('GET',
-                         'https://localhost:9000/bucket/?prefix=',
-                         {'User-Agent': _DEFAULT_USER_AGENT}, 200,
-                         content=mock_data)
+            MockResponse(
+                "GET",
+                "https://localhost:9000/bucket/"
+                "?delimiter=&max-keys=1000&prefix=",
+                {"User-Agent": _DEFAULT_USER_AGENT},
+                200,
+                content=mock_data,
+            ),
         )
         client = Minio('localhost:9000')
         bucket_iter = client.list_objects('bucket', recursive=True)
@@ -89,10 +93,14 @@ class ListObjectsTest(TestCase):
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
-            MockResponse('GET',
-                         'https://localhost:9000/bucket/?delimiter=%2F&prefix=',
-                         {'User-Agent': _DEFAULT_USER_AGENT}, 200,
-                         content=mock_data)
+            MockResponse(
+                "GET",
+                "https://localhost:9000/bucket/"
+                "?delimiter=%2F&max-keys=1000&prefix=",
+                {"User-Agent": _DEFAULT_USER_AGENT},
+                200,
+                content=mock_data,
+            ),
         )
         client = Minio('localhost:9000')
         bucket_iter = client.list_objects('bucket')
@@ -100,11 +108,14 @@ class ListObjectsTest(TestCase):
         for bucket in bucket_iter:
             # cause an xml exception and fail if we try retrieving again
             mock_server.mock_add_request(
-                MockResponse('GET',
-                             'https://localhost:9000/bucket/?delimiter=%2F&'
-                             'prefix=',
-                             {'User-Agent': _DEFAULT_USER_AGENT}, 200,
-                             content='')
+                MockResponse(
+                    "GET",
+                    "https://localhost:9000/bucket/"
+                    "?delimiter=%2F&max-keys=1000&prefix=",
+                    {"User-Agent": _DEFAULT_USER_AGENT},
+                    200,
+                    content="",
+                ),
             )
             buckets.append(bucket)
 
@@ -179,20 +190,29 @@ class ListObjectsTest(TestCase):
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
-            MockResponse('GET',
-                         'https://localhost:9000/bucket/?prefix=',
-                         {'User-Agent': _DEFAULT_USER_AGENT}, 200,
-                         content=mock_data1)
+            MockResponse(
+                "GET",
+                "https://localhost:9000/bucket/"
+                "?delimiter=&max-keys=1000&prefix=",
+                {"User-Agent": _DEFAULT_USER_AGENT},
+                200,
+                content=mock_data1,
+            ),
         )
         client = Minio('localhost:9000')
         bucket_iter = client.list_objects('bucket', recursive=True)
         buckets = []
         for bucket in bucket_iter:
-            url = 'https://localhost:9000/bucket/?marker=marker&prefix='
             mock_server.mock_add_request(
-                MockResponse('GET', url,
-                             {'User-Agent': _DEFAULT_USER_AGENT}, 200,
-                             content=mock_data2))
+                MockResponse(
+                    "GET",
+                    "https://localhost:9000/bucket/"
+                    "?delimiter=&marker=marker&max-keys=1000&prefix=",
+                    {"User-Agent": _DEFAULT_USER_AGENT},
+                    200,
+                    content=mock_data2,
+                ),
+            )
             buckets.append(bucket)
 
         eq_(4, len(buckets))

--- a/tests/unit/list_objects_v2_test.py
+++ b/tests/unit/list_objects_v2_test.py
@@ -41,10 +41,13 @@ class ListObjectsV2Test(TestCase):
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
             MockResponse(
-                'GET',
-                'https://localhost:9000/bucket/?list-type=2&prefix=&'
-                'start-after=',
-                {'User-Agent': _DEFAULT_USER_AGENT}, 200, content=mock_data)
+                "GET",
+                "https://localhost:9000/bucket/?delimiter=&list-type=2"
+                "&max-keys=1000&prefix=",
+                {"User-Agent": _DEFAULT_USER_AGENT},
+                200,
+                content=mock_data,
+            ),
         )
         client = Minio('localhost:9000')
         object_iter = client.list_objects_v2('bucket', recursive=True)
@@ -82,12 +85,13 @@ class ListObjectsV2Test(TestCase):
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
             MockResponse(
-                'GET',
-                'https://localhost:9000/bucket/?delimiter=%2F&list-type=2&'
-                'prefix=&start-after=',
-                {'User-Agent': _DEFAULT_USER_AGENT}, 200,
-                content=mock_data
-            )
+                "GET",
+                "https://localhost:9000/bucket/?delimiter=%2F&list-type=2"
+                "&max-keys=1000&prefix=",
+                {"User-Agent": _DEFAULT_USER_AGENT},
+                200,
+                content=mock_data,
+            ),
         )
         client = Minio('localhost:9000')
         objects_iter = client.list_objects_v2('bucket')


### PR DESCRIPTION
Added support to below APIs
* enable_bucket_versioning()
* disable_bucket_versioning()
* fget_object()
* get_object()
* stat_object()
* remove_object()
* remove_objects()
* presigned_get_object()
* list_objects()
* list_objects_v2()