### PR TITLE
Allow customizable check_bucket_name behavior

### DIFF
--- a/minio/api.py
+++ b/minio/api.py
@@ -561,7 +561,7 @@ class Minio:  # pylint: disable=too-many-public-methods
                     print(data.decode())
                 print(result.stats())
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         check_non_empty_string(object_name)
         if not isinstance(request, SelectRequest):
             raise ValueError("request must be SelectRequest type")
@@ -595,7 +595,7 @@ class Minio:  # pylint: disable=too-many-public-methods
             # Create bucket with object-lock feature on specific region.
             client.make_bucket("my-bucket", "eu-west-2", object_lock=True)
         """
-        check_bucket_name(bucket_name, True)
+        self._check_bucket_name(bucket_name, True)
         if self._base_url.region:
             # Error out if region does not match with region passed via
             # constructor.
@@ -653,7 +653,7 @@ class Minio:  # pylint: disable=too-many-public-methods
             else:
                 print("my-bucket does not exist")
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         try:
             self._execute("HEAD", bucket_name)
             return True
@@ -671,7 +671,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         Example::
             client.remove_bucket("my-bucket")
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         self._execute("DELETE", bucket_name)
         self._region_map.pop(bucket_name, None)
 
@@ -685,7 +685,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         Example::
             policy = client.get_bucket_policy("my-bucket")
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         response = self._execute(
             "GET", bucket_name, query_params={"policy": ""},
         )
@@ -700,7 +700,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         Example::
             client.delete_bucket_policy("my-bucket")
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         self._execute("DELETE", bucket_name, query_params={"policy": ""})
 
     def set_bucket_policy(self, bucket_name, policy):
@@ -713,7 +713,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         Example::
             client.set_bucket_policy("my-bucket", policy)
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         is_valid_policy_type(policy)
         self._execute(
             "PUT",
@@ -733,7 +733,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         Example::
             config = client.get_bucket_notification("my-bucket")
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         response = self._execute(
             "GET", bucket_name, query_params={"notification": ""},
         )
@@ -759,7 +759,7 @@ class Minio:  # pylint: disable=too-many-public-methods
             )
             client.set_bucket_notification("my-bucket", config)
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         if not isinstance(config, NotificationConfig):
             raise ValueError("config must be NotificationConfig type")
         body = marshal(config)
@@ -795,7 +795,7 @@ class Minio:  # pylint: disable=too-many-public-methods
                 "my-bucket", SSEConfig(Rule.new_sse_s3_rule()),
             )
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         if not isinstance(config, SSEConfig):
             raise ValueError("config must be SSEConfig type")
         body = marshal(config)
@@ -817,7 +817,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         Example::
             config = client.get_bucket_encryption("my-bucket")
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         try:
             response = self._execute(
                 "GET",
@@ -839,7 +839,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         Example::
             client.delete_bucket_encryption("my-bucket")
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         try:
             self._execute(
                 "DELETE",
@@ -873,7 +873,7 @@ class Minio:  # pylint: disable=too-many-public-methods
                 for event in events:
                     print(event)
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         if self._base_url.is_aws_host:
             raise ValueError(
                 "ListenBucketNotification API is not supported in Amazon S3",
@@ -904,7 +904,7 @@ class Minio:  # pylint: disable=too-many-public-methods
                 "my-bucket", VersioningConfig(ENABLED),
             )
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         if not isinstance(config, VersioningConfig):
             raise ValueError("config must be VersioningConfig type")
         body = marshal(config)
@@ -927,7 +927,7 @@ class Minio:  # pylint: disable=too-many-public-methods
             config = client.get_bucket_versioning("my-bucket")
             print(config.status)
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         response = self._execute(
             "GET",
             bucket_name,
@@ -1028,7 +1028,7 @@ class Minio:  # pylint: disable=too-many-public-methods
                 ssec=SseCustomerKey(b"32byteslongsecretkeymustprovided"),
             )
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         check_non_empty_string(object_name)
         if progress and not isinstance(progress, Thread):
             raise TypeError("progress object must be instance of Thread")
@@ -1139,7 +1139,7 @@ class Minio:  # pylint: disable=too-many-public-methods
                 response.close()
                 response.release_conn()
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         check_non_empty_string(object_name)
         check_ssec(ssec)
 
@@ -1218,7 +1218,7 @@ class Minio:  # pylint: disable=too-many-public-methods
             )
             print(result.object_name, result.version_id)
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         check_non_empty_string(object_name)
         if not isinstance(source, CopySource):
             raise ValueError("source must be CopySource type")
@@ -1421,7 +1421,7 @@ class Minio:  # pylint: disable=too-many-public-methods
             )
             print(result.object_name, result.version_id)
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         check_non_empty_string(object_name)
         if not isinstance(sources, (list, tuple)) or not sources:
             raise ValueError("sources must be non-empty list or tuple type")
@@ -1655,7 +1655,7 @@ class Minio:  # pylint: disable=too-many-public-methods
                 legal_hold=True,
             )
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         check_non_empty_string(object_name)
         check_sse(sse)
         if tags is not None and not isinstance(tags, Tags):
@@ -1856,7 +1856,7 @@ class Minio:  # pylint: disable=too-many-public-methods
             )
         """
 
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         check_non_empty_string(object_name)
         check_ssec(ssec)
 
@@ -1904,7 +1904,7 @@ class Minio:  # pylint: disable=too-many-public-methods
                 version_id="dfbd25b3-abec-4184-a4e8-5a35a5c1174d",
             )
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         check_non_empty_string(object_name)
         self._execute(
             "DELETE",
@@ -1980,7 +1980,7 @@ class Minio:  # pylint: disable=too-many-public-methods
             for error in errors:
                 print("error occurred when deleting object", error)
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
 
         # turn list like objects into an iterator.
         delete_object_list = itertools.chain(delete_object_list)
@@ -2043,7 +2043,7 @@ class Minio:  # pylint: disable=too-many-public-methods
             )
             print(url)
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         check_non_empty_string(object_name)
         if expires.total_seconds() < 1 or expires.total_seconds() > 604800:
             raise ValueError("expires must be between 1 second to 7 days")
@@ -2187,7 +2187,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         Example::
             client.delete_bucket_replication("my-bucket")
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         self._execute("DELETE", bucket_name, query_params={"replication": ""})
 
     def get_bucket_replication(self, bucket_name):
@@ -2200,7 +2200,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         Example::
             config = client.get_bucket_replication("my-bucket")
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         try:
             response = self._execute(
                 "GET", bucket_name, query_params={"replication": ""},
@@ -2243,7 +2243,7 @@ class Minio:  # pylint: disable=too-many-public-methods
             )
             client.set_bucket_replication("my-bucket", config)
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         if not isinstance(config, ReplicationConfig):
             raise ValueError("config must be ReplicationConfig type")
         body = marshal(config)
@@ -2264,7 +2264,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         Example::
             client.delete_bucket_lifecycle("my-bucket")
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         self._execute("DELETE", bucket_name, query_params={"lifecycle": ""})
 
     def get_bucket_lifecycle(self, bucket_name):
@@ -2277,7 +2277,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         Example::
             config = client.get_bucket_lifecycle("my-bucket")
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         try:
             response = self._execute(
                 "GET", bucket_name, query_params={"lifecycle": ""},
@@ -2316,7 +2316,7 @@ class Minio:  # pylint: disable=too-many-public-methods
             )
             client.set_bucket_lifecycle("my-bucket", config)
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         if not isinstance(config, LifecycleConfig):
             raise ValueError("config must be LifecycleConfig type")
         body = marshal(config)
@@ -2337,7 +2337,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         Example::
             client.delete_bucket_tags("my-bucket")
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         self._execute("DELETE", bucket_name, query_params={"tagging": ""})
 
     def get_bucket_tags(self, bucket_name):
@@ -2350,7 +2350,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         Example::
             tags = client.get_bucket_tags("my-bucket")
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         try:
             response = self._execute(
                 "GET", bucket_name, query_params={"tagging": ""},
@@ -2375,7 +2375,7 @@ class Minio:  # pylint: disable=too-many-public-methods
             tags["User"] = "jsmith"
             client.set_bucket_tags("my-bucket", tags)
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         if not isinstance(tags, Tags):
             raise ValueError("tags must be Tags type")
         body = marshal(Tagging(tags))
@@ -2398,7 +2398,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         Example::
             client.delete_object_tags("my-bucket", "my-object")
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         check_non_empty_string(object_name)
         query_params = {"versionId": version_id} if version_id else {}
         query_params["tagging"] = ""
@@ -2421,7 +2421,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         Example::
             tags = client.get_object_tags("my-bucket", "my-object")
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         check_non_empty_string(object_name)
         query_params = {"versionId": version_id} if version_id else {}
         query_params["tagging"] = ""
@@ -2454,7 +2454,7 @@ class Minio:  # pylint: disable=too-many-public-methods
             tags["User"] = "jsmith"
             client.set_object_tags("my-bucket", "my-object", tags)
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         check_non_empty_string(object_name)
         if not isinstance(tags, Tags):
             raise ValueError("tags must be Tags type")
@@ -2483,7 +2483,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         Example::
             client.enable_object_legal_hold("my-bucket", "my-object")
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         check_non_empty_string(object_name)
         body = marshal(LegalHold(True))
         query_params = {"versionId": version_id} if version_id else {}
@@ -2510,7 +2510,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         Example::
             client.disable_object_legal_hold("my-bucket", "my-object")
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         check_non_empty_string(object_name)
         body = marshal(LegalHold(False))
         query_params = {"versionId": version_id} if version_id else {}
@@ -2540,7 +2540,7 @@ class Minio:  # pylint: disable=too-many-public-methods
             else:
                 print("legal hold is not enabled on my-object")
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         check_non_empty_string(object_name)
         query_params = {"versionId": version_id} if version_id else {}
         query_params["legal-hold"] = ""
@@ -2581,7 +2581,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         Example::
             config = client.get_object_lock_config("my-bucket")
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         response = self._execute(
             "GET", bucket_name, query_params={"object-lock": ""},
         )
@@ -2598,7 +2598,7 @@ class Minio:  # pylint: disable=too-many-public-methods
             config = ObjectLockConfig(GOVERNANCE, 15, DAYS)
             client.set_object_lock_config("my-bucket", config)
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         if not isinstance(config, ObjectLockConfig):
             raise ValueError("config must be ObjectLockConfig type")
         body = marshal(config)
@@ -2624,7 +2624,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         Example::
             config = client.get_object_retention("my-bucket", "my-object")
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         check_non_empty_string(object_name)
         query_params = {"versionId": version_id} if version_id else {}
         query_params["retention"] = ""
@@ -2658,7 +2658,7 @@ class Minio:  # pylint: disable=too-many-public-methods
             )
             client.set_object_retention("my-bucket", "my-object", config)
         """
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
         check_non_empty_string(object_name)
         if not isinstance(config, Retention):
             raise ValueError("config must be Retention type")
@@ -2697,7 +2697,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         policies.
         """
 
-        check_bucket_name(bucket_name)
+        self._check_bucket_name(bucket_name)
 
         if version_id_marker:
             include_version = True
@@ -2829,3 +2829,8 @@ class Minio:  # pylint: disable=too-many-public-methods
             headers=extra_headers,
         )
         return ListPartsResult(response)
+
+    def _check_bucket_name(self, bucket_name, strict=False):
+        """Check whether bucket name is valid optional with strict check or not."""
+
+        return check_bucket_name(bucket_name, strict)


### PR DESCRIPTION
Following up on https://github.com/minio/minio-py/issues/1261 the suggestion given was to inherit the Minio class for all custom requirements. In this case I want to override the behavior of `check_bucket_name` to support my legacy usecase. Because this is a module level helper function, I couldn't easily replace it with inheritance, so this change is moving references to the helper into a proxy method on the instance.

This change allows me to override the default bucket checking logic easily without having to loosen the strict checks for other clients:

```py
BUCKET_NAME_EXEMPTIONS = ["legacy-bucket-ending-in-dash-"]

class CustomMinio(Minio):
    def _check_bucket_name(self, bucket_name, strict=False):
        if bucket_name not in BUCKET_NAME_EXEMPTIONS:
            return super()._check_bucket_name(bucket_name, strict)
```