### PR TITLE
allow hashlib.md5() calls to work with FIPS kernels

### DIFF
--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -255,7 +255,7 @@ def md5sum_hash(data):
     if data is None:
         return None
 
-    # "usedforsecurity=False" indicate md5 hashing algorithm is not used in a security context.
+    # indicate md5 hashing algorithm is not used in a security context.
     # Refer https://bugs.python.org/issue9216 for more information.
     hasher = hashlib.new("md5", usedforsecurity=False)
     hasher.update(data.encode() if isinstance(data, str) else data)

--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -255,7 +255,9 @@ def md5sum_hash(data):
     if data is None:
         return None
 
-    hasher = hashlib.md5()
+    # "usedforsecurity=False" indicate md5 hashing algorithm is not used in a security context.
+    # Refer https://bugs.python.org/issue9216 for more information.
+    hasher = hashlib.new("md5", usedforsecurity=False)
     hasher.update(data.encode() if isinstance(data, str) else data)
     md5sum = base64.b64encode(hasher.digest())
     return md5sum.decode() if isinstance(md5sum, bytes) else md5sum

--- a/minio/sse.py
+++ b/minio/sse.py
@@ -25,7 +25,6 @@ This module contains core API parsers.
 
 """
 import base64
-import hashlib
 import json
 from abc import ABCMeta, abstractmethod
 
@@ -56,9 +55,9 @@ class SseCustomerKey(Sse):
                 "SSE-C keys need to be 256 bit base64 encoded",
             )
         b64key = base64.b64encode(key).decode()
-        md5 = hashlib.md5()
-        md5.update(key)
-        md5key = base64.b64encode(md5.digest()).decode()
+        from .helpers import \
+            md5sum_hash  # pylint: disable=import-outside-toplevel
+        md5key = md5sum_hash(key)
         self._headers = {
             "X-Amz-Server-Side-Encryption-Customer-Algorithm": "AES256",
             "X-Amz-Server-Side-Encryption-Customer-Key": b64key,


### PR DESCRIPTION
in non-FIPS environments, the flag would be ignored.

will fix #789