### PR TITLE
Fix upload snowball objects with staging file

### DIFF
--- a/minio/api.py
+++ b/minio/api.py
@@ -2744,6 +2744,8 @@ class Minio:  # pylint: disable=too-many-public-methods
         if not name:
             length = fileobj.tell()
             fileobj.seek(0)
+        else:
+            length = os.stat(name).st_size
 
         if name:
             return self.fput_object(bucket_name, object_name, staging_filename,

--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -1899,7 +1899,8 @@ def test_upload_snowball_objects(log_entry):
     _test_upload_snowball_objects(log_entry)
 
 
-def test_upload_snowball_objects_with_staging(log_entry):
+def test_upload_snowball_objects_with_staging( # pylint: disable=invalid-name
+        log_entry):
     """Test upload_snowball_objects() with staging file."""
     staging_filename = f"{uuid4()}.tar"
     _test_upload_snowball_objects(log_entry, staging_filename)

--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -1894,12 +1894,13 @@ def _test_upload_snowball_objects(log_entry, staging_filename=None):
         if staging_filename and os.path.exists(staging_filename):
             os.remove(staging_filename)
 
+
 def test_upload_snowball_objects(log_entry):
     """Test upload_snowball_objects()."""
     _test_upload_snowball_objects(log_entry)
 
 
-def test_upload_snowball_objects_with_staging( # pylint: disable=invalid-name
+def test_upload_snowball_objects_with_staging(  # pylint: disable=invalid-name
         log_entry):
     """Test upload_snowball_objects() with staging file."""
     staging_filename = f"{uuid4()}.tar"

--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -1891,6 +1891,32 @@ def test_upload_snowball_objects(log_entry):
         _CLIENT.remove_object(bucket_name, "my-object3")
         _CLIENT.remove_bucket(bucket_name)
 
+    # run with staging file option
+    try:
+        _CLIENT.make_bucket(bucket_name)
+        size = 3 * MB
+        reader1 = LimitedRandomReader(size)
+        reader2 = LimitedRandomReader(size)
+        _CLIENT.upload_snowball_objects(
+            bucket_name,
+            [
+                SnowballObject("my-object1", data=io.BytesIO(b"py"), length=2),
+                SnowballObject(
+                    "my-object2", data=reader1, length=size,
+                ),
+                SnowballObject(
+                    "my-object3", data=reader2, length=size,
+                    mod_time=datetime.now(),
+                ),
+            ],
+            staging_filename="staging.tar"
+        )
+        _test_list_objects_api(bucket_name, 3)
+    finally:
+        _CLIENT.remove_object(bucket_name, "my-object1")
+        _CLIENT.remove_object(bucket_name, "my-object2")
+        _CLIENT.remove_object(bucket_name, "my-object3")
+        _CLIENT.remove_bucket(bucket_name)
 
 def main():
     """

--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -1891,7 +1891,16 @@ def test_upload_snowball_objects(log_entry):
         _CLIENT.remove_object(bucket_name, "my-object3")
         _CLIENT.remove_bucket(bucket_name)
 
-    # run with staging file option
+def test_upload_snowball_objects_with_staging(log_entry):
+    """Test upload_snowball_objects() with staging file."""
+
+    # Get a unique bucket_name
+    bucket_name = _gen_bucket_name()
+
+    log_entry["args"] = {
+        "bucket_name": bucket_name,
+    }
+
     try:
         _CLIENT.make_bucket(bucket_name)
         size = 3 * MB
@@ -1917,6 +1926,7 @@ def test_upload_snowball_objects(log_entry):
         _CLIENT.remove_object(bucket_name, "my-object2")
         _CLIENT.remove_object(bucket_name, "my-object3")
         _CLIENT.remove_bucket(bucket_name)
+        os.remove("staging.tar")
 
 def main():
     """
@@ -2015,6 +2025,7 @@ def main():
             test_get_bucket_notification: None,
             test_select_object_content: None,
             test_upload_snowball_objects: None,
+            test_upload_snowball_objects_with_staging: None,
         }
     else:
         tests = {


### PR DESCRIPTION
There is a bug in upload_snowball_objects when it is called with "staging_filename" parameter. The variable "length" passed to fput_object is not defined in this case. 