### PR TITLE
Remove unnecessary requirement on "future"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ packages = [
 ]
 
 requires = [
-    'future;python_version<"3.0"',
     'urllib3',
     'pytz',
     'certifi',


### PR DESCRIPTION
`future` was only required for Python 2, which is not supported by minio.