### PR TITLE
Remove universal wheel setting

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[wheel]
-universal = 1


### PR DESCRIPTION
This package does not support Python 2, so it should not be marked as a "universal wheel".
See: https://packaging.python.org/guides/distributing-packages-using-setuptools/#universal-wheels

Running `setup.py wheel` will still generate a wheel, but it will not be marked as compatible with Python 2.