### PR TITLE
docs: add anchor for `get_presigned_url` method in API docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1785,6 +1785,8 @@ policy.add_content_length_range_condition(
 form_data = client.presigned_post_policy(policy)
 ```
 
+<a name="get_presigned_url"></a>
+
 ### get_presigned_url(method, bucket_name, object_name, expires=timedelta(days=7), response_headers=None, request_date=None, version_id=None, extra_query_params=None)
 
 Get presigned URL of an object for HTTP method, expiry time and custom request parameters.


### PR DESCRIPTION
I noticed in [reference docs](https://docs.min.io/docs/python-client-api-reference.html) I couldn't jump to `get_presigned_url` method by clicking on it because it was missing an anchor tag