### PR TITLE
Added destructor to clear urllib3.PoolManager

### DIFF
--- a/minio/api.py
+++ b/minio/api.py
@@ -159,6 +159,9 @@ class Minio:  # pylint: disable=too-many-public-methods
             )
         )
 
+    def __del__(self):
+        self._http.clear()
+
     def _handle_redirect_response(
             self, method, bucket_name, response, retry=False,
     ):


### PR DESCRIPTION
To resolve ResourceWarnings from requests lib about unclosed SSLSockets - see psf/requests#1882.
It happens on pytest==6.2
pytest.PytestUnraisableExceptionWarning: Exception ignored in: <ssl.SSLSocket fd=-1, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>

ResourceWarning: unclosed <ssl.SSLSocket fd=7, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('172.28.0.10', 44592),>