### PR TITLE
queue and queue_empty were removed from compat.py in minio-py 6.0

### DIFF
--- a/examples/progress.py
+++ b/examples/progress.py
@@ -25,8 +25,8 @@ This module implements a progress printer while communicating with MinIO server
 import sys
 import time
 from threading import Thread
+from queue import Queue, Empty
 
-from minio.compat import queue, queue_empty
 
 _BAR_SIZE = 20
 _KILOBYTE = 1024
@@ -67,7 +67,7 @@ class Progress(Thread):
         self.last_printed_len = 0
         self.current_size = 0
 
-        self.display_queue = queue()
+        self.display_queue = Queue()
         self.initial_time = time.time()
         self.stdout = stdout
         self.start()
@@ -89,7 +89,7 @@ class Progress(Thread):
             try:
                 # display every interval secs
                 task = self.display_queue.get(timeout=self.interval)
-            except queue_empty:
+            except Empty:
                 elapsed_time = time.time() - self.initial_time
                 if elapsed_time > displayed_time:
                     displayed_time = elapsed_time


### PR DESCRIPTION
But the imports in `examples/progress.py` were not updated -> import error. PR after fixing it in one of my projects after upgrading to 6.0.