### PR TITLE
Convert timedelta.total_seconds() to integer in credential providers.

### DIFF
--- a/minio/credentials/providers.py
+++ b/minio/credentials/providers.py
@@ -98,11 +98,11 @@ class AssumeRoleProvider(Provider):
         query_params = {
             "Action": "AssumeRole",
             "Version": "2011-06-15",
-            "DurationSeconds": str(
+            "DurationSeconds": str(int(
                 duration_seconds
                 if duration_seconds > _DEFAULT_DURATION_SECONDS
                 else _DEFAULT_DURATION_SECONDS
-            ),
+            )),
         }
 
         if role_arn:

--- a/minio/credentials/providers.py
+++ b/minio/credentials/providers.py
@@ -37,9 +37,9 @@ from minio.xml import find, findtext
 
 from .credentials import Credentials
 
-_MIN_DURATION_SECONDS = timedelta(minutes=15).total_seconds()
-_MAX_DURATION_SECONDS = timedelta(days=7).total_seconds()
-_DEFAULT_DURATION_SECONDS = timedelta(hours=1).total_seconds()
+_MIN_DURATION_SECONDS = int(timedelta(minutes=15).total_seconds())
+_MAX_DURATION_SECONDS = int(timedelta(days=7).total_seconds())
+_DEFAULT_DURATION_SECONDS = int(timedelta(hours=1).total_seconds())
 
 
 def _parse_credentials(data, name):
@@ -98,11 +98,11 @@ class AssumeRoleProvider(Provider):
         query_params = {
             "Action": "AssumeRole",
             "Version": "2011-06-15",
-            "DurationSeconds": str(int(
+            "DurationSeconds": str(
                 duration_seconds
                 if duration_seconds > _DEFAULT_DURATION_SECONDS
                 else _DEFAULT_DURATION_SECONDS
-            )),
+            ),
         }
 
         if role_arn:


### PR DESCRIPTION
Ensure duration in seconds is an integer. 

Closes #1080