### PR TITLE
Bucket: add string representation and equality method

### DIFF
--- a/minio/datatypes.py
+++ b/minio/datatypes.py
@@ -60,7 +60,7 @@ class Bucket:
     def __eq__(self, other):
         if isinstance(other, Bucket):
             return self.name == other.name
-        elif isinstance(other, str):
+        if isinstance(other, str):
             return self.name == other
         return NotImplemented
 

--- a/minio/datatypes.py
+++ b/minio/datatypes.py
@@ -51,6 +51,19 @@ class Bucket:
         """Get creation date."""
         return self._creation_date
 
+    def __repr__(self):
+        return "{}({!r})".format(type(self).__name__, self.name)
+
+    def __str__(self):
+        return self.name
+
+    def __eq__(self, other):
+        if isinstance(other, Bucket):
+            return self.name == other.name
+        elif isinstance(other, str):
+            return self.name == other
+        return NotImplemented
+
 
 class ListAllMyBucketsResult:
     """LissBuckets API result."""

--- a/minio/datatypes.py
+++ b/minio/datatypes.py
@@ -64,6 +64,9 @@ class Bucket:
             return self.name == other
         return NotImplemented
 
+    def __hash__(self):
+        return hash(self.name)
+
 
 class ListAllMyBucketsResult:
     """LissBuckets API result."""


### PR DESCRIPTION
Hello there,

I added these changes for multiple reasons,

* First of all, when I'm dealing with buckets they lack string representation which is handly some use cases:
```python
In [4]: client.list_buckets()
Out[4]: 
[<minio.datatypes.Bucket at 0x7f15f097dc70>,
 <minio.datatypes.Bucket at 0x7f15eaae73d0>]

In [5]: # It could have been something like this:
Out[5]: [Bucket('a'), Bucket('b')]
# or this scenario:

In [6]: for b in client.list_buckets():
   ...:     print(b)
   ...: 
<minio.datatypes.Bucket object at 0x7f15eb4c4cd0>
<minio.datatypes.Bucket object at 0x7f15eaedda00>
# Instead:
In [7]: for b in client.list_buckets():
    ...:     print(b)
    ...: 
a
b
```
But more importantly, I wanted to check if a specific bucket exists inside a list of buckets, I know I can use `bucket_exists` method, but it's good to have an equality method for bucket object:

```python
In [7]: 'a' in client.list_buckets()
Out[7]: False
In [8]: 'a' in client.list_buckets() # when you have __eq__ method for bucket obj
Out[8]: True

