### PR TITLE
Handle empty stdout properly in MinioAdmin

### DIFF
--- a/minio/minioadmin.py
+++ b/minio/minioadmin.py
@@ -48,9 +48,12 @@ class MinioAdmin:
             capture_output=True,
             timeout=self._timeout,
             check=True,
+            text=True,
         )
+        if not proc.stdout:
+            return [] if multiline else {}
         if multiline:
-            return [json.loads(line) for line in proc.stdout.split("\n")]
+            return [json.loads(line) for line in proc.stdout.splitlines()]
         return json.loads(proc.stdout)
 
     def service_restart(self):


### PR DESCRIPTION
`json.loads(line)` would throw an error if line is empty (e.g. `line == b''`).
To fix it, simply check if line is truthy (i.e. not empty).

Also, since `proc.stdout` is of type `bytes` the argument passed to
`proc.stdout.split` was changed to `b"\n"`.