### PR TITLE
fix EnvAWSProvider/EnvMinioProvider to fetch access/secret keys and session token always from os.environ

### DIFF
--- a/minio/credentials/providers.py
+++ b/minio/credentials/providers.py
@@ -195,38 +195,29 @@ class ChainedProvider(Provider):
 class EnvAWSProvider(Provider):
     """Credential provider from AWS environment variables."""
 
-    def __init__(self):
-        self._access_key = (
-            os.environ.get("AWS_ACCESS_KEY_ID") or
-            os.environ.get("AWS_ACCESS_KEY")
-        )
-        self._secret_key = (
-            os.environ.get("AWS_SECRET_ACCESS_KEY") or
-            os.environ.get("AWS_SECRET_KEY")
-        )
-        self._session_token = os.environ.get("AWS_SESSION_TOKEN")
-
     def retrieve(self):
         """Retrieve credentials."""
         return Credentials(
-            access_key=self._access_key,
-            secret_key=self._secret_key,
-            session_token=self._session_token,
+            access_key=(
+                os.environ.get("AWS_ACCESS_KEY_ID") or
+                os.environ.get("AWS_ACCESS_KEY")
+            ),
+            secret_key=(
+                os.environ.get("AWS_SECRET_ACCESS_KEY") or
+                os.environ.get("AWS_SECRET_KEY")
+            ),
+            session_token=os.environ.get("AWS_SESSION_TOKEN"),
         )
 
 
 class EnvMinioProvider(Provider):
     """Credential provider from MinIO environment variables."""
 
-    def __init__(self):
-        self._access_key = os.environ.get("MINIO_ACCESS_KEY")
-        self._secret_key = os.environ.get("MINIO_SECRET_KEY")
-
     def retrieve(self):
         """Retrieve credentials."""
         return Credentials(
-            access_key=self._access_key,
-            secret_key=self._secret_key,
+            access_key=os.environ.get("MINIO_ACCESS_KEY"),
+            secret_key=os.environ.get("MINIO_SECRET_KEY"),
         )
 
 
@@ -474,17 +465,11 @@ class StaticProvider(Provider):
     """Fixed credential provider."""
 
     def __init__(self, access_key, secret_key, session_token=None):
-        self._access_key = access_key
-        self._secret_key = secret_key
-        self._session_token = session_token
+        self._credentials = Credentials(access_key, secret_key, session_token)
 
     def retrieve(self):
         """Return passed credentials."""
-        return Credentials(
-            access_key=self._access_key,
-            secret_key=self._secret_key,
-            session_token=self._session_token,
-        )
+        return self._credentials
 
 
 class WebIdentityClientGrantsProvider(Provider):

--- a/minio/credentials/providers.py
+++ b/minio/credentials/providers.py
@@ -196,37 +196,38 @@ class EnvAWSProvider(Provider):
     """Credential provider from AWS environment variables."""
 
     def __init__(self):
-        access_key = (
+        self._access_key = (
             os.environ.get("AWS_ACCESS_KEY_ID") or
             os.environ.get("AWS_ACCESS_KEY")
         )
-        secret_key = (
+        self._secret_key = (
             os.environ.get("AWS_SECRET_ACCESS_KEY") or
             os.environ.get("AWS_SECRET_KEY")
         )
-        self._credentials = Credentials(
-            access_key,
-            secret_key,
-            session_token=os.environ.get("AWS_SESSION_TOKEN"),
-        )
+        self._session_token = os.environ.get("AWS_SESSION_TOKEN")
 
     def retrieve(self):
         """Retrieve credentials."""
-        return self._credentials
+        return Credentials(
+            access_key=self._access_key,
+            secret_key=self._secret_key,
+            session_token=self._session_token,
+        )
 
 
 class EnvMinioProvider(Provider):
     """Credential provider from MinIO environment variables."""
 
     def __init__(self):
-        self._credentials = Credentials(
-            os.environ.get("MINIO_ACCESS_KEY"),
-            os.environ.get("MINIO_SECRET_KEY"),
-        )
+        self._access_key = os.environ.get("MINIO_ACCESS_KEY")
+        self._secret_key = os.environ.get("MINIO_SECRET_KEY")
 
     def retrieve(self):
         """Retrieve credentials."""
-        return self._credentials
+        return Credentials(
+            access_key=self._access_key,
+            secret_key=self._secret_key,
+        )
 
 
 class AWSConfigProvider(Provider):
@@ -473,11 +474,17 @@ class StaticProvider(Provider):
     """Fixed credential provider."""
 
     def __init__(self, access_key, secret_key, session_token=None):
-        self._credentials = Credentials(access_key, secret_key, session_token)
+        self._access_key = access_key
+        self._secret_key = secret_key
+        self._session_token = session_token
 
     def retrieve(self):
         """Return passed credentials."""
-        return self._credentials
+        return Credentials(
+            access_key=self._access_key,
+            secret_key=self._secret_key,
+            session_token=self._session_token,
+        )
 
 
 class WebIdentityClientGrantsProvider(Provider):

--- a/tests/unit/credentials_test.py
+++ b/tests/unit/credentials_test.py
@@ -94,14 +94,14 @@ class ChainedProviderTest(TestCase):
                 EnvAWSProvider(), EnvMinioProvider(),
             ]
         )
-        # retireve provider (env_aws) has priority
+        # retrieve provider (env_aws) has priority
         creds = provider.retrieve()
         # assert provider credentials
         self.assertEqual(creds.access_key, "access_aws")
         self.assertEqual(creds.secret_key, "secret_aws")
         self.assertEqual(creds.session_token, "token_aws")
 
-    def test_chain_retrieve_second(self):
+    def test_chain_retrieve_failed_provider(self):
         # clear environment
         os.environ.clear()
         # prepare env for env_minio
@@ -114,7 +114,7 @@ class ChainedProviderTest(TestCase):
                 EnvAWSProvider(), EnvMinioProvider(),
             ]
         )
-        # retireve provider: (env_minio) will be retrieved
+        # retrieve provider: (env_minio) will be retrieved
         creds = provider.retrieve()
         # assert provider credentials
         self.assertEqual(creds.access_key, "access_minio")

--- a/tests/unit/credentials_test.py
+++ b/tests/unit/credentials_test.py
@@ -101,6 +101,26 @@ class ChainedProviderTest(TestCase):
         self.assertEqual(creds.secret_key, "secret_aws")
         self.assertEqual(creds.session_token, "token_aws")
 
+    def test_chain_retrieve_second(self):
+        # clear environment
+        os.environ.clear()
+        # prepare env for env_minio
+        os.environ["MINIO_ACCESS_KEY"] = "access_minio"
+        os.environ["MINIO_SECRET_KEY"] = "secret_minio"
+        # create chain provider with env_aws and env_minio providers
+
+        provider = ChainedProvider(
+            [
+                EnvAWSProvider(), EnvMinioProvider(),
+            ]
+        )
+        # retireve provider: (env_minio) will be retrieved
+        creds = provider.retrieve()
+        # assert provider credentials
+        self.assertEqual(creds.access_key, "access_minio")
+        self.assertEqual(creds.secret_key, "secret_minio")
+        self.assertEqual(creds.session_token, None)
+
 
 class EnvAWSProviderTest(TestCase):
     def test_env_aws_retrieve(self):


### PR DESCRIPTION
Some providers, eg, EnvAWSProvider and EnvMinioProvider, creates the Credential object during __init__. However, if a key is None, a ValueError is raised. Therefore, when these providers are used within a ChainedProvider, the exception is raised before actually retrieving the credentials.

This bug is highlighted by the new test ChainedProviderTest.test_chain_retrieve_second, which fails without the proposed fix.