### PR TITLE
Fix query params type

### DIFF
--- a/minio/credentials/providers.py
+++ b/minio/credentials/providers.py
@@ -563,7 +563,7 @@ class WebIdentityClientGrantsProvider(Provider):
 
         jwt = self._jwt_provider_func()
 
-        query_params = {"Version", "2011-06-15"}
+        query_params = {"Version": "2011-06-15"}
         duration_seconds = self._get_duration_seconds(
             int(jwt.get("expires_in", "0")),
         )


### PR DESCRIPTION
I got the following error when I tried `IamAwsProvider` because there's a typo.

```
>>> from minio.credentials import IamAwsProvider
>>>
>>> cred = IamAwsProvider()
>>> cred.retrieve()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/src/minio/minio/credentials/providers.py", line 432, in retrieve
    self._credentials = provider.retrieve()
  File "/usr/local/src/minio/minio/credentials/providers.py", line 576, in retrieve
    query_params["Action"] = "AssumeRoleWithWebIdentity"
TypeError: 'set' object does not support item assignment
```