### PR TITLE
Ship missing credential files in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,7 @@
 include LICENSE README*
 recursive-include docs *.md
 recursive-include examples *.py
-recursive-include tests *.py *.sh *.crt *.key
-recursive-include minio/credentials *.empty *.sample
+recursive-include tests *.py *.sh *.crt *.key *.sample *.empty
 
 prune .github
 prune Makefile


### PR DESCRIPTION
When the credential changes were merged, MANIFEST.in was not also
changed to make certain the new file paths were shipped in the build
sdist. Drop the minio/credentials line and add those globs to tests.

Fixes #961