### PR TITLE
Fix outdated Exception name

### DIFF
--- a/examples/bucket_exists.py
+++ b/examples/bucket_exists.py
@@ -18,7 +18,7 @@
 # dummy values, please replace them with original values.
 
 from minio import Minio
-from minio.error import ResponseError
+from minio.error import InvalidResponseError
 
 client = Minio('s3.amazonaws.com',
                access_key='YOUR-ACCESSKEYID',
@@ -26,5 +26,5 @@ client = Minio('s3.amazonaws.com',
 
 try:
     print(client.bucket_exists('my-bucketname'))
-except ResponseError as err:
+except InvalidResponseError as err:
     print(err)


### PR DESCRIPTION
ResponseError  ->  InvalidResponseError

in the Version 7.0.1  of minio  (from  conda-forge)  ResponseError is not implemented.