### PR TITLE
Add python 3.9 support in github workflow.

### DIFF
--- a/.github/workflows/pythonpackage-linux.yml
+++ b/.github/workflows/pythonpackage-linux.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pythonpackage-linux.yml
+++ b/.github/workflows/pythonpackage-linux.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
     - master
-    - test-python-3.9
 
 jobs:
   build:

--- a/.github/workflows/pythonpackage-linux.yml
+++ b/.github/workflows/pythonpackage-linux.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
     - master
+    - test-python-3.9
 
 jobs:
   build:
@@ -15,7 +16,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/pythonpackage-windows.yml
+++ b/.github/workflows/pythonpackage-windows.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pythonpackage-windows.yml
+++ b/.github/workflows/pythonpackage-windows.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
     - master
+    - test-python-3.9
 
 jobs:
   build:
@@ -15,7 +16,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         os: [windows-latest]
 
     steps:

--- a/.github/workflows/pythonpackage-windows.yml
+++ b/.github/workflows/pythonpackage-windows.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
     - master
-    - test-python-3.9
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This document assumes that you have a working [Python](https://www.python.org/do
 
 ## Minimum Requirements
 
-- Python 3.4 or higher
+- Python 3.6 or higher
 
 ## Download from pip
 

--- a/setup.py
+++ b/setup.py
@@ -72,8 +72,6 @@ setup(
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     long_description=readme,


### PR DESCRIPTION
- Add python 3.9 to tested python versions
- Use  setup-python@v2 (v1 has bug, see https://github.com/actions/setup-python/issues/154)
- Update setup.py that the library supports python 3.9