### PR TITLE
select: yield available payload fully by requested num_bytes

### DIFF
--- a/minio/select.py
+++ b/minio/select.py
@@ -421,7 +421,7 @@ class SelectObjectReader:
         should call self.close() to release network resources.
         """
         while True:
-            if self._payload:
+            while self._payload:
                 result = self._payload
                 if num_bytes < len(self._payload):
                     result = self._payload[:num_bytes]

--- a/minio/select.py
+++ b/minio/select.py
@@ -420,13 +420,10 @@ class SelectObjectReader:
         Stream extracted payload from response data. Upon completion, caller
         should call self.close() to release network resources.
         """
-        while True:
+        while self._read() > 0:
             while self._payload:
                 result = self._payload
                 if num_bytes < len(self._payload):
                     result = self._payload[:num_bytes]
                 self._payload = self._payload[len(result):]
                 yield result
-
-            if self._read() <= 0:
-                break

--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -281,7 +281,7 @@ def test_select_object_content(log_entry):
         data = _CLIENT.select_object_content(bucket_name, csvfile, request)
         # Get the records
         records = io.BytesIO()
-        for data_bytes in data.stream(10*KB):
+        for data_bytes in data.stream(16):
             records.write(data_bytes)
 
         expected_crc = crc32(content.getvalue()) & 0xffffffff


### PR DESCRIPTION
When the specified number of bytes was less than the payload size, the rest of the payload was discarded. I fixed the method and adjusted the test to trigger this behavior.