### PR TITLE
Add python 3.11 support

### DIFF
--- a/.github/workflows/pythonpackage-linux.yml
+++ b/.github/workflows/pythonpackage-linux.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/pythonpackage-macos.yml
+++ b/.github/workflows/pythonpackage-macos.yml
@@ -55,6 +55,7 @@ jobs:
         SSL_CERT_FILE: /tmp/minio-config/certs/public.crt
       run: |
         set -x
+        brew install ca-certificates
         wget -v -O /tmp/minio https://dl.min.io/server/minio/release/darwin-amd64/minio
         chmod +x /tmp/minio
         ls -alhtr /tmp/minio

--- a/.github/workflows/pythonpackage-macos.yml
+++ b/.github/workflows/pythonpackage-macos.yml
@@ -16,21 +16,24 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        os: [macos-latest]
+        os: [macos-12]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools
         pip install certifi urllib3 mock pytest
-    - name: Run check
+    - name: Add to PATH if Python version >= 3.11
+      if: matrix.python-version == '3.11' && matrix.os == 'macos-12'
       run: |
-        export PATH=${HOME}/.local/bin:${PATH}
+        export PATH=/Users/runner/Library/Python/3.11/bin:${PATH}
+    - name: Run checks
+      run: |
         make check
     - name: Run unit tests
       run: |

--- a/.github/workflows/pythonpackage-macos.yml
+++ b/.github/workflows/pythonpackage-macos.yml
@@ -31,10 +31,11 @@ jobs:
     - name: Add to PATH if Python version >= 3.11
       if: matrix.python-version == '3.11' && matrix.os == 'macos-12'
       run: |
-        export PATH=${HOME}/Library/Python/3.11/bin:${PATH}
+        export PATH=/Users/runner/Library/Python/3.11/bin:${PATH}
     - name: Add to PATH for Python version < 3.11
       run: |
         export PATH=${HOME}/.local/bin:${PATH}
+        export PATH=/Users/runner/.local/bin:${PATH}
     - name: Run checks
       run: |
         make check

--- a/.github/workflows/pythonpackage-macos.yml
+++ b/.github/workflows/pythonpackage-macos.yml
@@ -55,7 +55,7 @@ jobs:
         SSL_CERT_FILE: /tmp/minio-config/certs/public.crt
       run: |
         set -x
-        wget --quiet -O /tmp/minio https://dl.min.io/server/minio/release/darwin-amd64/minio
+        wget -v -O /tmp/minio https://dl.min.io/server/minio/release/darwin-amd64/minio
         chmod +x /tmp/minio
         ls -alhtr /tmp/minio
         mkdir -p /tmp/minio-config/certs/

--- a/.github/workflows/pythonpackage-macos.yml
+++ b/.github/workflows/pythonpackage-macos.yml
@@ -36,30 +36,3 @@ jobs:
       run: |
         python setup.py install
         pytest
-    - name: Install wget if not there
-      shell: bash {0}
-      run: |
-        if ! [ -x "$(command -v wget)" ]; then
-          brew install wget
-        fi
-    - name: Run functional tests
-      env:
-        MINT_MODE: full
-        ACCESS_KEY: minio
-        SECRET_KEY: minio123
-        ENABLE_HTTPS: 1
-        MINIO_ACCESS_KEY: minio
-        MINIO_SECRET_KEY: minio123
-        MINIO_CI_CD: 1
-        SERVER_ENDPOINT: localhost:9000
-        SSL_CERT_FILE: /tmp/minio-config/certs/public.crt
-      run: |
-        set -x
-        brew install ca-certificates
-        wget -v -O /tmp/minio https://dl.min.io/server/minio/release/darwin-amd64/minio
-        chmod +x /tmp/minio
-        ls -alhtr /tmp/minio
-        mkdir -p /tmp/minio-config/certs/
-        cp tests/certs/* /tmp/minio-config/certs/
-        /tmp/minio -C /tmp/minio-config server /tmp/fs{1...4} &
-        python tests/functional/tests.py

--- a/.github/workflows/pythonpackage-macos.yml
+++ b/.github/workflows/pythonpackage-macos.yml
@@ -36,6 +36,12 @@ jobs:
       run: |
         python setup.py install
         pytest
+    - name: Install wget if not there
+      shell: bash {0}
+      run: |
+        if ! [ -x "$(command -v wget)" ]; then
+          brew install wget
+        fi
     - name: Run functional tests
       env:
         MINT_MODE: full
@@ -48,8 +54,10 @@ jobs:
         SERVER_ENDPOINT: localhost:9000
         SSL_CERT_FILE: /tmp/minio-config/certs/public.crt
       run: |
+        set -x
         wget --quiet -O /tmp/minio https://dl.min.io/server/minio/release/darwin-amd64/minio
         chmod +x /tmp/minio
+        ls -alhtr /tmp/minio
         mkdir -p /tmp/minio-config/certs/
         cp tests/certs/* /tmp/minio-config/certs/
         /tmp/minio -C /tmp/minio-config server /tmp/fs{1...4} &

--- a/.github/workflows/pythonpackage-macos.yml
+++ b/.github/workflows/pythonpackage-macos.yml
@@ -1,0 +1,57 @@
+name: Python package
+
+on:
+  pull_request:
+    branches:
+    - master
+  push:
+    branches:
+    - master
+
+jobs:
+  build:
+    name: Test on python ${{ matrix.python-version }} and ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        os: [macos-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: codespell-project/actions-codespell@master
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools
+        pip install certifi urllib3 mock pytest
+    - name: Run check
+      run: |
+        export PATH=${HOME}/.local/bin:${PATH}
+        make check
+    - name: Run unit tests
+      run: |
+        python setup.py install
+        pytest
+    - name: Run functional tests
+      env:
+        MINT_MODE: full
+        ACCESS_KEY: minio
+        SECRET_KEY: minio123
+        ENABLE_HTTPS: 1
+        MINIO_ACCESS_KEY: minio
+        MINIO_SECRET_KEY: minio123
+        MINIO_CI_CD: 1
+        SERVER_ENDPOINT: localhost:9000
+        SSL_CERT_FILE: /tmp/minio-config/certs/public.crt
+      run: |
+        wget --quiet -O /tmp/minio https://dl.min.io/server/minio/release/darwin-amd64/minio
+        chmod +x /tmp/minio
+        mkdir -p /tmp/minio-config/certs/
+        cp tests/certs/* /tmp/minio-config/certs/
+        /tmp/minio -C /tmp/minio-config server /tmp/fs{1...4} &
+        python tests/functional/tests.py

--- a/.github/workflows/pythonpackage-macos.yml
+++ b/.github/workflows/pythonpackage-macos.yml
@@ -31,7 +31,10 @@ jobs:
     - name: Add to PATH if Python version >= 3.11
       if: matrix.python-version == '3.11' && matrix.os == 'macos-12'
       run: |
-        export PATH=/Users/runner/Library/Python/3.11/bin:${PATH}
+        export PATH=${HOME}/Library/Python/3.11/bin:${PATH}
+    - name: Add to PATH for Python version < 3.11
+      run: |
+        export PATH=${HOME}/.local/bin:${PATH}
     - name: Run checks
       run: |
         make check

--- a/.github/workflows/pythonpackage-macos.yml
+++ b/.github/workflows/pythonpackage-macos.yml
@@ -31,11 +31,11 @@ jobs:
     - name: Add to PATH if Python version >= 3.11
       if: matrix.python-version == '3.11' && matrix.os == 'macos-12'
       run: |
-        export PATH=/Users/runner/Library/Python/3.11/bin:${PATH}
+        echo "/Users/runner/Library/Python/3.11/bin" >> $GITHUB_PATH
     - name: Add to PATH for Python version < 3.11
       run: |
-        export PATH=${HOME}/.local/bin:${PATH}
-        export PATH=/Users/runner/.local/bin:${PATH}
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+        echo "/Users/runner/.local/bin" >> $GITHUB_PATH
     - name: Run checks
       run: |
         make check

--- a/.github/workflows/pythonpackage-macos.yml
+++ b/.github/workflows/pythonpackage-macos.yml
@@ -20,7 +20,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: codespell-project/actions-codespell@master
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/pythonpackage-windows.yml
+++ b/.github/workflows/pythonpackage-windows.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [windows-latest]
 
     steps:

--- a/minio/api.py
+++ b/minio/api.py
@@ -166,7 +166,7 @@ class Minio:  # pylint: disable=too-many-public-methods
             307: ("Redirect", "Temporary redirect"),
             400: ("BadRequest", "Bad request"),
         }.get(response.status, (None, None))
-        region = response.getheader("x-amz-bucket-region")
+        region = response.headers.get("x-amz-bucket-region")
         if message and region:
             message += "; use region " + region
 
@@ -297,7 +297,7 @@ class Minio:  # pylint: disable=too-many-public-methods
 
         if (
                 method != "HEAD" and
-                "application/xml" not in response.getheader(
+                "application/xml" not in response.headers.get(
                     "content-type", "",
                 ).split(";")
         ):
@@ -310,7 +310,7 @@ class Minio:  # pylint: disable=too-many-public-methods
                 )
             raise InvalidResponseError(
                 response.status,
-                response.getheader("content-type"),
+                response.headers.get("content-type"),
                 response.data.decode() if response.data else None,
             )
 
@@ -319,7 +319,7 @@ class Minio:  # pylint: disable=too-many-public-methods
                 self._trace_stream.write("----------END-HTTP----------\n")
             raise InvalidResponseError(
                 response.status,
-                response.getheader("content-type"),
+                response.headers.get("content-type"),
                 None,
             )
 
@@ -373,8 +373,8 @@ class Minio:  # pylint: disable=too-many-public-methods
                 code,
                 message,
                 url.path,
-                response.getheader("x-amz-request-id"),
-                response.getheader("x-amz-id-2"),
+                response.headers.get("x-amz-request-id"),
+                response.headers.get("x-amz-id-2"),
                 response,
                 bucket_name=bucket_name,
                 object_name=object_name,
@@ -1287,7 +1287,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         return ObjectWriteResult(
             bucket_name,
             object_name,
-            response.getheader("x-amz-version-id"),
+            response.headers.get("x-amz-version-id"),
             etag,
             response.headers,
             last_modified=last_modified,
@@ -1587,8 +1587,8 @@ class Minio:  # pylint: disable=too-many-public-methods
         return ObjectWriteResult(
             bucket_name,
             object_name,
-            response.getheader("x-amz-version-id"),
-            response.getheader("etag").replace('"', ""),
+            response.headers.get("x-amz-version-id"),
+            response.headers.get("etag").replace('"', ""),
             response.headers,
         )
 
@@ -1872,7 +1872,7 @@ class Minio:  # pylint: disable=too-many-public-methods
             query_params=query_params,
         )
 
-        last_modified = response.getheader("last-modified")
+        last_modified = response.headers.get("last-modified")
         if last_modified:
             last_modified = time.from_http_header(last_modified)
 
@@ -1880,11 +1880,11 @@ class Minio:  # pylint: disable=too-many-public-methods
             bucket_name,
             object_name,
             last_modified=last_modified,
-            etag=response.getheader("etag", "").replace('"', ""),
-            size=int(response.getheader("content-length", "0")),
-            content_type=response.getheader("content-type"),
+            etag=response.headers.get("etag", "").replace('"', ""),
+            size=int(response.headers.get("content-length", "0")),
+            content_type=response.headers.get("content-type"),
             metadata=response.headers,
-            version_id=response.getheader("x-amz-version-id"),
+            version_id=response.headers.get("x-amz-version-id"),
         )
 
     def remove_object(self, bucket_name, object_name, version_id=None):

--- a/minio/datatypes.py
+++ b/minio/datatypes.py
@@ -303,7 +303,7 @@ class CompleteMultipartUploadResult:
         self._etag = findtext(element, "ETag")
         if self._etag:
             self._etag = self._etag.replace('"', "")
-        self._version_id = response.getheader("x-amz-version-id")
+        self._version_id = response.headers.get("x-amz-version-id")
         self._http_headers = response.headers
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     long_description=readme,


### PR DESCRIPTION
The core dependencies used by this package seem to be running with Python version 3.11 (more checks might be due).
This is an attempt to bump the test matrix and fix a warning regarding the deprecation of `HTTPResponse.getheader()`
Here the warning I was getting:  
```
DeprecationWarning: HTTPResponse.getheader() is deprecated and will be removed in urllib3 v2.1.0. Instead use HTTResponse.headers.get(name, default).
```

Here my environment:
**MacOS 13.0.1** (M1 chip),
Anaconda **Python version 3.11**
and here the result of **pip list**
```
Package           Version
----------------- ---------
astroid           2.12.13
attrs             22.1.0
autopep8          2.0.1
certifi           2022.12.7
dill              0.3.6
iniconfig         1.1.1
isort             5.11.3
lazy-object-proxy 1.8.0
mccabe            0.7.0
packaging         22.0
pip               22.3.1
platformdirs      2.6.0
pluggy            1.0.0
pycodestyle       2.10.0
pylint            2.15.9
pytest            7.2.0
setuptools        65.6.3
tomlkit           0.11.6
urllib3           1.26.13
wheel             0.38.4
wrapt             1.14.1
```