### PR TITLE
IAMProvider accepts ECS IAM Task roles

### DIFF
--- a/tests/unit/credentials_test.py
+++ b/tests/unit/credentials_test.py
@@ -63,6 +63,15 @@ class CredsResponse(object):
         "LastUpdated": "2009-11-23T0:00:00Z"
     })
 
+class ECSCredsResponse(object):
+    status = 200
+    data = json.dumps({
+        "RoleArn": "arn:aws:iam::123456789101:role/my-ecs-role",
+        "AccessKeyId": "accessKey",
+        "SecretAccessKey": "secret",
+        "Token": "token",
+        "Expiration": "2014-12-16T01:51:37Z",
+    })
 
 class IAMProviderTest(TestCase):
     @mock.patch("urllib3.PoolManager.urlopen")
@@ -75,6 +84,16 @@ class IAMProviderTest(TestCase):
         eq_(creds.session_token, "token")
         eq_(expiry, datetime(2014, 12, 16, 1, 46, 37))
 
+class IAMProviderECSTest(TestCase):
+    @mock.patch("urllib3.PoolManager.urlopen")
+    def test_iam(self, mock_connection):
+        mock_connection.side_effect = [ECSCredsResponse()]
+        provider = IAMProvider(expiry_delta=timedelta(minutes=5), is_ecs_task=True)
+        creds, expiry = provider.retrieve()
+        eq_(creds.access_key, "accessKey")
+        eq_(creds.secret_key, "secret")
+        eq_(creds.session_token, "token")
+        eq_(expiry, datetime(2014, 12, 16, 1, 46, 37))
 
 class ChainProviderTest(TestCase):
     def test_chain_retrieve(self):


### PR DESCRIPTION
Per this issue https://github.com/minio/minio-py/issues/956

This PR adds the `is_ecs_task` arg to `IAMProvider`. When it is set to `True`, it follows a slightly different URL path to get credentials.

If you run a task on AWS ECS without a given task role, then `curl http://169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` from within the container return a `404` error, and this would be caught by the error handling already in this class.

This would also require updates to the documentation on `IAMProvider`.