### PR TITLE
[WIP] refactor: Always use HTTPHeaderDict where possible while working with HTTP headers

### DIFF
--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -351,6 +351,19 @@ def normalize_headers(headers):
 
 
 def to_http_headers(source_dict=None):
+    """
+    Transforms the given argument into ``HTTPHeaderDict`` instance.
+    No transformation is made if source_dict is already an
+    instance ``HTTPHeaderDict``.
+
+    :type source_dict: Union[dict, HTTPHeaderDict, None]
+    :param source_dict: The source headers as a plain Python
+    dictionary.
+
+    :rtype: ``HTTPHeaderDict``
+    :return: The source dictionary converted to ``HTTPHeaderDict``
+    (if necessary) or a new empty HTTPHeaderDict instance
+    """
     if isinstance(source_dict, HTTPHeaderDict):
         return source_dict
 


### PR DESCRIPTION
Plain dict should not be used for such purpose, because there is a mess with header names, which are case-insensitive by nature. Assigning header values with different case (e.g. 'Content-Length' vs 'content-length') might create serious issues, which would be hard to track