### PR TITLE
Fixed small Markdown rendering issue

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -78,6 +78,7 @@ minioClient = Minio('play.min.io',
 ```
 
 > NOTE: If there is a corporate proxy, specify a custom httpClient using *urllib3.ProxyManager* as shown below:
+
 ```py
 from minio import Minio
 from minio.error import ResponseError


### PR DESCRIPTION
	- Added empty string after the line 80 to avoid consideration of Python
	  code as part of citation block.