### PR TITLE
Populate available session token in presigned_url()

### DIFF
--- a/minio/api.py
+++ b/minio/api.py
@@ -1601,6 +1601,9 @@ class Minio:  # pylint: disable=too-many-public-methods
         query_params = extra_query_params or {}
         query_params.update({"versionId": version_id} if version_id else {})
         query_params.update(response_headers or {})
+        creds = self._provider.retrieve() if self._provider else None
+        if creds and creds.session_token:
+            query_params["X-Amz-Security-Token"] = creds.session_token
         url = self._base_url.build(
             method,
             region,
@@ -1609,12 +1612,12 @@ class Minio:  # pylint: disable=too-many-public-methods
             query_params=query_params,
         )
 
-        if self._provider:
+        if creds:
             url = presign_v4(
                 method,
                 url,
                 region,
-                self._provider.retrieve(),
+                creds,
                 request_date or datetime.utcnow(),
                 int(expires.total_seconds()),
             )

--- a/minio/credentials/providers.py
+++ b/minio/credentials/providers.py
@@ -563,7 +563,7 @@ class WebIdentityClientGrantsProvider(Provider):
 
         jwt = self._jwt_provider_func()
 
-        query_params = {"Version", "2011-06-15"}
+        query_params = {"Version": "2011-06-15"}
         duration_seconds = self._get_duration_seconds(
             int(jwt.get("expires_in", "0")),
         )

--- a/minio/signer.py
+++ b/minio/signer.py
@@ -30,7 +30,7 @@ import hashlib
 import hmac
 import re
 from collections import OrderedDict
-from urllib.parse import SplitResult
+from urllib.parse import SplitResult, quote
 
 from .helpers import queryencode, sha256_hash
 
@@ -264,7 +264,7 @@ def _get_presign_canonical_request_hash(  # pylint: disable=invalid-name
         signed_headers,
     )
     if token is not None:
-        query += "&X-Amz-Security-Token={0}".format(token)
+        query += "&X-Amz-Security-Token={0}".format(quote(token, safe=''))
     parts = list(url)
     parts[3] = query
     url = SplitResult(*parts)

--- a/minio/signer.py
+++ b/minio/signer.py
@@ -30,7 +30,7 @@ import hashlib
 import hmac
 import re
 from collections import OrderedDict
-from urllib.parse import SplitResult, quote
+from urllib.parse import SplitResult
 
 from .helpers import queryencode, sha256_hash
 
@@ -244,7 +244,7 @@ def sign_v4_sts(
 
 
 def _get_presign_canonical_request_hash(  # pylint: disable=invalid-name
-        method, url, access_key, scope, date, expires, token
+        method, url, access_key, scope, date, expires,
 ):
     """Get canonical request hash for presign request."""
 
@@ -263,8 +263,6 @@ def _get_presign_canonical_request_hash(  # pylint: disable=invalid-name
         expires,
         signed_headers,
     )
-    if token is not None:
-        query += "&X-Amz-Security-Token={0}".format(quote(token, safe=''))
     parts = list(url)
     parts[3] = query
     url = SplitResult(*parts)
@@ -306,14 +304,9 @@ def presign_v4(
 ):
     """Do signature V4 of given presign request."""
 
-    session_token = None
-    if hasattr(credentials, "session_token"):
-        session_token = credentials.session_token
-
     scope = _get_scope(date, region, "s3")
     canonical_request_hash, url = _get_presign_canonical_request_hash(
-        method, url, credentials.access_key,
-        scope, date, expires, session_token,
+        method, url, credentials.access_key, scope, date, expires,
     )
     string_to_sign = _get_string_to_sign(date, scope, canonical_request_hash)
     signing_key = _get_signing_key(credentials.secret_key, date, region, "s3")

--- a/minio/signer.py
+++ b/minio/signer.py
@@ -312,7 +312,8 @@ def presign_v4(
 
     scope = _get_scope(date, region, "s3")
     canonical_request_hash, url = _get_presign_canonical_request_hash(
-        method, url, credentials.access_key, scope, date, expires, session_token,
+        method, url, credentials.access_key,
+        scope, date, expires, session_token,
     )
     string_to_sign = _get_string_to_sign(date, scope, canonical_request_hash)
     signing_key = _get_signing_key(credentials.secret_key, date, region, "s3")

--- a/minio/signer.py
+++ b/minio/signer.py
@@ -244,7 +244,7 @@ def sign_v4_sts(
 
 
 def _get_presign_canonical_request_hash(  # pylint: disable=invalid-name
-        method, url, access_key, scope, date, expires,
+        method, url, access_key, scope, date, expires, token
 ):
     """Get canonical request hash for presign request."""
 
@@ -263,6 +263,8 @@ def _get_presign_canonical_request_hash(  # pylint: disable=invalid-name
         expires,
         signed_headers,
     )
+    if token is not None:
+        query += "&X-Amz-Security-Token={0}".format(token)
     parts = list(url)
     parts[3] = query
     url = SplitResult(*parts)
@@ -304,9 +306,13 @@ def presign_v4(
 ):
     """Do signature V4 of given presign request."""
 
+    session_token = None
+    if hasattr(credentials, "session_token"):
+        session_token = credentials.session_token
+
     scope = _get_scope(date, region, "s3")
     canonical_request_hash, url = _get_presign_canonical_request_hash(
-        method, url, credentials.access_key, scope, date, expires,
+        method, url, credentials.access_key, scope, date, expires, session_token,
     )
     string_to_sign = _get_string_to_sign(date, scope, canonical_request_hash)
     signing_key = _get_signing_key(credentials.secret_key, date, region, "s3")


### PR DESCRIPTION
Minio's Presigned URL didn't support an IAM role which requires a session token for a presigned URL.

I followed the code of the botocore.
https://github.com/boto/botocore/blob/30206ab9e9081c80fa68e8b2cb56296b09be6337/botocore/auth.py#L484-L492

This PR has includes the fix of #998 because it cannot test the function without it.