### PR TITLE
fix: pylint build issues in minio-py

### DIFF
--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -127,8 +127,7 @@ def _get_part_info(object_size, part_size):
         return part_size, -1
 
     if part_size > 0:
-        if part_size > object_size:
-            part_size = object_size
+        part_size = min(part_size, object_size)
         return part_size, math.ceil(object_size / part_size) if part_size else 1
 
     part_size = math.ceil(
@@ -322,7 +321,7 @@ def _metadata_to_headers(metadata):
 
 def normalize_headers(headers):
     """Normalize headers by prefixing 'X-Amz-Meta-' for user metadata."""
-    headers = headers.copy() if headers else {}
+    headers = {str(key): value for key, value in (headers or {}).items()}
 
     def guess_user_metadata(key):
         key = key.lower()
@@ -699,7 +698,7 @@ class ThreadPool:
         the caller also prevents the latter from allocating a lot of
         memory while workers are still busy running their assigned tasks.
         """
-        self._sem.acquire()
+        self._sem.acquire()  # pylint: disable=consider-using-with
         cleanup_func = self._sem.release
         self._tasks_queue.put((func, args, kargs, cleanup_func))
 

--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -466,8 +466,11 @@ def test_copy_object_with_metadata(log_entry):
     object_name = "{0}".format(uuid4())
     object_source = object_name + "-source"
     object_copy = object_name + "-copy"
-    metadata = {"testing-string": "string",
-                "testing-int": 1}
+    metadata = {
+        "testing-string": "string",
+        "testing-int": 1,
+        10: 'value',
+    }
 
     log_entry["args"] = {
         "bucket_name": bucket_name,
@@ -490,7 +493,8 @@ def test_copy_object_with_metadata(log_entry):
         # Verification
         st_obj = _CLIENT.stat_object(bucket_name, object_copy)
         expected_metadata = {'x-amz-meta-testing-int': '1',
-                             'x-amz-meta-testing-string': 'string'}
+                             'x-amz-meta-testing-string': 'string',
+                             'x-amz-meta-10': 'value'}
         _validate_stat(st_obj, size, expected_metadata)
     finally:
         _CLIENT.remove_object(bucket_name, object_source)


### PR DESCRIPTION
Bonus: also stringify the `key` for
additional metadata, otherwise key's with
numeric names might fail with key ValueError.