### PR TITLE
Remove collections.abc fallback import

### DIFF
--- a/minio/copy_conditions.py
+++ b/minio/copy_conditions.py
@@ -25,10 +25,7 @@ This module contains :class:`CopyConditions <CopyConditions>` implementation.
 
 """
 
-try:
-    from collections import MutableMapping
-except ImportError:
-    from collections.abc import MutableMapping
+from collections.abc import MutableMapping
 
 from .helpers import check_non_empty_string
 


### PR DESCRIPTION
`collections.abc` has been the preferred import since Python 3.3. The oldest version presently supported by minio is Python 3.4.

This fixes a `DeprecationWarning` raised in Python 3.8.