### PR TITLE
:sparkles: Allow PathLike objects in fget_object() & add types

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -947,16 +947,16 @@ Downloads data of an object to file.
 
 __Parameters__
 
-| Param                | Type             | Description                                          |
-|:---------------------|:-----------------|:-----------------------------------------------------|
-| `bucket_name`        | _str_            | Name of the bucket.                                  |
-| `object_name`        | _str_            | Object name in the bucket.                           |
-| `file_path`          | _str_            | Name of file to download.                            |
-| `request_headers`    | _dict_           | Any additional headers to be added with GET request. |
-| `ssec`               | _SseCustomerKey_ | Server-side encryption customer key.                 |
-| `version_id`         | _str_            | Version-ID of the object.                            |
-| `extra_query_params` | _dict_           | Extra query parameters for advanced usage.           |
-| `tmp_file_path`      | _str_            | Path to a temporary file.                            |
+| Param                | Type                      | Description                                          |
+|:---------------------|:--------------------------|:-----------------------------------------------------|
+| `bucket_name`        | _str_                     | Name of the bucket.                                  |
+| `object_name`        | _str_                     | Object name in the bucket.                           |
+| `file_path`          | _Union[str, os.PathLike]_ | Name of file to download.                            |
+| `request_headers`    | _dict_                    | Any additional headers to be added with GET request. |
+| `ssec`               | _SseCustomerKey_          | Server-side encryption customer key.                 |
+| `version_id`         | _str_                     | Version-ID of the object.                            |
+| `extra_query_params` | _dict_                    | Extra query parameters for advanced usage.           |
+| `tmp_file_path`      | _Union[str, os.PathLike]_ | Path to a temporary file.                            |
 
 __Return Value__
 

--- a/minio/api.py
+++ b/minio/api.py
@@ -28,6 +28,7 @@ import os
 import platform
 from datetime import timedelta
 from threading import Thread
+from typing import Union, Dict, Optional, Any
 from urllib.parse import urlunsplit
 from xml.etree import ElementTree as ET
 
@@ -994,15 +995,21 @@ class Minio:  # pylint: disable=too-many-public-methods
                 tags=tags, retention=retention, legal_hold=legal_hold,
             )
 
-    def fget_object(self, bucket_name, object_name, file_path,
-                    request_headers=None, ssec=None, version_id=None,
-                    extra_query_params=None, tmp_file_path=None):
+    def fget_object(self,
+                    bucket_name: str,
+                    object_name: str,
+                    file_path: Union[str, os.PathLike],
+                    request_headers: Optional[Dict[str, str]] = None,
+                    ssec: Optional[SseCustomerKey] = None,
+                    version_id: Optional[str] = None,
+                    extra_query_params: Optional[Dict[str, Any]] = None,
+                    tmp_file_path:  Union[str, os.PathLike, None] = None):
         """
         Downloads data of an object to file.
 
         :param bucket_name: Name of the bucket.
         :param object_name: Object name in the bucket.
-        :param file_path: Name of file to download.
+        :param file_path: Path of file to download.
         :param request_headers: Any additional headers to be added with GET
                                 request.
         :param ssec: Server-side encryption customer key.
@@ -1044,6 +1051,8 @@ class Minio:  # pylint: disable=too-many-public-methods
         )
 
         # Write to a temporary file "file_path.part.minio" before saving.
+        file_path = os.fspath(file_path)
+        tmp_file_path = tmp_file_path or os.fspath(tmp_file_path)
         tmp_file_path = (
             tmp_file_path or file_path + "." + stat.etag + ".part.minio"
         )

--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -915,7 +915,7 @@ def test_get_object_version(log_entry, sse=None):
     _test_get_object(log_entry, sse, version_check=True)
 
 
-def _test_fget_object(log_entry, sse=None, version_check=False):
+def _test_fget_object(log_entry, sse=None, version_check=False, use_pathlib=False):
     """Test fget_object()."""
 
     if sse:
@@ -925,6 +925,8 @@ def _test_fget_object(log_entry, sse=None, version_check=False):
     bucket_name = _gen_bucket_name()
     object_name = f"{uuid4()}"
     tmpfd, tmpfile = tempfile.mkstemp()
+    if use_pathlib:
+        tmpfile = Path(tmpfile)
     os.close(tmpfd)
     length = 1 * MB
 
@@ -959,6 +961,11 @@ def _test_fget_object(log_entry, sse=None, version_check=False):
 def test_fget_object(log_entry, sse=None):
     """Test fget_object()."""
     _test_fget_object(log_entry, sse)
+
+
+def test_fget_object_pathlib(log_entry, sse=None):
+    """Test fget_object() with a pathlib object."""
+    _test_fget_object(log_entry, sse, use_pathlib=True)
 
 
 def test_fget_object_version(log_entry, sse=None):
@@ -1930,6 +1937,7 @@ def main():
             test_get_object: {"sse": ssec} if ssec else None,
             test_get_object_version: {"sse": ssec} if ssec else None,
             test_fget_object: {"sse": ssec} if ssec else None,
+            test_fget_object_pathlib: {"sse": ssec} if ssec else None,
             test_fget_object_version: {"sse": ssec} if ssec else None,
             test_get_object_with_default_length: None,
             test_get_partial_object: {"sse": ssec} if ssec else None,

--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -34,6 +34,7 @@ import traceback
 from binascii import crc32
 from datetime import datetime, timedelta, timezone
 from inspect import getfullargspec
+from pathlib import Path
 from threading import Thread
 from uuid import uuid4
 

--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -916,7 +916,12 @@ def test_get_object_version(log_entry, sse=None):
     _test_get_object(log_entry, sse, version_check=True)
 
 
-def _test_fget_object(log_entry, sse=None, version_check=False, use_pathlib=False):
+def _test_fget_object(
+    log_entry,
+    sse=None,
+    version_check=False,
+    use_pathlib=False
+):
     """Test fget_object()."""
 
     if sse:


### PR DESCRIPTION
Related to #1214 

I noticed that the function couln't take arbitrary path objects so I fixed it. It was mostly because of the `+` operator not working with pathlib.