### PR TITLE
fix omitted FilterRules in get_bucket_notification response

### DIFF
--- a/minio/parsers.py
+++ b/minio/parsers.py
@@ -474,8 +474,8 @@ def _add_notifying_service_config(data, notifications, service_key,
                             'Name': xml_filter_rule.get_child_text('Name'),
                             'Value': xml_filter_rule.get_child_text('Value'),
                         }
-                        for xml_filter_rule in xml_filter_rules.findall(
-                            './S3Key/FilterRule')
+                        for s3_key_rule in xml_filter_rules.findall('S3Key')
+                        for xml_filter_rule in s3_key_rule.findall('FilterRule')
                     ]
                 }
             }

--- a/tests/unit/get_bucket_notification_test.py
+++ b/tests/unit/get_bucket_notification_test.py
@@ -27,7 +27,7 @@ from .minio_mocks import MockConnection, MockResponse
 
 class GetBucketNotificationTest(TestCase):
     @mock.patch('urllib3.PoolManager')
-    def test_notification_config_filterspec_is_valid_7(self, mock_connection):
+    def test_get_bucket_notification_parse_response(self, mock_connection):
         mock_data="""<?xml version="1.0"?>
 <NotificationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
     <QueueConfiguration>

--- a/tests/unit/get_bucket_notification_test.py
+++ b/tests/unit/get_bucket_notification_test.py
@@ -1,0 +1,80 @@
+ # -*- coding: utf-8 -*-
+# MinIO Python Library for Amazon S3 Compatible Cloud Storage,
+# (C) 2015 MinIO, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+
+from nose.tools import eq_
+
+import mock
+from minio import Minio
+from minio.api import _DEFAULT_USER_AGENT
+from minio.error import InvalidArgumentError
+
+from .minio_mocks import MockConnection, MockResponse
+
+class GetBucketNotificationTest(TestCase):
+    @mock.patch('urllib3.PoolManager')
+    def test_notification_config_filterspec_is_valid_7(self, mock_connection):
+        mock_data="""<?xml version="1.0"?>
+<NotificationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+    <QueueConfiguration>
+        <Id></Id>
+        <Filter>
+            <S3Key>
+                <FilterRule>
+                    <Name>prefix</Name>
+                    <Value>img</Value>
+                </FilterRule>
+                <FilterRule>
+                    <Name>suffix</Name>
+                    <Value>.jpg</Value>
+                </FilterRule>
+            </S3Key>
+        </Filter>
+        <Event>s3:ObjectCreated:*</Event>
+        <Queue>arn:minio:sqs::6ccc8843-d78d-49e8-84c4-3734a4af9929:webhook</Queue>
+    </QueueConfiguration>
+</NotificationConfiguration>
+"""
+        mock_server = MockConnection()
+        mock_connection.return_value = mock_server
+        mock_server.mock_add_request(
+            MockResponse(
+                'GET',
+                'https://localhost:9000/my-test-bucket/?notification=',
+                {'User-Agent': _DEFAULT_USER_AGENT}, 200,
+                content=mock_data.encode('utf-8')
+            )
+        )
+        client = Minio('localhost:9000')
+        response = client.get_bucket_notification('my-test-bucket')
+        
+        expected={
+            'QueueConfigurations': [
+                {
+                    'Id': None, 
+                    'Arn': 'arn:minio:sqs::6ccc8843-d78d-49e8-84c4-3734a4af9929:webhook', 
+                    'Events': ['s3:ObjectCreated:*'], 
+                    'Filter': [
+                        {'Key': {'FilterRules': [
+                            {'Name': 'prefix', 'Value': 'img'}, 
+                            {'Name': 'suffix', 'Value': '.jpg'}
+                        ]}}
+                    ]
+                }
+            ]
+        }
+        eq_(expected,response)


### PR DESCRIPTION
The 6.0.xx releases of minio-py do not include any filter rules in the `get_bucket_notification` response. 

This fix resolves the issues in the release branch, and adds a test case for the issue.