### PR TITLE
Use Apache license SPDX identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     packages=["minio", "minio.credentials"],
     install_requires=["certifi", "urllib3"],
     tests_require=[],
-    license="Apache License 2.0",
+    license="Apache-2.0",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",


### PR DESCRIPTION
I suggest to change the license string in the package information to an [SPDX parsable license expression](https://spdx.org/licenses/).
This makes it easier for downstream users to get the license information directly from the package metadata.