### PR TITLE
fix: canonical request path if empty choose '/'

### DIFF
--- a/minio/credentials/providers.py
+++ b/minio/credentials/providers.py
@@ -115,6 +115,7 @@ class AssumeRoleProvider(Provider):
         self._body = urlencode(query_params)
         self._content_sha256 = sha256_hash(self._body)
         url = urlsplit(sts_endpoint)
+        self._url = url
         self._host = url.netloc
         if (
                 (url.scheme == "http" and url.port == 80) or
@@ -131,7 +132,7 @@ class AssumeRoleProvider(Provider):
         utctime = utcnow()
         headers = sign_v4_sts(
             "POST",
-            urlsplit(self._sts_endpoint),
+            self._url,
             self._region,
             {
                 "Content-Type": "application/x-www-form-urlencoded",

--- a/minio/signer.py
+++ b/minio/signer.py
@@ -58,8 +58,8 @@ def _get_canonical_headers(headers):
     for key, values in headers.items():
         key = key.lower()
         if key not in (
-                "authorization", "content-type",
-                "content-length", "user-agent",
+                "authorization",
+                "user-agent",
         ):
             values = values if isinstance(values, (list, tuple)) else [values]
             canonical_headers[key] = ",".join([
@@ -101,7 +101,7 @@ def _get_canonical_request_hash(method, url, headers, content_sha256):
     #   HexEncode(Hash(RequestPayload))
     canonical_request = (
         f"{method}\n"
-        f"{url.path}\n"
+        f"{url.path or '/'}\n"
         f"{canonical_query_string}\n"
         f"{canonical_headers}\n\n"
         f"{signed_headers}\n"
@@ -248,7 +248,7 @@ def _get_presign_canonical_request_hash(  # pylint: disable=invalid-name
     #   HexEncode(Hash(RequestPayload))
     canonical_request = (
         f"{method}\n"
-        f"{url.path}\n"
+        f"{url.path or '/'}\n"
         f"{canonical_query_string}\n"
         f"{canonical_headers}\n\n"
         f"{signed_headers}\n"


### PR DESCRIPTION
additionally this PR allows content-type and
content-length to be part of signed headers as
this is allowed in signature v4.