### PR TITLE
Format with black

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ default: tests
 
 getdeps:
 	@echo "Installing required dependencies"
-	@pip install --user --upgrade autopep8 certifi pytest pylint urllib3
+	@pip install --user --upgrade autopep8 certifi pytest pylint urllib3 black
 
 check: getdeps
 	@echo "Running checks"
@@ -11,6 +11,7 @@ check: getdeps
 	@pylint --reports=no --score=no minio/credentials tests/functional
 	@isort --diff .
 	@find . -name "*.py" -exec autopep8 --diff --exit-code {} +
+	@black .
 
 apply: getdeps
 	@isort .

--- a/Makefile
+++ b/Makefile
@@ -3,19 +3,18 @@ default: tests
 
 getdeps:
 	@echo "Installing required dependencies"
-	@pip install --user --upgrade autopep8 certifi pytest pylint urllib3 black
+	@pip install --user --upgrade certifi pytest pylint urllib3 black
 
 check: getdeps
 	@echo "Running checks"
 	@pylint --reports=no --score=no --disable=R0401,R0801 minio/*py
 	@pylint --reports=no --score=no minio/credentials tests/functional
 	@isort --diff .
-	@find . -name "*.py" -exec autopep8 --diff --exit-code {} +
-	@black .
+	@black --check .
 
 apply: getdeps
 	@isort .
-	@find . -name "*.py" -exec autopep8 --in-place {} +
+	@black .
 
 tests: check
 	@echo "Running unit tests"

--- a/examples/fget_object.py
+++ b/examples/fget_object.py
@@ -28,12 +28,16 @@ client.fget_object("my-bucket", "my-object", "my-filename")
 
 # Download data of an object of version-ID.
 client.fget_object(
-    "my-bucket", "my-object", "my-filename",
+    "my-bucket",
+    "my-object",
+    "my-filename",
     version_id="dfbd25b3-abec-4184-a4e8-5a35a5c1174d",
 )
 
 # Download data of an SSE-C encrypted object.
 client.fget_object(
-    "my-bucket", "my-object", "my-filename",
+    "my-bucket",
+    "my-object",
+    "my-filename",
     ssec=SseCustomerKey(b"32byteslongsecretkeymustprovided"),
 )

--- a/examples/fput_object.py
+++ b/examples/fput_object.py
@@ -30,94 +30,129 @@ client = Minio(
 
 # Upload data.
 result = client.fput_object(
-    "my-bucket", "my-object", "my-filename",
+    "my-bucket",
+    "my-object",
+    "my-filename",
 )
 print(
     "created {0} object; etag: {1}, version-id: {2}".format(
-        result.object_name, result.etag, result.version_id,
+        result.object_name,
+        result.etag,
+        result.version_id,
     ),
 )
 
 # Upload data with content-type.
 result = client.fput_object(
-    "my-bucket", "my-object", "my-filename",
+    "my-bucket",
+    "my-object",
+    "my-filename",
     content_type="application/csv",
 )
 print(
     "created {0} object; etag: {1}, version-id: {2}".format(
-        result.object_name, result.etag, result.version_id,
+        result.object_name,
+        result.etag,
+        result.version_id,
     ),
 )
 
 # Upload data with metadata.
 result = client.fput_object(
-    "my-bucket", "my-object", "my-filename",
+    "my-bucket",
+    "my-object",
+    "my-filename",
     metadata={"My-Project": "one"},
 )
 print(
     "created {0} object; etag: {1}, version-id: {2}".format(
-        result.object_name, result.etag, result.version_id,
+        result.object_name,
+        result.etag,
+        result.version_id,
     ),
 )
 
 # Upload data with customer key type of server-side encryption.
 result = client.fput_object(
-    "my-bucket", "my-object", "my-filename",
+    "my-bucket",
+    "my-object",
+    "my-filename",
     sse=SseCustomerKey(b"32byteslongsecretkeymustprovided"),
 )
 print(
     "created {0} object; etag: {1}, version-id: {2}".format(
-        result.object_name, result.etag, result.version_id,
+        result.object_name,
+        result.etag,
+        result.version_id,
     ),
 )
 
 # Upload data with KMS type of server-side encryption.
 result = client.fput_object(
-    "my-bucket", "my-object", "my-filename",
+    "my-bucket",
+    "my-object",
+    "my-filename",
     sse=SseKMS("KMS-KEY-ID", {"Key1": "Value1", "Key2": "Value2"}),
 )
 print(
     "created {0} object; etag: {1}, version-id: {2}".format(
-        result.object_name, result.etag, result.version_id,
+        result.object_name,
+        result.etag,
+        result.version_id,
     ),
 )
 
 # Upload data with S3 type of server-side encryption.
 result = client.fput_object(
-    "my-bucket", "my-object", "my-filename",
+    "my-bucket",
+    "my-object",
+    "my-filename",
     sse=SseS3(),
 )
 print(
     "created {0} object; etag: {1}, version-id: {2}".format(
-        result.object_name, result.etag, result.version_id,
+        result.object_name,
+        result.etag,
+        result.version_id,
     ),
 )
 
 # Upload data with tags, retention and legal-hold.
 date = datetime.utcnow().replace(
-    hour=0, minute=0, second=0, microsecond=0,
+    hour=0,
+    minute=0,
+    second=0,
+    microsecond=0,
 ) + timedelta(days=30)
 tags = Tags(for_object=True)
 tags["User"] = "jsmith"
 result = client.fput_object(
-    "my-bucket", "my-object", "my-filename",
+    "my-bucket",
+    "my-object",
+    "my-filename",
     tags=tags,
     retention=Retention(GOVERNANCE, date),
     legal_hold=True,
 )
 print(
     "created {0} object; etag: {1}, version-id: {2}".format(
-        result.object_name, result.etag, result.version_id,
+        result.object_name,
+        result.etag,
+        result.version_id,
     ),
 )
 
 # Upload data with progress bar.
 result = client.fput_object(
-    "my-bucket", "my-object", "my-filename",
+    "my-bucket",
+    "my-object",
+    "my-filename",
     progress=Progress(),
 )
 print(
     "created {0} object; etag: {1}, version-id: {2}".format(
-        result.object_name, result.etag, result.version_id,
+        result.object_name,
+        result.etag,
+        result.version_id,
     ),
 )

--- a/examples/get_object.py
+++ b/examples/get_object.py
@@ -34,7 +34,8 @@ finally:
 # Get data of an object of version-ID.
 try:
     response = client.get_object(
-        "my-bucket", "my-object",
+        "my-bucket",
+        "my-object",
         version_id="dfbd25b3-abec-4184-a4e8-5a35a5c1174d",
     )
     # Read data from response.
@@ -45,7 +46,10 @@ finally:
 # Get data of an object from offset and length.
 try:
     response = client.get_object(
-        "my-bucket", "my-object", offset=512, length=1024,
+        "my-bucket",
+        "my-object",
+        offset=512,
+        length=1024,
     )
     # Read data from response.
 finally:
@@ -55,7 +59,8 @@ finally:
 # Get data of an SSE-C encrypted object.
 try:
     response = client.get_object(
-        "my-bucket", "my-object",
+        "my-bucket",
+        "my-object",
         ssec=SseCustomerKey(b"32byteslongsecretkeymustprovided"),
     )
     # Read data from response.

--- a/examples/list_objects.py
+++ b/examples/list_objects.py
@@ -40,7 +40,9 @@ for obj in objects:
 # List objects information recursively whose names starts with
 # "my/prefix/".
 objects = client.list_objects(
-    "my-bucket", prefix="my/prefix/", recursive=True,
+    "my-bucket",
+    prefix="my/prefix/",
+    recursive=True,
 )
 for obj in objects:
     print(obj)
@@ -48,7 +50,9 @@ for obj in objects:
 # List objects information recursively after object name
 # "my/prefix/world/1".
 objects = client.list_objects(
-    "my-bucket", recursive=True, start_after="my/prefix/world/1",
+    "my-bucket",
+    recursive=True,
+    start_after="my/prefix/world/1",
 )
 for obj in objects:
     print(obj)

--- a/examples/minio_with_certificate_identity_provider.py
+++ b/examples/minio_with_certificate_identity_provider.py
@@ -28,7 +28,9 @@ cert_file = "/path/to/client.pem"
 key_file = "/path/to/client.key"
 
 provider = CertificateIdentityProvider(
-    sts_endpoint, cert_file=cert_file, key_file=key_file,
+    sts_endpoint,
+    cert_file=cert_file,
+    key_file=key_file,
 )
 
 client = Minio("MINIO-HOST:MINIO-PORT", credentials=provider)

--- a/examples/minio_with_chained_provider.py
+++ b/examples/minio_with_chained_provider.py
@@ -19,8 +19,12 @@
 # 'providers' list
 
 from minio import Minio
-from minio.credentials import (AWSConfigProvider, ChainedProvider,
-                               EnvAWSProvider, IamAwsProvider)
+from minio.credentials import (
+    AWSConfigProvider,
+    ChainedProvider,
+    EnvAWSProvider,
+    IamAwsProvider,
+)
 
 client = Minio(
     "s3.amazonaws.com",
@@ -30,7 +34,7 @@ client = Minio(
             AWSConfigProvider(),
             EnvAWSProvider(),
         ]
-    )
+    ),
 )
 
 # Get information of an object.

--- a/examples/minio_with_client_grants_provider.py
+++ b/examples/minio_with_client_grants_provider.py
@@ -38,7 +38,7 @@ def get_jwt(client_id, client_secret, idp_endpoint):
 
 # IDP endpoint.
 idp_endpoint = (
-    "https://IDP-HOST:IDP-PORT/auth/realms/master" "/protocol/openid-connect/token"
+    "https://IDP-HOST:IDP-PORT/auth/realms/master/protocol/openid-connect/token"
 )
 
 # Client-ID to fetch JWT.

--- a/examples/minio_with_client_grants_provider.py
+++ b/examples/minio_with_client_grants_provider.py
@@ -38,8 +38,7 @@ def get_jwt(client_id, client_secret, idp_endpoint):
 
 # IDP endpoint.
 idp_endpoint = (
-    "https://IDP-HOST:IDP-PORT/auth/realms/master"
-    "/protocol/openid-connect/token"
+    "https://IDP-HOST:IDP-PORT/auth/realms/master" "/protocol/openid-connect/token"
 )
 
 # Client-ID to fetch JWT.

--- a/examples/minio_with_client_grants_provider.py
+++ b/examples/minio_with_client_grants_provider.py
@@ -52,7 +52,8 @@ client_secret = "PASSWORD"
 sts_endpoint = "http://STS-HOST:STS-PORT/"
 
 provider = ClientGrantsProvider(
-    lambda: get_jwt(client_id, client_secret, idp_endpoint), sts_endpoint,
+    lambda: get_jwt(client_id, client_secret, idp_endpoint),
+    sts_endpoint,
 )
 
 client = Minio("MINIO-HOST:MINIO-PORT", credentials=provider)

--- a/examples/minio_with_minio_client_config_provider.py
+++ b/examples/minio_with_minio_client_config_provider.py
@@ -19,7 +19,8 @@ from minio import Minio
 from minio.credentials import MinioClientConfigProvider
 
 client = Minio(
-    "MINIO-HOST:MINIO-PORT", credentials=MinioClientConfigProvider(),
+    "MINIO-HOST:MINIO-PORT",
+    credentials=MinioClientConfigProvider(),
 )
 
 # Get information of an object.

--- a/examples/minio_with_web_identity_provider.py
+++ b/examples/minio_with_web_identity_provider.py
@@ -40,7 +40,7 @@ def get_jwt(client_id, client_secret, idp_client_id, idp_endpoint):
 
 # IDP endpoint.
 idp_endpoint = (
-    "https://IDP-HOST:IDP-PORT/auth/realms/master" "/protocol/openid-connect/token"
+    "https://IDP-HOST:IDP-PORT/auth/realms/master/protocol/openid-connect/token"
 )
 
 # Client-ID to fetch JWT.

--- a/examples/minio_with_web_identity_provider.py
+++ b/examples/minio_with_web_identity_provider.py
@@ -40,8 +40,7 @@ def get_jwt(client_id, client_secret, idp_client_id, idp_endpoint):
 
 # IDP endpoint.
 idp_endpoint = (
-    "https://IDP-HOST:IDP-PORT/auth/realms/master"
-    "/protocol/openid-connect/token"
+    "https://IDP-HOST:IDP-PORT/auth/realms/master" "/protocol/openid-connect/token"
 )
 
 # Client-ID to fetch JWT.

--- a/examples/presigned_get_object.py
+++ b/examples/presigned_get_object.py
@@ -32,6 +32,8 @@ print(url)
 # Get presigned URL string to download 'my-object' in
 # 'my-bucket' with two hours expiry.
 url = client.presigned_get_object(
-    "my-bucket", "my-object", expires=timedelta(hours=2),
+    "my-bucket",
+    "my-object",
+    expires=timedelta(hours=2),
 )
 print(url)

--- a/examples/presigned_post_policy.py
+++ b/examples/presigned_post_policy.py
@@ -26,10 +26,11 @@ client = Minio(
 )
 
 policy = PostPolicy(
-    "my-bucket", datetime.utcnow() + timedelta(days=10),
+    "my-bucket",
+    datetime.utcnow() + timedelta(days=10),
 )
 policy.add_starts_with_condition("key", "my/object/prefix/")
-policy.add_content_length_range_condition(1*1024*1024, 10*1024*1024)
+policy.add_content_length_range_condition(1 * 1024 * 1024, 10 * 1024 * 1024)
 
 form_data = client.presigned_post_policy(policy)
 

--- a/examples/presigned_put_object.py
+++ b/examples/presigned_put_object.py
@@ -32,6 +32,8 @@ print(url)
 # Get presigned URL string to upload data to 'my-object' in
 # 'my-bucket' with two hours expiry.
 url = client.presigned_put_object(
-    "my-bucket", "my-object", expires=timedelta(hours=2),
+    "my-bucket",
+    "my-object",
+    expires=timedelta(hours=2),
 )
 print(url)

--- a/examples/progress.py
+++ b/examples/progress.py
@@ -172,26 +172,19 @@ def format_string(current_size, total_length, elapsed_time):
     n_to_mb = current_size / _KILOBYTE / _KILOBYTE
     elapsed_str = seconds_to_time(elapsed_time)
 
-    rate = (
-        _RATE_FORMAT % (n_to_mb / elapsed_time)
-        if elapsed_time
-        else _UNKNOWN_SIZE
-    )
+    rate = _RATE_FORMAT % (n_to_mb / elapsed_time) if elapsed_time else _UNKNOWN_SIZE
     frac = float(current_size) / total_length
     bar_length = int(frac * _BAR_SIZE)
     bar = _FINISHED_BAR * bar_length + _REMAINING_BAR * (_BAR_SIZE - bar_length)
     percentage = _PERCENTAGE_FORMAT % (frac * 100)
     left_str = (
-        seconds_to_time(
-            elapsed_time / current_size * (total_length - current_size)
-        )
+        seconds_to_time(elapsed_time / current_size * (total_length - current_size))
         if current_size
         else _UNKNOWN_SIZE
     )
 
     humanized_total = (
-        _HUMANINZED_FORMAT % (total_length / _KILOBYTE / _KILOBYTE)
-        + _STR_MEGABYTE
+        _HUMANINZED_FORMAT % (total_length / _KILOBYTE / _KILOBYTE) + _STR_MEGABYTE
     )
     humanized_n = _HUMANINZED_FORMAT % n_to_mb + _STR_MEGABYTE
 

--- a/examples/progress.py
+++ b/examples/progress.py
@@ -29,31 +29,31 @@ from threading import Thread
 
 _BAR_SIZE = 20
 _KILOBYTE = 1024
-_FINISHED_BAR = '#'
-_REMAINING_BAR = '-'
+_FINISHED_BAR = "#"
+_REMAINING_BAR = "-"
 
-_UNKNOWN_SIZE = '?'
-_STR_MEGABYTE = ' MB'
+_UNKNOWN_SIZE = "?"
+_STR_MEGABYTE = " MB"
 
-_HOURS_OF_ELAPSED = '%d:%02d:%02d'
-_MINUTES_OF_ELAPSED = '%02d:%02d'
+_HOURS_OF_ELAPSED = "%d:%02d:%02d"
+_MINUTES_OF_ELAPSED = "%02d:%02d"
 
-_RATE_FORMAT = '%5.2f'
-_PERCENTAGE_FORMAT = '%3d%%'
-_HUMANINZED_FORMAT = '%0.2f'
+_RATE_FORMAT = "%5.2f"
+_PERCENTAGE_FORMAT = "%3d%%"
+_HUMANINZED_FORMAT = "%0.2f"
 
-_DISPLAY_FORMAT = '|%s| %s/%s %s [elapsed: %s left: %s, %s MB/sec]'
+_DISPLAY_FORMAT = "|%s| %s/%s %s [elapsed: %s left: %s, %s MB/sec]"
 
-_REFRESH_CHAR = '\r'
+_REFRESH_CHAR = "\r"
 
 
 class Progress(Thread):
     """
-        Constructs a :class:`Progress` object.
-        :param interval: Sets the time interval to be displayed on the screen.
-        :param stdout: Sets the standard output
+    Constructs a :class:`Progress` object.
+    :param interval: Sets the time interval to be displayed on the screen.
+    :param stdout: Sets the standard output
 
-        :return: :class:`Progress` object
+    :return: :class:`Progress` object
     """
 
     def __init__(self, interval=1, stdout=sys.stdout):
@@ -80,7 +80,7 @@ class Progress(Thread):
         """
         self.total_length = total_length
         self.object_name = object_name
-        self.prefix = self.object_name + ': ' if self.object_name else ''
+        self.prefix = self.object_name + ": " if self.object_name else ""
 
     def run(self):
         displayed_time = 0
@@ -92,18 +92,22 @@ class Progress(Thread):
                 elapsed_time = time.time() - self.initial_time
                 if elapsed_time > displayed_time:
                     displayed_time = elapsed_time
-                self.print_status(current_size=self.current_size,
-                                  total_length=self.total_length,
-                                  displayed_time=displayed_time,
-                                  prefix=self.prefix)
+                self.print_status(
+                    current_size=self.current_size,
+                    total_length=self.total_length,
+                    displayed_time=displayed_time,
+                    prefix=self.prefix,
+                )
                 continue
 
             current_size, total_length = task
             displayed_time = time.time() - self.initial_time
-            self.print_status(current_size=current_size,
-                              total_length=total_length,
-                              displayed_time=displayed_time,
-                              prefix=self.prefix)
+            self.print_status(
+                current_size=current_size,
+                total_length=total_length,
+                displayed_time=displayed_time,
+                prefix=self.prefix,
+            )
             self.display_queue.task_done()
             if current_size == total_length:
                 # once we have done uploading everything return
@@ -117,8 +121,10 @@ class Progress(Thread):
                      bytes.
         """
         if not isinstance(size, int):
-            raise ValueError('{} type can not be displayed. '
-                             'Please change it to Int.'.format(type(size)))
+            raise ValueError(
+                "{} type can not be displayed. "
+                "Please change it to Int.".format(type(size))
+            )
 
         self.current_size += size
         self.display_queue.put((self.current_size, self.total_length))
@@ -131,9 +137,13 @@ class Progress(Thread):
 
     def print_status(self, current_size, total_length, displayed_time, prefix):
         formatted_str = prefix + format_string(
-            current_size, total_length, displayed_time)
-        self.stdout.write(_REFRESH_CHAR + formatted_str + ' ' *
-                          max(self.last_printed_len - len(formatted_str), 0))
+            current_size, total_length, displayed_time
+        )
+        self.stdout.write(
+            _REFRESH_CHAR
+            + formatted_str
+            + " " * max(self.last_printed_len - len(formatted_str), 0)
+        )
         self.stdout.flush()
         self.last_printed_len = len(formatted_str)
 
@@ -162,21 +172,35 @@ def format_string(current_size, total_length, elapsed_time):
     n_to_mb = current_size / _KILOBYTE / _KILOBYTE
     elapsed_str = seconds_to_time(elapsed_time)
 
-    rate = _RATE_FORMAT % (
-        n_to_mb / elapsed_time) if elapsed_time else _UNKNOWN_SIZE
+    rate = (
+        _RATE_FORMAT % (n_to_mb / elapsed_time)
+        if elapsed_time
+        else _UNKNOWN_SIZE
+    )
     frac = float(current_size) / total_length
     bar_length = int(frac * _BAR_SIZE)
-    bar = (_FINISHED_BAR * bar_length +
-           _REMAINING_BAR * (_BAR_SIZE - bar_length))
+    bar = _FINISHED_BAR * bar_length + _REMAINING_BAR * (_BAR_SIZE - bar_length)
     percentage = _PERCENTAGE_FORMAT % (frac * 100)
     left_str = (
         seconds_to_time(
-            elapsed_time / current_size * (total_length - current_size))
-        if current_size else _UNKNOWN_SIZE)
+            elapsed_time / current_size * (total_length - current_size)
+        )
+        if current_size
+        else _UNKNOWN_SIZE
+    )
 
-    humanized_total = _HUMANINZED_FORMAT % (
-        total_length / _KILOBYTE / _KILOBYTE) + _STR_MEGABYTE
+    humanized_total = (
+        _HUMANINZED_FORMAT % (total_length / _KILOBYTE / _KILOBYTE)
+        + _STR_MEGABYTE
+    )
     humanized_n = _HUMANINZED_FORMAT % n_to_mb + _STR_MEGABYTE
 
-    return _DISPLAY_FORMAT % (bar, humanized_n, humanized_total, percentage,
-                              elapsed_str, left_str, rate)
+    return _DISPLAY_FORMAT % (
+        bar,
+        humanized_n,
+        humanized_total,
+        percentage,
+        elapsed_str,
+        left_str,
+        rate,
+    )

--- a/examples/put_object.py
+++ b/examples/put_object.py
@@ -32,11 +32,16 @@ client = Minio(
 
 # Upload data.
 result = client.put_object(
-    "my-bucket", "my-object", io.BytesIO(b"hello"), 5,
+    "my-bucket",
+    "my-object",
+    io.BytesIO(b"hello"),
+    5,
 )
 print(
     "created {0} object; etag: {1}, version-id: {2}".format(
-        result.object_name, result.etag, result.version_id,
+        result.object_name,
+        result.etag,
+        result.version_id,
     ),
 )
 
@@ -45,94 +50,138 @@ data = urlopen(
     "https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.4.81.tar.xz",
 )
 result = client.put_object(
-    "my-bucket", "my-object", data, length=-1, part_size=10*1024*1024,
+    "my-bucket",
+    "my-object",
+    data,
+    length=-1,
+    part_size=10 * 1024 * 1024,
 )
 print(
     "created {0} object; etag: {1}, version-id: {2}".format(
-        result.object_name, result.etag, result.version_id,
+        result.object_name,
+        result.etag,
+        result.version_id,
     ),
 )
 
 # Upload data with content-type.
 result = client.put_object(
-    "my-bucket", "my-object", io.BytesIO(b"hello"), 5,
+    "my-bucket",
+    "my-object",
+    io.BytesIO(b"hello"),
+    5,
     content_type="application/csv",
 )
 print(
     "created {0} object; etag: {1}, version-id: {2}".format(
-        result.object_name, result.etag, result.version_id,
+        result.object_name,
+        result.etag,
+        result.version_id,
     ),
 )
 
 # Upload data with metadata.
 result = client.put_object(
-    "my-bucket", "my-object", io.BytesIO(b"hello"), 5,
+    "my-bucket",
+    "my-object",
+    io.BytesIO(b"hello"),
+    5,
     metadata={"My-Project": "one"},
 )
 print(
     "created {0} object; etag: {1}, version-id: {2}".format(
-        result.object_name, result.etag, result.version_id,
+        result.object_name,
+        result.etag,
+        result.version_id,
     ),
 )
 
 # Upload data with customer key type of server-side encryption.
 result = client.put_object(
-    "my-bucket", "my-object", io.BytesIO(b"hello"), 5,
+    "my-bucket",
+    "my-object",
+    io.BytesIO(b"hello"),
+    5,
     sse=SseCustomerKey(b"32byteslongsecretkeymustprovided"),
 )
 print(
     "created {0} object; etag: {1}, version-id: {2}".format(
-        result.object_name, result.etag, result.version_id,
+        result.object_name,
+        result.etag,
+        result.version_id,
     ),
 )
 
 # Upload data with KMS type of server-side encryption.
 result = client.put_object(
-    "my-bucket", "my-object", io.BytesIO(b"hello"), 5,
+    "my-bucket",
+    "my-object",
+    io.BytesIO(b"hello"),
+    5,
     sse=SseKMS("KMS-KEY-ID", {"Key1": "Value1", "Key2": "Value2"}),
 )
 print(
     "created {0} object; etag: {1}, version-id: {2}".format(
-        result.object_name, result.etag, result.version_id,
+        result.object_name,
+        result.etag,
+        result.version_id,
     ),
 )
 
 # Upload data with S3 type of server-side encryption.
 result = client.put_object(
-    "my-bucket", "my-object", io.BytesIO(b"hello"), 5,
+    "my-bucket",
+    "my-object",
+    io.BytesIO(b"hello"),
+    5,
     sse=SseS3(),
 )
 print(
     "created {0} object; etag: {1}, version-id: {2}".format(
-        result.object_name, result.etag, result.version_id,
+        result.object_name,
+        result.etag,
+        result.version_id,
     ),
 )
 
 # Upload data with tags, retention and legal-hold.
 date = datetime.utcnow().replace(
-    hour=0, minute=0, second=0, microsecond=0,
+    hour=0,
+    minute=0,
+    second=0,
+    microsecond=0,
 ) + timedelta(days=30)
 tags = Tags(for_object=True)
 tags["User"] = "jsmith"
 result = client.put_object(
-    "my-bucket", "my-object", io.BytesIO(b"hello"), 5,
+    "my-bucket",
+    "my-object",
+    io.BytesIO(b"hello"),
+    5,
     tags=tags,
     retention=Retention(GOVERNANCE, date),
     legal_hold=True,
 )
 print(
     "created {0} object; etag: {1}, version-id: {2}".format(
-        result.object_name, result.etag, result.version_id,
+        result.object_name,
+        result.etag,
+        result.version_id,
     ),
 )
 
 # Upload data with progress bar.
 result = client.put_object(
-    "my-bucket", "my-object", io.BytesIO(b"hello"), 5,
+    "my-bucket",
+    "my-object",
+    io.BytesIO(b"hello"),
+    5,
     progress=Progress(),
 )
 print(
     "created {0} object; etag: {1}, version-id: {2}".format(
-        result.object_name, result.etag, result.version_id,
+        result.object_name,
+        result.etag,
+        result.version_id,
     ),
 )

--- a/examples/remove_object.py
+++ b/examples/remove_object.py
@@ -27,6 +27,7 @@ client.remove_object("my-bucket", "my-object")
 
 # Remove version of an object.
 client.remove_object(
-    "my-bucket", "my-object",
+    "my-bucket",
+    "my-object",
     version_id="dfbd25b3-abec-4184-a4e8-5a35a5c1174d",
 )

--- a/examples/select_object_content.py
+++ b/examples/select_object_content.py
@@ -16,11 +16,7 @@
 
 
 from minio import Minio
-from minio.select import (
-    CSVInputSerialization,
-    CSVOutputSerialization,
-    SelectRequest,
-)
+from minio.select import CSVInputSerialization, CSVOutputSerialization, SelectRequest
 
 client = Minio(
     "play.min.io",

--- a/examples/select_object_content.py
+++ b/examples/select_object_content.py
@@ -16,8 +16,11 @@
 
 
 from minio import Minio
-from minio.select import (CSVInputSerialization, CSVOutputSerialization,
-                          SelectRequest)
+from minio.select import (
+    CSVInputSerialization,
+    CSVOutputSerialization,
+    SelectRequest,
+)
 
 client = Minio(
     "play.min.io",
@@ -26,14 +29,14 @@ client = Minio(
 )
 
 with client.select_object_content(
-        "my-bucket",
-        "my-object.csv",
-        SelectRequest(
-            "select * from S3Object",
-            CSVInputSerialization(),
-            CSVOutputSerialization(),
-            request_progress=True,
-        ),
+    "my-bucket",
+    "my-object.csv",
+    SelectRequest(
+        "select * from S3Object",
+        CSVInputSerialization(),
+        CSVOutputSerialization(),
+        request_progress=True,
+    ),
 ) as result:
     for data in result.stream():
         print(data.decode())

--- a/examples/set_bucket_encryption.py
+++ b/examples/set_bucket_encryption.py
@@ -24,5 +24,6 @@ client = Minio(
 )
 
 client.set_bucket_encryption(
-    "my-bucket", SSEConfig(Rule.new_sse_s3_rule()),
+    "my-bucket",
+    SSEConfig(Rule.new_sse_s3_rule()),
 )

--- a/examples/set_bucket_notification.py
+++ b/examples/set_bucket_notification.py
@@ -15,11 +15,7 @@
 # limitations under the License.
 
 from minio import Minio
-from minio.notificationconfig import (
-    NotificationConfig,
-    PrefixFilterRule,
-    QueueConfig,
-)
+from minio.notificationconfig import NotificationConfig, PrefixFilterRule, QueueConfig
 
 client = Minio(
     "play.min.io",

--- a/examples/set_bucket_notification.py
+++ b/examples/set_bucket_notification.py
@@ -15,8 +15,11 @@
 # limitations under the License.
 
 from minio import Minio
-from minio.notificationconfig import (NotificationConfig, PrefixFilterRule,
-                                      QueueConfig)
+from minio.notificationconfig import (
+    NotificationConfig,
+    PrefixFilterRule,
+    QueueConfig,
+)
 
 client = Minio(
     "play.min.io",

--- a/examples/set_bucket_replication.py
+++ b/examples/set_bucket_replication.py
@@ -16,8 +16,12 @@
 
 from minio import Minio
 from minio.commonconfig import DISABLED, ENABLED, AndOperator, Filter
-from minio.replicationconfig import (DeleteMarkerReplication, Destination,
-                                     ReplicationConfig, Rule)
+from minio.replicationconfig import (
+    DeleteMarkerReplication,
+    Destination,
+    ReplicationConfig,
+    Rule,
+)
 
 client = Minio(
     "play.min.io",

--- a/examples/stat_object.py
+++ b/examples/stat_object.py
@@ -27,28 +27,33 @@ client = Minio(
 result = client.stat_object("my-bucket", "my-object")
 print(
     "last-modified: {0}, size: {1}".format(
-        result.last_modified, result.size,
+        result.last_modified,
+        result.size,
     ),
 )
 
 # Get object information of version-ID.
 result = client.stat_object(
-    "my-bucket", "my-object",
+    "my-bucket",
+    "my-object",
     version_id="dfbd25b3-abec-4184-a4e8-5a35a5c1174d",
 )
 print(
     "last-modified: {0}, size: {1}".format(
-        result.last_modified, result.size,
+        result.last_modified,
+        result.size,
     ),
 )
 
 # Get SSE-C encrypted object information.
 result = client.stat_object(
-    "my-bucket", "my-object",
+    "my-bucket",
+    "my-object",
     ssec=SseCustomerKey(b"32byteslongsecretkeymustprovided"),
 )
 print(
     "last-modified: {0}, size: {1}".format(
-        result.last_modified, result.size,
+        result.last_modified,
+        result.size,
     ),
 )

--- a/examples/upload_snowball_objects.py
+++ b/examples/upload_snowball_objects.py
@@ -31,10 +31,14 @@ client.upload_snowball_objects(
     [
         SnowballObject("my-object1", filename="/etc/hostname"),
         SnowballObject(
-            "my-object2", data=io.BytesIO(b"hello"), length=5,
+            "my-object2",
+            data=io.BytesIO(b"hello"),
+            length=5,
         ),
         SnowballObject(
-            "my-object3", data=io.BytesIO(b"world"), length=5,
+            "my-object3",
+            data=io.BytesIO(b"world"),
+            length=5,
             mod_time=datetime.now(),
         ),
     ],

--- a/minio/api.py
+++ b/minio/api.py
@@ -151,7 +151,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         # Validate http client has correct base class.
         if http_client and not isinstance(http_client, urllib3.poolmanager.PoolManager):
             raise ValueError(
-                "HTTP client should be instance of " "`urllib3.poolmanager.PoolManager`"
+                "HTTP client should be instance of `urllib3.poolmanager.PoolManager`"
             )
 
         self._region_map = {}

--- a/minio/api.py
+++ b/minio/api.py
@@ -91,8 +91,7 @@ from .versioningconfig import VersioningConfig
 from .xml import Element, SubElement, findtext, getbytes, marshal, unmarshal
 
 _DEFAULT_USER_AGENT = (
-    f"MinIO ({platform.system()}; {platform.machine()}) "
-    f"{__title__}/{__version__}"
+    f"MinIO ({platform.system()}; {platform.machine()}) " f"{__title__}/{__version__}"
 )
 
 
@@ -150,12 +149,9 @@ class Minio:  # pylint: disable=too-many-public-methods
         cert_check=True,
     ):
         # Validate http client has correct base class.
-        if http_client and not isinstance(
-            http_client, urllib3.poolmanager.PoolManager
-        ):
+        if http_client and not isinstance(http_client, urllib3.poolmanager.PoolManager):
             raise ValueError(
-                "HTTP client should be instance of "
-                "`urllib3.poolmanager.PoolManager`"
+                "HTTP client should be instance of " "`urllib3.poolmanager.PoolManager`"
             )
 
         self._region_map = {}
@@ -633,23 +629,16 @@ class Minio:  # pylint: disable=too-many-public-methods
             # Create bucket with object-lock feature on specific region.
             client.make_bucket("my-bucket", "eu-west-2", object_lock=True)
         """
-        check_bucket_name(
-            bucket_name, True, s3_check=self._base_url.is_aws_host
-        )
+        check_bucket_name(bucket_name, True, s3_check=self._base_url.is_aws_host)
         if self._base_url.region:
             # Error out if region does not match with region passed via
             # constructor.
             if location and self._base_url.region != location:
                 raise ValueError(
-                    f"region must be {self._base_url.region}, "
-                    f"but passed {location}"
+                    f"region must be {self._base_url.region}, " f"but passed {location}"
                 )
         location = self._base_url.region or location or "us-east-1"
-        headers = (
-            {"x-amz-bucket-object-lock-enabled": "true"}
-            if object_lock
-            else None
-        )
+        headers = {"x-amz-bucket-object-lock-enabled": "true"} if object_lock else None
 
         body = None
         if location != "us-east-1":
@@ -1541,11 +1530,7 @@ class Minio:  # pylint: disable=too-many-public-methods
             raise ValueError("retention must be Retention type")
 
         part_count = self._calc_part_count(sources)
-        if (
-            part_count == 1
-            and sources[0].offset is None
-            and sources[0].length is None
-        ):
+        if part_count == 1 and sources[0].offset is None and sources[0].length is None:
             return self.copy_object(
                 bucket_name,
                 object_name,
@@ -1690,9 +1675,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         element = ET.fromstring(response.data.decode())
         return findtext(element, "UploadId")
 
-    def _put_object(
-        self, bucket_name, object_name, data, headers, query_params=None
-    ):
+    def _put_object(self, bucket_name, object_name, data, headers, query_params=None):
         """Execute PutObject S3 API."""
         response = self._execute(
             "PUT",
@@ -2309,9 +2292,7 @@ class Minio:  # pylint: disable=too-many-public-methods
             extra_query_params=extra_query_params,
         )
 
-    def presigned_put_object(
-        self, bucket_name, object_name, expires=timedelta(days=7)
-    ):
+    def presigned_put_object(self, bucket_name, object_name, expires=timedelta(days=7)):
         """
         Get presigned URL of an object to upload data with expiry time and
         custom request parameters.
@@ -2365,9 +2346,7 @@ class Minio:  # pylint: disable=too-many-public-methods
             raise ValueError(
                 "anonymous access does not require presigned post form-data",
             )
-        check_bucket_name(
-            policy.bucket_name, s3_check=self._base_url.is_aws_host
-        )
+        check_bucket_name(policy.bucket_name, s3_check=self._base_url.is_aws_host)
         return policy.form_data(
             self._provider.retrieve(),
             self._get_region(policy.bucket_name),
@@ -2777,9 +2756,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         Example::
             client.delete_object_lock_config("my-bucket")
         """
-        self.set_object_lock_config(
-            bucket_name, ObjectLockConfig(None, None, None)
-        )
+        self.set_object_lock_config(bucket_name, ObjectLockConfig(None, None, None))
 
     def get_object_lock_config(self, bucket_name):
         """

--- a/minio/api.py
+++ b/minio/api.py
@@ -41,18 +41,41 @@ from urllib3._collections import HTTPHeaderDict
 from . import __title__, __version__, time
 from .commonconfig import COPY, REPLACE, ComposeSource, CopySource, Tags
 from .credentials import StaticProvider
-from .datatypes import (CompleteMultipartUploadResult, EventIterable,
-                        ListAllMyBucketsResult, ListMultipartUploadsResult,
-                        ListPartsResult, Object, Part, PostPolicy,
-                        parse_copy_object, parse_list_objects)
+from .datatypes import (
+    CompleteMultipartUploadResult,
+    EventIterable,
+    ListAllMyBucketsResult,
+    ListMultipartUploadsResult,
+    ListPartsResult,
+    Object,
+    Part,
+    PostPolicy,
+    parse_copy_object,
+    parse_list_objects,
+)
 from .deleteobjects import DeleteError, DeleteRequest, DeleteResult
 from .error import InvalidResponseError, S3Error, ServerError
-from .helpers import (MAX_MULTIPART_COUNT, MAX_MULTIPART_OBJECT_SIZE,
-                      MAX_PART_SIZE, MIN_PART_SIZE, BaseURL, ObjectWriteResult,
-                      ThreadPool, check_bucket_name, check_non_empty_string,
-                      check_sse, check_ssec, genheaders, get_part_info,
-                      headers_to_strings, is_valid_policy_type, makedirs,
-                      md5sum_hash, read_part_data, sha256_hash)
+from .helpers import (
+    MAX_MULTIPART_COUNT,
+    MAX_MULTIPART_OBJECT_SIZE,
+    MAX_PART_SIZE,
+    MIN_PART_SIZE,
+    BaseURL,
+    ObjectWriteResult,
+    ThreadPool,
+    check_bucket_name,
+    check_non_empty_string,
+    check_sse,
+    check_ssec,
+    genheaders,
+    get_part_info,
+    headers_to_strings,
+    is_valid_policy_type,
+    makedirs,
+    md5sum_hash,
+    read_part_data,
+    sha256_hash,
+)
 from .legalhold import LegalHold
 from .lifecycleconfig import LifecycleConfig
 from .notificationconfig import NotificationConfig
@@ -114,18 +137,22 @@ class Minio:  # pylint: disable=too-many-public-methods
     """
 
     # pylint: disable=too-many-function-args
-    def __init__(self, endpoint, access_key=None,
-                 secret_key=None,
-                 session_token=None,
-                 secure=True,
-                 region=None,
-                 http_client=None,
-                 credentials=None,
-                 cert_check=True):
+    def __init__(
+        self,
+        endpoint,
+        access_key=None,
+        secret_key=None,
+        session_token=None,
+        secure=True,
+        region=None,
+        http_client=None,
+        credentials=None,
+        cert_check=True,
+    ):
         # Validate http client has correct base class.
         if http_client and not isinstance(
-                http_client,
-                urllib3.poolmanager.PoolManager):
+            http_client, urllib3.poolmanager.PoolManager
+        ):
             raise ValueError(
                 "HTTP client should be instance of "
                 "`urllib3.poolmanager.PoolManager`"
@@ -147,20 +174,24 @@ class Minio:  # pylint: disable=too-many-public-methods
         self._http = http_client or urllib3.PoolManager(
             timeout=urllib3.util.Timeout(connect=timeout, read=timeout),
             maxsize=10,
-            cert_reqs='CERT_REQUIRED' if cert_check else 'CERT_NONE',
-            ca_certs=os.environ.get('SSL_CERT_FILE') or certifi.where(),
+            cert_reqs="CERT_REQUIRED" if cert_check else "CERT_NONE",
+            ca_certs=os.environ.get("SSL_CERT_FILE") or certifi.where(),
             retries=urllib3.Retry(
                 total=5,
                 backoff_factor=0.2,
-                status_forcelist=[500, 502, 503, 504]
-            )
+                status_forcelist=[500, 502, 503, 504],
+            ),
         )
 
     def __del__(self):
         self._http.clear()
 
     def _handle_redirect_response(
-            self, method, bucket_name, response, retry=False,
+        self,
+        method,
+        bucket_name,
+        response,
+        retry=False,
     ):
         """
         Handle redirect response indicates whether retry HEAD request
@@ -176,8 +207,11 @@ class Minio:  # pylint: disable=too-many-public-methods
             message += "; use region " + region
 
         if (
-                retry and region and method == "HEAD" and bucket_name and
-                self._region_map.get(bucket_name)
+            retry
+            and region
+            and method == "HEAD"
+            and bucket_name
+            and self._region_map.get(bucket_name)
         ):
             code, message = ("RetryHead", None)
 
@@ -213,16 +247,16 @@ class Minio:  # pylint: disable=too-many-public-methods
         return headers, date
 
     def _url_open(  # pylint: disable=too-many-branches
-            self,
-            method,
-            region,
-            bucket_name=None,
-            object_name=None,
-            body=None,
-            headers=None,
-            query_params=None,
-            preload_content=True,
-            no_body_trace=False,
+        self,
+        method,
+        region,
+        bucket_name=None,
+        object_name=None,
+        body=None,
+        headers=None,
+        query_params=None,
+        preload_content=True,
+        no_body_trace=False,
     ):
         """Execute HTTP request."""
         creds = self._provider.retrieve() if self._provider else None
@@ -300,12 +334,10 @@ class Minio:  # pylint: disable=too-many-public-methods
             self._trace_stream.write(response.data.decode())
             self._trace_stream.write("\n")
 
-        if (
-                method != "HEAD" and
-                "application/xml" not in response.headers.get(
-                    "content-type", "",
-                ).split(";")
-        ):
+        if method != "HEAD" and "application/xml" not in response.headers.get(
+            "content-type",
+            "",
+        ).split(";"):
             if self._trace_stream:
                 self._trace_stream.write("----------END-HTTP----------\n")
             if response.status == 304 and not response.data:
@@ -335,13 +367,22 @@ class Minio:  # pylint: disable=too-many-public-methods
 
         error_map = {
             301: lambda: self._handle_redirect_response(
-                method, bucket_name, response, True,
+                method,
+                bucket_name,
+                response,
+                True,
             ),
             307: lambda: self._handle_redirect_response(
-                method, bucket_name, response, True,
+                method,
+                bucket_name,
+                response,
+                True,
             ),
             400: lambda: self._handle_redirect_response(
-                method, bucket_name, response, True,
+                method,
+                bucket_name,
+                response,
+                True,
             ),
             403: lambda: ("AccessDenied", "Access denied"),
             404: lambda: (
@@ -391,15 +432,15 @@ class Minio:  # pylint: disable=too-many-public-methods
         raise response_error
 
     def _execute(
-            self,
-            method,
-            bucket_name=None,
-            object_name=None,
-            body=None,
-            headers=None,
-            query_params=None,
-            preload_content=True,
-            no_body_trace=False,
+        self,
+        method,
+        bucket_name=None,
+        object_name=None,
+        body=None,
+        headers=None,
+        query_params=None,
+        preload_content=True,
+        no_body_trace=False,
     ):
         """Execute HTTP request."""
         region = self._get_region(bucket_name)
@@ -438,7 +479,9 @@ class Minio:  # pylint: disable=too-many-public-methods
                 raise
 
             code, message = self._handle_redirect_response(
-                method, bucket_name, exc.response,
+                method,
+                bucket_name,
+                exc.response,
             )
             raise exc.copy(code, message)
 
@@ -498,7 +541,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         :param stream: Stream for writing HTTP call tracing.
         """
         if not stream:
-            raise ValueError('Input stream for trace output is invalid.')
+            raise ValueError("Input stream for trace output is invalid.")
         # Save new output stream.
         self._trace_stream = stream
 
@@ -590,8 +633,9 @@ class Minio:  # pylint: disable=too-many-public-methods
             # Create bucket with object-lock feature on specific region.
             client.make_bucket("my-bucket", "eu-west-2", object_lock=True)
         """
-        check_bucket_name(bucket_name, True,
-                          s3_check=self._base_url.is_aws_host)
+        check_bucket_name(
+            bucket_name, True, s3_check=self._base_url.is_aws_host
+        )
         if self._base_url.region:
             # Error out if region does not match with region passed via
             # constructor.
@@ -603,7 +647,8 @@ class Minio:  # pylint: disable=too-many-public-methods
         location = self._base_url.region or location or "us-east-1"
         headers = (
             {"x-amz-bucket-object-lock-enabled": "true"}
-            if object_lock else None
+            if object_lock
+            else None
         )
 
         body = None
@@ -683,7 +728,9 @@ class Minio:  # pylint: disable=too-many-public-methods
         """
         check_bucket_name(bucket_name, s3_check=self._base_url.is_aws_host)
         response = self._execute(
-            "GET", bucket_name, query_params={"policy": ""},
+            "GET",
+            bucket_name,
+            query_params={"policy": ""},
         )
         return response.data.decode()
 
@@ -731,7 +778,9 @@ class Minio:  # pylint: disable=too-many-public-methods
         """
         check_bucket_name(bucket_name, s3_check=self._base_url.is_aws_host)
         response = self._execute(
-            "GET", bucket_name, query_params={"notification": ""},
+            "GET",
+            bucket_name,
+            query_params={"notification": ""},
         )
         return unmarshal(NotificationConfig, response.data.decode())
 
@@ -846,10 +895,17 @@ class Minio:  # pylint: disable=too-many-public-methods
             if exc.code != "ServerSideEncryptionConfigurationNotFoundError":
                 raise
 
-    def listen_bucket_notification(self, bucket_name, prefix='', suffix='',
-                                   events=('s3:ObjectCreated:*',
-                                           's3:ObjectRemoved:*',
-                                           's3:ObjectAccessed:*')):
+    def listen_bucket_notification(
+        self,
+        bucket_name,
+        prefix="",
+        suffix="",
+        events=(
+            "s3:ObjectCreated:*",
+            "s3:ObjectRemoved:*",
+            "s3:ObjectAccessed:*",
+        ),
+    ):
         """
         Listen events of object prefix and suffix of a bucket. Caller should
         iterate returned iterator to read new events.
@@ -931,11 +987,21 @@ class Minio:  # pylint: disable=too-many-public-methods
         )
         return unmarshal(VersioningConfig, response.data.decode())
 
-    def fput_object(self, bucket_name, object_name, file_path,
-                    content_type="application/octet-stream",
-                    metadata=None, sse=None, progress=None,
-                    part_size=0, num_parallel_uploads=3,
-                    tags=None, retention=None, legal_hold=False):
+    def fput_object(
+        self,
+        bucket_name,
+        object_name,
+        file_path,
+        content_type="application/octet-stream",
+        metadata=None,
+        sse=None,
+        progress=None,
+        part_size=0,
+        num_parallel_uploads=3,
+        tags=None,
+        retention=None,
+        legal_hold=False,
+    ):
         """
         Uploads data from a file to an object in a bucket.
 
@@ -983,16 +1049,33 @@ class Minio:  # pylint: disable=too-many-public-methods
         file_size = os.stat(file_path).st_size
         with open(file_path, "rb") as file_data:
             return self.put_object(
-                bucket_name, object_name, file_data, file_size,
+                bucket_name,
+                object_name,
+                file_data,
+                file_size,
                 content_type=content_type,
-                metadata=metadata, sse=sse, progress=progress,
-                part_size=part_size, num_parallel_uploads=num_parallel_uploads,
-                tags=tags, retention=retention, legal_hold=legal_hold,
+                metadata=metadata,
+                sse=sse,
+                progress=progress,
+                part_size=part_size,
+                num_parallel_uploads=num_parallel_uploads,
+                tags=tags,
+                retention=retention,
+                legal_hold=legal_hold,
             )
 
-    def fget_object(self, bucket_name, object_name, file_path,
-                    request_headers=None, ssec=None, version_id=None,
-                    extra_query_params=None, tmp_file_path=None, progress=None):
+    def fget_object(
+        self,
+        bucket_name,
+        object_name,
+        file_path,
+        request_headers=None,
+        ssec=None,
+        version_id=None,
+        extra_query_params=None,
+        tmp_file_path=None,
+        progress=None,
+    ):
         """
         Downloads data of an object to file.
 
@@ -1058,11 +1141,11 @@ class Minio:  # pylint: disable=too-many-public-methods
 
             if progress:
                 # Set progress bar length and object name before upload
-                length = int(response.headers.get('content-length', 0))
+                length = int(response.headers.get("content-length", 0))
                 progress.set_meta(object_name=object_name, total_length=length)
 
             with open(tmp_file_path, "wb") as tmp_file:
-                for data in response.stream(amt=1024*1024):
+                for data in response.stream(amt=1024 * 1024):
                     size = tmp_file.write(data)
                     if progress:
                         progress.update(size)
@@ -1075,9 +1158,17 @@ class Minio:  # pylint: disable=too-many-public-methods
                 response.close()
                 response.release_conn()
 
-    def get_object(self, bucket_name, object_name, offset=0, length=0,
-                   request_headers=None, ssec=None, version_id=None,
-                   extra_query_params=None):
+    def get_object(
+        self,
+        bucket_name,
+        object_name,
+        offset=0,
+        length=0,
+        request_headers=None,
+        ssec=None,
+        version_id=None,
+        extra_query_params=None,
+    ):
         """
         Get data of an object. Returned response should be closed after use to
         release network resources. To reuse the connection, it's required to
@@ -1144,7 +1235,7 @@ class Minio:  # pylint: disable=too-many-public-methods
 
         if offset or length:
             end = (offset + length - 1) if length else ""
-            headers['Range'] = f"bytes={offset}-{end}"
+            headers["Range"] = f"bytes={offset}-{end}"
 
         if version_id:
             extra_query_params = extra_query_params or {}
@@ -1159,10 +1250,19 @@ class Minio:  # pylint: disable=too-many-public-methods
             preload_content=False,
         )
 
-    def copy_object(self, bucket_name, object_name, source,
-                    sse=None, metadata=None, tags=None, retention=None,
-                    legal_hold=False, metadata_directive=None,
-                    tagging_directive=None):
+    def copy_object(
+        self,
+        bucket_name,
+        object_name,
+        source,
+        sse=None,
+        metadata=None,
+        tags=None,
+        retention=None,
+        legal_hold=False,
+        metadata_directive=None,
+        tagging_directive=None,
+    ):
         """
         Create an object by server-side copying data from another object.
         In this API maximum supported source object size is 5GiB.
@@ -1223,15 +1323,15 @@ class Minio:  # pylint: disable=too-many-public-methods
             raise ValueError("tags must be Tags type")
         if retention is not None and not isinstance(retention, Retention):
             raise ValueError("retention must be Retention type")
-        if (
-                metadata_directive is not None and
-                metadata_directive not in [COPY, REPLACE]
-        ):
+        if metadata_directive is not None and metadata_directive not in [
+            COPY,
+            REPLACE,
+        ]:
             raise ValueError(f"metadata directive must be {COPY} or {REPLACE}")
-        if (
-                tagging_directive is not None and
-                tagging_directive not in [COPY, REPLACE]
-        ):
+        if tagging_directive is not None and tagging_directive not in [
+            COPY,
+            REPLACE,
+        ]:
             raise ValueError(f"tagging directive must be {COPY} or {REPLACE}")
 
         size = -1
@@ -1245,9 +1345,9 @@ class Minio:  # pylint: disable=too-many-public-methods
             size = stat.size
 
         if (
-                source.offset is not None or
-                source.length is not None or
-                size > MAX_PART_SIZE
+            source.offset is not None
+            or source.length is not None
+            or size > MAX_PART_SIZE
         ):
             if metadata_directive == COPY:
                 raise ValueError(
@@ -1260,8 +1360,13 @@ class Minio:  # pylint: disable=too-many-public-methods
                     "object size greater than 5 GiB"
                 )
             return self.compose_object(
-                bucket_name, object_name, ComposeSource.of(source),
-                sse=sse, metadata=metadata, tags=tags, retention=retention,
+                bucket_name,
+                object_name,
+                ComposeSource.of(source),
+                sse=sse,
+                metadata=metadata,
+                tags=tags,
+                retention=retention,
                 legal_hold=legal_hold,
             )
 
@@ -1307,11 +1412,7 @@ class Minio:  # pylint: disable=too-many-public-methods
             elif src.offset is not None:
                 size -= src.offset
 
-            if (
-                    size < MIN_PART_SIZE and
-                    len(sources) != 1 and
-                    i != len(sources)
-            ):
+            if size < MIN_PART_SIZE and len(sources) != 1 and i != len(sources):
                 raise ValueError(
                     f"source {src.bucket_name}/{src.object_name}: size {size} "
                     f"must be greater than {MIN_PART_SIZE}"
@@ -1332,9 +1433,9 @@ class Minio:  # pylint: disable=too-many-public-methods
                 else:
                     last_part_size = MAX_PART_SIZE
                 if (
-                        last_part_size < MIN_PART_SIZE and
-                        len(sources) != 1 and
-                        i != len(sources)
+                    last_part_size < MIN_PART_SIZE
+                    and len(sources) != 1
+                    and i != len(sources)
                 ):
                     raise ValueError(
                         f"source {src.bucket_name}/{src.object_name}: "
@@ -1352,8 +1453,9 @@ class Minio:  # pylint: disable=too-many-public-methods
             )
         return part_count
 
-    def _upload_part_copy(self, bucket_name, object_name, upload_id,
-                          part_number, headers):
+    def _upload_part_copy(
+        self, bucket_name, object_name, upload_id, part_number, headers
+    ):
         """Execute UploadPartCopy S3 API."""
         query_params = {
             "partNumber": str(part_number),
@@ -1369,9 +1471,15 @@ class Minio:  # pylint: disable=too-many-public-methods
         return parse_copy_object(response)
 
     def compose_object(  # pylint: disable=too-many-branches
-            self, bucket_name, object_name, sources,
-            sse=None, metadata=None, tags=None, retention=None,
-            legal_hold=False,
+        self,
+        bucket_name,
+        object_name,
+        sources,
+        sse=None,
+        metadata=None,
+        tags=None,
+        retention=None,
+        legal_hold=False,
     ):
         """
         Create an object by combining data from different source objects using
@@ -1434,13 +1542,18 @@ class Minio:  # pylint: disable=too-many-public-methods
 
         part_count = self._calc_part_count(sources)
         if (
-                part_count == 1 and
-                sources[0].offset is None and
-                sources[0].length is None
+            part_count == 1
+            and sources[0].offset is None
+            and sources[0].length is None
         ):
             return self.copy_object(
-                bucket_name, object_name, CopySource.of(sources[0]),
-                sse=sse, metadata=metadata, tags=tags, retention=retention,
+                bucket_name,
+                object_name,
+                CopySource.of(sources[0]),
+                sse=sse,
+                metadata=metadata,
+                tags=tags,
+                retention=retention,
                 legal_hold=legal_hold,
                 metadata_directive=REPLACE if metadata else None,
                 tagging_directive=REPLACE if tags else None,
@@ -1448,7 +1561,9 @@ class Minio:  # pylint: disable=too-many-public-methods
 
         headers = genheaders(metadata, sse, tags, retention, legal_hold)
         upload_id = self._create_multipart_upload(
-            bucket_name, object_name, headers,
+            bucket_name,
+            object_name,
+            headers,
         )
         ssec_headers = sse.headers() if isinstance(sse, SseCustomerKey) else {}
         try:
@@ -1466,13 +1581,13 @@ class Minio:  # pylint: disable=too-many-public-methods
                 if size <= MAX_PART_SIZE:
                     part_number += 1
                     if src.length is not None:
-                        headers["x-amz-copy-source-range"] = (
-                            f"bytes={offset}-{offset+src.length-1}"
-                        )
+                        headers[
+                            "x-amz-copy-source-range"
+                        ] = f"bytes={offset}-{offset+src.length-1}"
                     elif src.offset is not None:
-                        headers["x-amz-copy-source-range"] = (
-                            f"bytes={offset}-{offset+size-1}"
-                        )
+                        headers[
+                            "x-amz-copy-source-range"
+                        ] = f"bytes={offset}-{offset+size-1}"
                     etag, _ = self._upload_part_copy(
                         bucket_name,
                         object_name,
@@ -1489,9 +1604,9 @@ class Minio:  # pylint: disable=too-many-public-methods
                     if size < MAX_PART_SIZE:
                         end_bytes = start_bytes + size
                     headers_copy = headers.copy()
-                    headers_copy["x-amz-copy-source-range"] = (
-                        f"bytes={start_bytes}-{end_bytes}"
-                    )
+                    headers_copy[
+                        "x-amz-copy-source-range"
+                    ] = f"bytes={start_bytes}-{end_bytes}"
                     etag, _ = self._upload_part_copy(
                         bucket_name,
                         object_name,
@@ -1503,7 +1618,10 @@ class Minio:  # pylint: disable=too-many-public-methods
                     offset = start_bytes
                     size -= end_bytes - start_bytes
             result = self._complete_multipart_upload(
-                bucket_name, object_name, upload_id, total_parts,
+                bucket_name,
+                object_name,
+                upload_id,
+                total_parts,
             )
             return ObjectWriteResult(
                 result.bucket_name,
@@ -1516,7 +1634,9 @@ class Minio:  # pylint: disable=too-many-public-methods
         except Exception as exc:
             if upload_id:
                 self._abort_multipart_upload(
-                    bucket_name, object_name, upload_id,
+                    bucket_name,
+                    object_name,
+                    upload_id,
                 )
             raise exc
 
@@ -1526,11 +1646,15 @@ class Minio:  # pylint: disable=too-many-public-methods
             "DELETE",
             bucket_name,
             object_name,
-            query_params={'uploadId': upload_id},
+            query_params={"uploadId": upload_id},
         )
 
     def _complete_multipart_upload(
-            self, bucket_name, object_name, upload_id, parts,
+        self,
+        bucket_name,
+        object_name,
+        upload_id,
+        parts,
     ):
         """Execute CompleteMultipartUpload S3 API."""
         element = Element("CompleteMultipartUpload")
@@ -1545,10 +1669,10 @@ class Minio:  # pylint: disable=too-many-public-methods
             object_name,
             body=body,
             headers={
-                "Content-Type": 'application/xml',
+                "Content-Type": "application/xml",
                 "Content-MD5": md5sum_hash(body),
             },
-            query_params={'uploadId': upload_id},
+            query_params={"uploadId": upload_id},
         )
         return CompleteMultipartUploadResult(response)
 
@@ -1566,8 +1690,9 @@ class Minio:  # pylint: disable=too-many-public-methods
         element = ET.fromstring(response.data.decode())
         return findtext(element, "UploadId")
 
-    def _put_object(self, bucket_name, object_name, data, headers,
-                    query_params=None):
+    def _put_object(
+        self, bucket_name, object_name, data, headers, query_params=None
+    ):
         """Execute PutObject S3 API."""
         response = self._execute(
             "PUT",
@@ -1586,15 +1711,20 @@ class Minio:  # pylint: disable=too-many-public-methods
             response.headers,
         )
 
-    def _upload_part(self, bucket_name, object_name, data, headers,
-                     upload_id, part_number):
+    def _upload_part(
+        self, bucket_name, object_name, data, headers, upload_id, part_number
+    ):
         """Execute UploadPart S3 API."""
         query_params = {
             "partNumber": str(part_number),
             "uploadId": upload_id,
         }
         result = self._put_object(
-            bucket_name, object_name, data, headers, query_params=query_params,
+            bucket_name,
+            object_name,
+            data,
+            headers,
+            query_params=query_params,
         )
         return result.etag
 
@@ -1602,11 +1732,22 @@ class Minio:  # pylint: disable=too-many-public-methods
         """Upload_part task for ThreadPool."""
         return args[5], self._upload_part(*args)
 
-    def put_object(self, bucket_name, object_name, data, length,
-                   content_type="application/octet-stream",
-                   metadata=None, sse=None, progress=None,
-                   part_size=0, num_parallel_uploads=3,
-                   tags=None, retention=None, legal_hold=False):
+    def put_object(
+        self,
+        bucket_name,
+        object_name,
+        data,
+        length,
+        content_type="application/octet-stream",
+        metadata=None,
+        sse=None,
+        progress=None,
+        part_size=0,
+        num_parallel_uploads=3,
+        tags=None,
+        retention=None,
+        legal_hold=False,
+    ):
         """
         Uploads data from a stream to an object in a bucket.
 
@@ -1687,7 +1828,9 @@ class Minio:  # pylint: disable=too-many-public-methods
                         part_size = object_size - uploaded_size
                         stop = True
                     part_data = read_part_data(
-                        data, part_size, progress=progress,
+                        data,
+                        part_size,
+                        progress=progress,
                     )
                     if len(part_data) != part_size:
                         raise IOError(
@@ -1697,7 +1840,10 @@ class Minio:  # pylint: disable=too-many-public-methods
                         )
                 else:
                     part_data = read_part_data(
-                        data, part_size + 1, one_byte, progress=progress,
+                        data,
+                        part_size + 1,
+                        one_byte,
+                        progress=progress,
                     )
                     # If part_data_size is less or equal to part_size,
                     # then we have reached last part.
@@ -1712,21 +1858,29 @@ class Minio:  # pylint: disable=too-many-public-methods
 
                 if part_count == 1:
                     return self._put_object(
-                        bucket_name, object_name, part_data, headers,
+                        bucket_name,
+                        object_name,
+                        part_data,
+                        headers,
                     )
 
                 if not upload_id:
                     upload_id = self._create_multipart_upload(
-                        bucket_name, object_name, headers,
+                        bucket_name,
+                        object_name,
+                        headers,
                     )
                     if num_parallel_uploads and num_parallel_uploads > 1:
                         pool = ThreadPool(num_parallel_uploads)
                         pool.start_parallel()
 
                 args = (
-                    bucket_name, object_name, part_data,
+                    bucket_name,
+                    object_name,
+                    part_data,
                     sse.headers() if isinstance(sse, SseCustomerKey) else None,
-                    upload_id, part_number,
+                    upload_id,
+                    part_number,
                 )
                 if num_parallel_uploads > 1:
                     pool.add_task(self._upload_part_task, args)
@@ -1739,10 +1893,13 @@ class Minio:  # pylint: disable=too-many-public-methods
                 parts = [None] * part_count
                 while not result.empty():
                     part_number, etag = result.get()
-                    parts[part_number-1] = Part(part_number, etag)
+                    parts[part_number - 1] = Part(part_number, etag)
 
             result = self._complete_multipart_upload(
-                bucket_name, object_name, upload_id, parts,
+                bucket_name,
+                object_name,
+                upload_id,
+                parts,
             )
             return ObjectWriteResult(
                 result.bucket_name,
@@ -1755,14 +1912,24 @@ class Minio:  # pylint: disable=too-many-public-methods
         except Exception as exc:
             if upload_id:
                 self._abort_multipart_upload(
-                    bucket_name, object_name, upload_id,
+                    bucket_name,
+                    object_name,
+                    upload_id,
                 )
             raise exc
 
-    def list_objects(self, bucket_name, prefix=None, recursive=False,
-                     start_after=None, include_user_meta=False,
-                     include_version=False, use_api_v1=False,
-                     use_url_encoding_type=True, fetch_owner=False):
+    def list_objects(
+        self,
+        bucket_name,
+        prefix=None,
+        recursive=False,
+        start_after=None,
+        include_user_meta=False,
+        include_version=False,
+        use_api_v1=False,
+        use_url_encoding_type=True,
+        fetch_owner=False,
+    ):
         """
         Lists object information of a bucket.
 
@@ -1823,8 +1990,14 @@ class Minio:  # pylint: disable=too-many-public-methods
             fetch_owner=fetch_owner,
         )
 
-    def stat_object(self, bucket_name, object_name, ssec=None, version_id=None,
-                    extra_query_params=None):
+    def stat_object(
+        self,
+        bucket_name,
+        object_name,
+        ssec=None,
+        version_id=None,
+        extra_query_params=None,
+    ):
         """
         Get object information and metadata of an object.
 
@@ -1909,8 +2082,13 @@ class Minio:  # pylint: disable=too-many-public-methods
             query_params={"versionId": version_id} if version_id else None,
         )
 
-    def _delete_objects(self, bucket_name, delete_object_list,
-                        quiet=False, bypass_governance_mode=False):
+    def _delete_objects(
+        self,
+        bucket_name,
+        delete_object_list,
+        quiet=False,
+        bypass_governance_mode=False,
+    ):
         """
         Delete multiple objects.
 
@@ -1940,8 +2118,9 @@ class Minio:  # pylint: disable=too-many-public-methods
             else unmarshal(DeleteResult, response.data.decode())
         )
 
-    def remove_objects(self, bucket_name, delete_object_list,
-                       bypass_governance_mode=False):
+    def remove_objects(
+        self, bucket_name, delete_object_list, bypass_governance_mode=False
+    ):
         """
         Remove multiple objects.
 
@@ -1984,8 +2163,10 @@ class Minio:  # pylint: disable=too-many-public-methods
         while True:
             # get 1000 entries or whatever available.
             objects = [
-                delete_object for _, delete_object in zip(
-                    range(1000), delete_object_list,
+                delete_object
+                for _, delete_object in zip(
+                    range(1000),
+                    delete_object_list,
                 )
             ]
 
@@ -2006,10 +2187,17 @@ class Minio:  # pylint: disable=too-many-public-methods
                 if error.code != "NoSuchVersion":
                     yield error
 
-    def get_presigned_url(self, method, bucket_name, object_name,
-                          expires=timedelta(days=7), response_headers=None,
-                          request_date=None, version_id=None,
-                          extra_query_params=None):
+    def get_presigned_url(
+        self,
+        method,
+        bucket_name,
+        object_name,
+        expires=timedelta(days=7),
+        response_headers=None,
+        request_date=None,
+        version_id=None,
+        extra_query_params=None,
+    ):
         """
         Get presigned URL of an object for HTTP method, expiry time and custom
         request parameters.
@@ -2070,12 +2258,16 @@ class Minio:  # pylint: disable=too-many-public-methods
             )
         return urlunsplit(url)
 
-    def presigned_get_object(self, bucket_name, object_name,
-                             expires=timedelta(days=7),
-                             response_headers=None,
-                             request_date=None,
-                             version_id=None,
-                             extra_query_params=None):
+    def presigned_get_object(
+        self,
+        bucket_name,
+        object_name,
+        expires=timedelta(days=7),
+        response_headers=None,
+        request_date=None,
+        version_id=None,
+        extra_query_params=None,
+    ):
         """
         Get presigned URL of an object to download its data with expiry time
         and custom request parameters.
@@ -2117,8 +2309,9 @@ class Minio:  # pylint: disable=too-many-public-methods
             extra_query_params=extra_query_params,
         )
 
-    def presigned_put_object(self, bucket_name, object_name,
-                             expires=timedelta(days=7)):
+    def presigned_put_object(
+        self, bucket_name, object_name, expires=timedelta(days=7)
+    ):
         """
         Get presigned URL of an object to upload data with expiry time and
         custom request parameters.
@@ -2142,7 +2335,10 @@ class Minio:  # pylint: disable=too-many-public-methods
             print(url)
         """
         return self.get_presigned_url(
-            "PUT", bucket_name, object_name, expires,
+            "PUT",
+            bucket_name,
+            object_name,
+            expires,
         )
 
     def presigned_post_policy(self, policy):
@@ -2170,7 +2366,8 @@ class Minio:  # pylint: disable=too-many-public-methods
                 "anonymous access does not require presigned post form-data",
             )
         check_bucket_name(
-            policy.bucket_name, s3_check=self._base_url.is_aws_host)
+            policy.bucket_name, s3_check=self._base_url.is_aws_host
+        )
         return policy.form_data(
             self._provider.retrieve(),
             self._get_region(policy.bucket_name),
@@ -2201,7 +2398,9 @@ class Minio:  # pylint: disable=too-many-public-methods
         check_bucket_name(bucket_name, s3_check=self._base_url.is_aws_host)
         try:
             response = self._execute(
-                "GET", bucket_name, query_params={"replication": ""},
+                "GET",
+                bucket_name,
+                query_params={"replication": ""},
             )
             return unmarshal(ReplicationConfig, response.data.decode())
         except S3Error as exc:
@@ -2278,7 +2477,9 @@ class Minio:  # pylint: disable=too-many-public-methods
         check_bucket_name(bucket_name, s3_check=self._base_url.is_aws_host)
         try:
             response = self._execute(
-                "GET", bucket_name, query_params={"lifecycle": ""},
+                "GET",
+                bucket_name,
+                query_params={"lifecycle": ""},
             )
             return unmarshal(LifecycleConfig, response.data.decode())
         except S3Error as exc:
@@ -2351,7 +2552,9 @@ class Minio:  # pylint: disable=too-many-public-methods
         check_bucket_name(bucket_name, s3_check=self._base_url.is_aws_host)
         try:
             response = self._execute(
-                "GET", bucket_name, query_params={"tagging": ""},
+                "GET",
+                bucket_name,
+                query_params={"tagging": ""},
             )
             tagging = unmarshal(Tagging, response.data.decode())
             return tagging.tags
@@ -2469,7 +2672,10 @@ class Minio:  # pylint: disable=too-many-public-methods
         )
 
     def enable_object_legal_hold(
-            self, bucket_name, object_name, version_id=None,
+        self,
+        bucket_name,
+        object_name,
+        version_id=None,
     ):
         """
         Enable legal hold on an object.
@@ -2496,7 +2702,10 @@ class Minio:  # pylint: disable=too-many-public-methods
         )
 
     def disable_object_legal_hold(
-            self, bucket_name, object_name, version_id=None,
+        self,
+        bucket_name,
+        object_name,
+        version_id=None,
     ):
         """
         Disable legal hold on an object.
@@ -2523,7 +2732,10 @@ class Minio:  # pylint: disable=too-many-public-methods
         )
 
     def is_object_legal_hold_enabled(
-            self, bucket_name, object_name, version_id=None,
+        self,
+        bucket_name,
+        object_name,
+        version_id=None,
     ):
         """
         Returns true if legal hold is enabled on an object.
@@ -2581,7 +2793,9 @@ class Minio:  # pylint: disable=too-many-public-methods
         """
         check_bucket_name(bucket_name, s3_check=self._base_url.is_aws_host)
         response = self._execute(
-            "GET", bucket_name, query_params={"object-lock": ""},
+            "GET",
+            bucket_name,
+            query_params={"object-lock": ""},
         )
         return unmarshal(ObjectLockConfig, response.data.decode())
 
@@ -2609,7 +2823,10 @@ class Minio:  # pylint: disable=too-many-public-methods
         )
 
     def get_object_retention(
-            self, bucket_name, object_name, version_id=None,
+        self,
+        bucket_name,
+        object_name,
+        version_id=None,
     ):
         """
         Get retention configuration of an object.
@@ -2640,7 +2857,11 @@ class Minio:  # pylint: disable=too-many-public-methods
         return None
 
     def set_object_retention(
-            self, bucket_name, object_name, config, version_id=None,
+        self,
+        bucket_name,
+        object_name,
+        config,
+        version_id=None,
     ):
         """
         Set retention configuration on an object.
@@ -2672,10 +2893,18 @@ class Minio:  # pylint: disable=too-many-public-methods
             query_params=query_params,
         )
 
-    def upload_snowball_objects(self, bucket_name, object_list, metadata=None,
-                                sse=None, tags=None, retention=None,
-                                legal_hold=False, staging_filename=None,
-                                compression=False):
+    def upload_snowball_objects(
+        self,
+        bucket_name,
+        object_list,
+        metadata=None,
+        sse=None,
+        tags=None,
+        retention=None,
+        legal_hold=False,
+        staging_filename=None,
+        compression=False,
+    ):
         """
         Uploads multiple objects in a single put call. It is done by creating
         intermediate TAR file optionally compressed which is uploaded to S3
@@ -2741,29 +2970,44 @@ class Minio:  # pylint: disable=too-many-public-methods
             length = os.stat(name).st_size
 
         if name:
-            return self.fput_object(bucket_name, object_name, staging_filename,
-                                    metadata=metadata, sse=sse,
-                                    tags=tags, retention=retention,
-                                    legal_hold=legal_hold, part_size=length)
-        return self.put_object(bucket_name, object_name, fileobj,
-                               length, metadata=metadata, sse=sse,
-                               tags=tags, retention=retention,
-                               legal_hold=legal_hold, part_size=length)
+            return self.fput_object(
+                bucket_name,
+                object_name,
+                staging_filename,
+                metadata=metadata,
+                sse=sse,
+                tags=tags,
+                retention=retention,
+                legal_hold=legal_hold,
+                part_size=length,
+            )
+        return self.put_object(
+            bucket_name,
+            object_name,
+            fileobj,
+            length,
+            metadata=metadata,
+            sse=sse,
+            tags=tags,
+            retention=retention,
+            legal_hold=legal_hold,
+            part_size=length,
+        )
 
     def _list_objects(  # pylint: disable=too-many-arguments,too-many-branches
-            self,
-            bucket_name,
-            continuation_token=None,  # listV2 only
-            delimiter=None,  # all
-            encoding_type=None,  # all
-            fetch_owner=None,  # listV2 only
-            include_user_meta=None,  # MinIO specific listV2.
-            max_keys=None,  # all
-            prefix=None,  # all
-            start_after=None,  # all: v1:marker, versioned:key_marker
-            version_id_marker=None,  # versioned
-            use_api_v1=False,
-            include_version=False,
+        self,
+        bucket_name,
+        continuation_token=None,  # listV2 only
+        delimiter=None,  # all
+        encoding_type=None,  # all
+        fetch_owner=None,  # listV2 only
+        include_user_meta=None,  # MinIO specific listV2.
+        max_keys=None,  # all
+        prefix=None,  # all
+        start_after=None,  # all: v1:marker, versioned:key_marker
+        version_id_marker=None,  # versioned
+        use_api_v1=False,
+        include_version=False,
     ):
         """
         List objects optionally including versions.
@@ -2810,9 +3054,12 @@ class Minio:  # pylint: disable=too-many-public-methods
 
             response = self._execute("GET", bucket_name, query_params=query)
 
-            objects, is_truncated, start_after, version_id_marker = (
-                parse_list_objects(response)
-            )
+            (
+                objects,
+                is_truncated,
+                start_after,
+                version_id_marker,
+            ) = parse_list_objects(response)
 
             if not include_version:
                 version_id_marker = None
@@ -2822,11 +3069,18 @@ class Minio:  # pylint: disable=too-many-public-methods
             for obj in objects:
                 yield obj
 
-    def _list_multipart_uploads(self, bucket_name, delimiter=None,
-                                encoding_type=None, key_marker=None,
-                                max_uploads=None, prefix=None,
-                                upload_id_marker=None, extra_headers=None,
-                                extra_query_params=None):
+    def _list_multipart_uploads(
+        self,
+        bucket_name,
+        delimiter=None,
+        encoding_type=None,
+        key_marker=None,
+        max_uploads=None,
+        prefix=None,
+        upload_id_marker=None,
+        extra_headers=None,
+        extra_query_params=None,
+    ):
         """
         Execute ListMultipartUploads S3 API.
 
@@ -2870,9 +3124,16 @@ class Minio:  # pylint: disable=too-many-public-methods
         )
         return ListMultipartUploadsResult(response)
 
-    def _list_parts(self, bucket_name, object_name, upload_id,
-                    max_parts=None, part_number_marker=None,
-                    extra_headers=None, extra_query_params=None):
+    def _list_parts(
+        self,
+        bucket_name,
+        object_name,
+        upload_id,
+        max_parts=None,
+        part_number_marker=None,
+        extra_headers=None,
+        extra_query_params=None,
+    ):
         """
         Execute ListParts S3 API.
 

--- a/minio/commonconfig.py
+++ b/minio/commonconfig.py
@@ -166,11 +166,7 @@ class Filter:
     """Lifecycle rule filter."""
 
     def __init__(self, and_operator=None, prefix=None, tag=None):
-        valid = (
-            (and_operator is not None)
-            ^ (prefix is not None)
-            ^ (tag is not None)
-        )
+        valid = (and_operator is not None) ^ (prefix is not None) ^ (tag is not None)
         if not valid:
             raise ValueError("only one of and, prefix or tag must be provided")
         self._and_operator = and_operator
@@ -197,9 +193,7 @@ class Filter:
         """Create new object with values from XML element."""
         element = find(element, "Filter")
         and_operator = (
-            None
-            if find(element, "And") is None
-            else AndOperator.fromxml(element)
+            None if find(element, "And") is None else AndOperator.fromxml(element)
         )
         prefix = findtext(element, "Prefix")
         tag = None if find(element, "Tag") is None else Tag.fromxml(element)
@@ -479,8 +473,7 @@ class ComposeSource(ObjectConditionalReadArgs):
         """Get object size."""
         if self._object_size is None:
             raise MinioException(
-                "build_headers() must be called prior to "
-                "this method invocation",
+                "build_headers() must be called prior to " "this method invocation",
             )
         return self._object_size
 
@@ -489,8 +482,7 @@ class ComposeSource(ObjectConditionalReadArgs):
         """Get headers."""
         if self._headers is None:
             raise MinioException(
-                "build_headers() must be called prior to "
-                "this method invocation",
+                "build_headers() must be called prior to " "this method invocation",
             )
         return self._headers.copy()
 

--- a/minio/commonconfig.py
+++ b/minio/commonconfig.py
@@ -473,7 +473,7 @@ class ComposeSource(ObjectConditionalReadArgs):
         """Get object size."""
         if self._object_size is None:
             raise MinioException(
-                "build_headers() must be called prior to " "this method invocation",
+                "build_headers() must be called prior to this method invocation",
             )
         return self._object_size
 
@@ -482,7 +482,7 @@ class ComposeSource(ObjectConditionalReadArgs):
         """Get headers."""
         if self._headers is None:
             raise MinioException(
-                "build_headers() must be called prior to " "this method invocation",
+                "build_headers() must be called prior to this method invocation",
             )
         return self._headers.copy()
 

--- a/minio/credentials/__init__.py
+++ b/minio/credentials/__init__.py
@@ -18,8 +18,17 @@
 
 # pylint: disable=unused-import
 from .credentials import Credentials
-from .providers import (AssumeRoleProvider, AWSConfigProvider, ChainedProvider,
-                        ClientGrantsProvider, EnvAWSProvider, EnvMinioProvider,
-                        IamAwsProvider, LdapIdentityProvider,
-                        MinioClientConfigProvider, Provider, StaticProvider,
-                        WebIdentityProvider)
+from .providers import (
+    AssumeRoleProvider,
+    AWSConfigProvider,
+    ChainedProvider,
+    ClientGrantsProvider,
+    EnvAWSProvider,
+    EnvMinioProvider,
+    IamAwsProvider,
+    LdapIdentityProvider,
+    MinioClientConfigProvider,
+    Provider,
+    StaticProvider,
+    WebIdentityProvider,
+)

--- a/minio/credentials/credentials.py
+++ b/minio/credentials/credentials.py
@@ -25,7 +25,11 @@ class Credentials:
     """
 
     def __init__(
-            self, access_key, secret_key, session_token=None, expiration=None,
+        self,
+        access_key,
+        secret_key,
+        session_token=None,
+        expiration=None,
     ):
         if not access_key:
             raise ValueError("Access key must not be empty")
@@ -37,8 +41,8 @@ class Credentials:
         self._secret_key = secret_key
         self._session_token = session_token
         if expiration and expiration.tzinfo:
-            expiration = (
-                expiration.astimezone(timezone.utc).replace(tzinfo=None)
+            expiration = expiration.astimezone(timezone.utc).replace(
+                tzinfo=None
             )
         self._expiration = expiration
 
@@ -61,5 +65,6 @@ class Credentials:
         """Check whether this credentials expired or not."""
         return (
             self._expiration < (datetime.utcnow() + timedelta(seconds=10))
-            if self._expiration else False
+            if self._expiration
+            else False
         )

--- a/minio/credentials/credentials.py
+++ b/minio/credentials/credentials.py
@@ -41,9 +41,7 @@ class Credentials:
         self._secret_key = secret_key
         self._session_token = session_token
         if expiration and expiration.tzinfo:
-            expiration = expiration.astimezone(timezone.utc).replace(
-                tzinfo=None
-            )
+            expiration = expiration.astimezone(timezone.utc).replace(tzinfo=None)
         self._expiration = expiration
 
     @property

--- a/minio/credentials/providers.py
+++ b/minio/credentials/providers.py
@@ -68,11 +68,7 @@ def _urlopen(http_client, method, url, body=None, headers=None):
 
 def _user_home_dir():
     """Return current user home folder."""
-    return (
-        os.environ.get("HOME")
-        or os.environ.get("UserProfile")
-        or str(Path.home())
-    )
+    return os.environ.get("HOME") or os.environ.get("UserProfile") or str(Path.home())
 
 
 class Provider:  # pylint: disable=too-few-public-methods
@@ -219,8 +215,7 @@ class EnvAWSProvider(Provider):
         """Retrieve credentials."""
         return Credentials(
             access_key=(
-                os.environ.get("AWS_ACCESS_KEY_ID")
-                or os.environ.get("AWS_ACCESS_KEY")
+                os.environ.get("AWS_ACCESS_KEY_ID") or os.environ.get("AWS_ACCESS_KEY")
             ),
             secret_key=(
                 os.environ.get("AWS_SECRET_ACCESS_KEY")
@@ -544,9 +539,7 @@ class WebIdentityClientGrantsProvider(Provider):
         if expiry <= 0:
             return expiry
 
-        return (
-            _MIN_DURATION_SECONDS if expiry < _MIN_DURATION_SECONDS else expiry
-        )
+        return _MIN_DURATION_SECONDS if expiry < _MIN_DURATION_SECONDS else expiry
 
     def retrieve(self):
         """Retrieve credentials."""

--- a/minio/datatypes.py
+++ b/minio/datatypes.py
@@ -103,14 +103,22 @@ class ListAllMyBucketsResult:
 class Object:
     """Object information."""
 
-    def __init__(self,  # pylint: disable=too-many-arguments
-                 bucket_name,
-                 object_name,
-                 last_modified=None, etag=None,
-                 size=None, metadata=None,
-                 version_id=None, is_latest=None, storage_class=None,
-                 owner_id=None, owner_name=None, content_type=None,
-                 is_delete_marker=False):
+    def __init__(
+        self,  # pylint: disable=too-many-arguments
+        bucket_name,
+        object_name,
+        last_modified=None,
+        etag=None,
+        size=None,
+        metadata=None,
+        version_id=None,
+        is_latest=None,
+        storage_class=None,
+        owner_id=None,
+        owner_name=None,
+        content_type=None,
+        is_delete_marker=False,
+    ):
         self._bucket_name = bucket_name
         self._object_name = object_name
         self._last_modified = last_modified
@@ -196,8 +204,9 @@ class Object:
         return self._content_type
 
     @classmethod
-    def fromxml(cls, element, bucket_name, is_delete_marker=False,
-                encoding_type=None):
+    def fromxml(
+        cls, element, bucket_name, is_delete_marker=False, encoding_type=None
+    ):
         """Create new object with values from XML element."""
         tag = findtext(element, "LastModified")
         last_modified = None if tag is None else from_iso8601utc(tag)
@@ -210,7 +219,8 @@ class Object:
 
         tag = find(element, "Owner")
         owner_id, owner_name = (
-            (None, None) if tag is None
+            (None, None)
+            if tag is None
             else (findtext(tag, "ID"), findtext(tag, "DisplayName"))
         )
 
@@ -261,15 +271,19 @@ def parse_list_objects(response, bucket_name=None):
     elements = findall(element, "CommonPrefixes")
     objects += [
         Object(
-            bucket_name, unquote_plus(findtext(tag, "Prefix", True))
-            if encoding_type == "url" else findtext(tag, "Prefix", True)
-        ) for tag in elements
+            bucket_name,
+            unquote_plus(findtext(tag, "Prefix", True))
+            if encoding_type == "url"
+            else findtext(tag, "Prefix", True),
+        )
+        for tag in elements
     ]
 
     elements = findall(element, "DeleteMarker")
     objects += [
-        Object.fromxml(tag, bucket_name, is_delete_marker=True,
-                       encoding_type=encoding_type)
+        Object.fromxml(
+            tag, bucket_name, is_delete_marker=True, encoding_type=encoding_type
+        )
         for tag in elements
     ]
 
@@ -346,7 +360,7 @@ class Part:
 
     @property
     def part_number(self):
-        """Get part number. """
+        """Get part number."""
         return self._part_number
 
     @property
@@ -386,23 +400,18 @@ class ListPartsResult:
         self._bucket_name = findtext(element, "Bucket")
         self._object_name = findtext(element, "Key")
         tag = find(element, "Initiator")
-        self._initiator_id = (
-            None if tag is None else findtext(tag, "ID")
-        )
+        self._initiator_id = None if tag is None else findtext(tag, "ID")
         self._initiator_name = (
             None if tag is None else findtext(tag, "DisplayName")
         )
         tag = find(element, "Owner")
-        self._owner_id = (
-            None if tag is None else findtext(tag, "ID")
-        )
-        self._owner_name = (
-            None if tag is None else findtext(tag, "DisplayName")
-        )
+        self._owner_id = None if tag is None else findtext(tag, "ID")
+        self._owner_name = None if tag is None else findtext(tag, "DisplayName")
         self._storage_class = findtext(element, "StorageClass")
         self._part_number_marker = findtext(element, "PartNumberMarker")
         self._next_part_number_marker = findtext(
-            element, "NextPartNumberMarker",
+            element,
+            "NextPartNumberMarker",
         )
         if self._next_part_number_marker:
             self._next_part_number_marker = int(self._next_part_number_marker)
@@ -411,8 +420,8 @@ class ListPartsResult:
             self._max_parts = int(self._max_parts)
         self._is_truncated = findtext(element, "IsTruncated")
         self._is_truncated = (
-            self._is_truncated is not None and
-            self._is_truncated.lower() == "true"
+            self._is_truncated is not None
+            and self._is_truncated.lower() == "true"
         )
         self._parts = [Part.fromxml(tag) for tag in findall(element, "Part")]
 
@@ -478,30 +487,25 @@ class ListPartsResult:
 
 
 class Upload:
-    """ Upload information of a multipart upload."""
+    """Upload information of a multipart upload."""
 
     def __init__(self, element, encoding_type=None):
         self._encoding_type = encoding_type
         self._object_name = findtext(element, "Key", True)
         self._object_name = (
-            unquote_plus(self._object_name) if self._encoding_type == "url"
+            unquote_plus(self._object_name)
+            if self._encoding_type == "url"
             else self._object_name
         )
         self._upload_id = findtext(element, "UploadId")
         tag = find(element, "Initiator")
-        self._initiator_id = (
-            None if tag is None else findtext(tag, "ID")
-        )
+        self._initiator_id = None if tag is None else findtext(tag, "ID")
         self._initiator_name = (
             None if tag is None else findtext(tag, "DisplayName")
         )
         tag = find(element, "Owner")
-        self._owner_id = (
-            None if tag is None else findtext(tag, "ID")
-        )
-        self._owner_name = (
-            None if tag is None else findtext(tag, "DisplayName")
-        )
+        self._owner_id = None if tag is None else findtext(tag, "ID")
+        self._owner_name = None if tag is None else findtext(tag, "DisplayName")
         self._storage_class = findtext(element, "StorageClass")
         self._initiated_time = findtext(element, "Initiated")
         if self._initiated_time:
@@ -558,7 +562,8 @@ class ListMultipartUploadsResult:
         self._key_marker = findtext(element, "KeyMarker")
         if self._key_marker:
             self._key_marker = (
-                unquote_plus(self._key_marker) if self._encoding_type == "url"
+                unquote_plus(self._key_marker)
+                if self._encoding_type == "url"
                 else self._key_marker
             )
         self._upload_id_marker = findtext(element, "UploadIdMarker")
@@ -566,7 +571,8 @@ class ListMultipartUploadsResult:
         if self._next_key_marker:
             self._next_key_marker = (
                 unquote_plus(self._next_key_marker)
-                if self._encoding_type == "url" else self._next_key_marker
+                if self._encoding_type == "url"
+                else self._next_key_marker
             )
         self._next_upload_id_marker = findtext(element, "NextUploadIdMarker")
         self._max_uploads = findtext(element, "MaxUploads")
@@ -574,8 +580,8 @@ class ListMultipartUploadsResult:
             self._max_uploads = int(self._max_uploads)
         self._is_truncated = findtext(element, "IsTruncated")
         self._is_truncated = (
-            self._is_truncated is not None and
-            self._is_truncated.lower() == "true"
+            self._is_truncated is not None
+            and self._is_truncated.lower() == "true"
         )
         self._uploads = [
             Upload(tag, self._encoding_type)
@@ -671,13 +677,11 @@ class PostPolicy:
         if not element:
             raise ValueError("condition element cannot be empty")
         element = _trim_dollar(element)
-        if (
-                element in [
-                    "success_action_redirect",
-                    "redirect",
-                    "content-length-range",
-                ]
-        ):
+        if element in [
+            "success_action_redirect",
+            "redirect",
+            "content-length-range",
+        ]:
             raise ValueError(element + " is unsupported for equals condition")
         if element in _RESERVED_ELEMENTS:
             raise ValueError(element + " cannot be set")
@@ -697,12 +701,9 @@ class PostPolicy:
         if not element:
             raise ValueError("condition element cannot be empty")
         element = _trim_dollar(element)
-        if (
-                element in ["success_action_status", "content-length-range"] or
-                (
-                    element.startswith("x-amz-") and
-                    not element.startswith("x-amz-meta-")
-                )
+        if element in ["success_action_status", "content-length-range"] or (
+            element.startswith("x-amz-")
+            and not element.startswith("x-amz-meta-")
         ):
             raise ValueError(
                 f"{element} is unsupported for starts-with condition",
@@ -718,7 +719,8 @@ class PostPolicy:
         self._conditions[_STARTS_WITH].pop(element)
 
     def add_content_length_range_condition(  # pylint: disable=invalid-name
-            self, lower_limit, upper_limit):
+        self, lower_limit, upper_limit
+    ):
         """Add content-length-range condition with lower and upper limits."""
         if lower_limit < 0:
             raise ValueError("lower limit cannot be negative number")
@@ -730,7 +732,8 @@ class PostPolicy:
         self._upper_limit = upper_limit
 
     def remove_content_length_range_condition(  # pylint: disable=invalid-name
-            self):
+        self,
+    ):
         """Remove previously set content-length-range condition."""
         self._lower_limit = None
         self._upper_limit = None
@@ -746,8 +749,8 @@ class PostPolicy:
         if not region:
             raise ValueError("region cannot be empty")
         if (
-                "key" not in self._conditions[_EQ] and
-                "key" not in self._conditions[_STARTS_WITH]
+            "key" not in self._conditions[_EQ]
+            and "key" not in self._conditions[_STARTS_WITH]
         ):
             raise ValueError("key condition must be set")
 
@@ -756,7 +759,7 @@ class PostPolicy:
         policy["conditions"] = [[_EQ, "$bucket", self._bucket_name]]
         for cond_key, conditions in self._conditions.items():
             for key, value in conditions.items():
-                policy["conditions"].append([cond_key, "$"+key, value])
+                policy["conditions"].append([cond_key, "$" + key, value])
         if self._lower_limit is not None and self._upper_limit is not None:
             policy["conditions"].append(
                 ["content-length-range", self._lower_limit, self._upper_limit],
@@ -774,7 +777,10 @@ class PostPolicy:
 
         policy = base64.b64encode(json.dumps(policy).encode()).decode("utf-8")
         signature = post_presign_v4(
-            policy, creds.secret_key, utcnow, region,
+            policy,
+            creds.secret_key,
+            utcnow,
+            region,
         )
         form_data = {
             "x-amz-algorithm": _ALGORITHM,
@@ -828,10 +834,10 @@ class EventIterable:
             line = self._response.readline().strip()
             if not line:
                 return None
-            if hasattr(line, 'decode'):
+            if hasattr(line, "decode"):
                 line = line.decode()
             event = json.loads(line)
-            if event['Records']:
+            if event["Records"]:
                 return event
         except (StopIteration, JSONDecodeError):
             self._close_response()

--- a/minio/datatypes.py
+++ b/minio/datatypes.py
@@ -103,7 +103,7 @@ class ListAllMyBucketsResult:
 class Object:
     """Object information."""
 
-    def __init__(   # pylint: disable=too-many-arguments
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         bucket_name,
         object_name,

--- a/minio/datatypes.py
+++ b/minio/datatypes.py
@@ -204,9 +204,7 @@ class Object:
         return self._content_type
 
     @classmethod
-    def fromxml(
-        cls, element, bucket_name, is_delete_marker=False, encoding_type=None
-    ):
+    def fromxml(cls, element, bucket_name, is_delete_marker=False, encoding_type=None):
         """Create new object with values from XML element."""
         tag = findtext(element, "LastModified")
         last_modified = None if tag is None else from_iso8601utc(tag)
@@ -401,9 +399,7 @@ class ListPartsResult:
         self._object_name = findtext(element, "Key")
         tag = find(element, "Initiator")
         self._initiator_id = None if tag is None else findtext(tag, "ID")
-        self._initiator_name = (
-            None if tag is None else findtext(tag, "DisplayName")
-        )
+        self._initiator_name = None if tag is None else findtext(tag, "DisplayName")
         tag = find(element, "Owner")
         self._owner_id = None if tag is None else findtext(tag, "ID")
         self._owner_name = None if tag is None else findtext(tag, "DisplayName")
@@ -420,8 +416,7 @@ class ListPartsResult:
             self._max_parts = int(self._max_parts)
         self._is_truncated = findtext(element, "IsTruncated")
         self._is_truncated = (
-            self._is_truncated is not None
-            and self._is_truncated.lower() == "true"
+            self._is_truncated is not None and self._is_truncated.lower() == "true"
         )
         self._parts = [Part.fromxml(tag) for tag in findall(element, "Part")]
 
@@ -500,9 +495,7 @@ class Upload:
         self._upload_id = findtext(element, "UploadId")
         tag = find(element, "Initiator")
         self._initiator_id = None if tag is None else findtext(tag, "ID")
-        self._initiator_name = (
-            None if tag is None else findtext(tag, "DisplayName")
-        )
+        self._initiator_name = None if tag is None else findtext(tag, "DisplayName")
         tag = find(element, "Owner")
         self._owner_id = None if tag is None else findtext(tag, "ID")
         self._owner_name = None if tag is None else findtext(tag, "DisplayName")
@@ -580,12 +573,10 @@ class ListMultipartUploadsResult:
             self._max_uploads = int(self._max_uploads)
         self._is_truncated = findtext(element, "IsTruncated")
         self._is_truncated = (
-            self._is_truncated is not None
-            and self._is_truncated.lower() == "true"
+            self._is_truncated is not None and self._is_truncated.lower() == "true"
         )
         self._uploads = [
-            Upload(tag, self._encoding_type)
-            for tag in findall(element, "Upload")
+            Upload(tag, self._encoding_type) for tag in findall(element, "Upload")
         ]
 
     @property
@@ -702,8 +693,7 @@ class PostPolicy:
             raise ValueError("condition element cannot be empty")
         element = _trim_dollar(element)
         if element in ["success_action_status", "content-length-range"] or (
-            element.startswith("x-amz-")
-            and not element.startswith("x-amz-meta-")
+            element.startswith("x-amz-") and not element.startswith("x-amz-meta-")
         ):
             raise ValueError(
                 f"{element} is unsupported for starts-with condition",

--- a/minio/datatypes.py
+++ b/minio/datatypes.py
@@ -103,8 +103,8 @@ class ListAllMyBucketsResult:
 class Object:
     """Object information."""
 
-    def __init__(
-        self,  # pylint: disable=too-many-arguments
+    def __init__(   # pylint: disable=too-many-arguments
+        self,
         bucket_name,
         object_name,
         last_modified=None,

--- a/minio/deleteobjects.py
+++ b/minio/deleteobjects.py
@@ -57,8 +57,9 @@ class DeleteRequest:
 class DeletedObject:
     """Deleted object information."""
 
-    def __init__(self, name, version_id, delete_marker,
-                 delete_marker_version_id):
+    def __init__(
+        self, name, version_id, delete_marker, delete_marker_version_id
+    ):
         self._name = name
         self._version_id = version_id
         self._delete_marker = delete_marker

--- a/minio/deleteobjects.py
+++ b/minio/deleteobjects.py
@@ -57,9 +57,7 @@ class DeleteRequest:
 class DeletedObject:
     """Deleted object information."""
 
-    def __init__(
-        self, name, version_id, delete_marker, delete_marker_version_id
-    ):
+    def __init__(self, name, version_id, delete_marker, delete_marker_version_id):
         self._name = name
         self._version_id = version_id
         self._delete_marker = delete_marker
@@ -91,9 +89,7 @@ class DeletedObject:
         name = findtext(element, "Key", True)
         version_id = findtext(element, "VersionId")
         delete_marker = findtext(element, "DeleteMarker")
-        delete_marker = (
-            delete_marker is not None and delete_marker.title() == "True"
-        )
+        delete_marker = delete_marker is not None and delete_marker.title() == "True"
         delete_marker_version_id = findtext(element, "DeleteMarkerVersionId")
         return cls(name, version_id, delete_marker, delete_marker_version_id)
 

--- a/minio/error.py
+++ b/minio/error.py
@@ -72,8 +72,17 @@ class S3Error(MinioException):
     when executing S3 operation.
     """
 
-    def __init__(self, code, message, resource, request_id, host_id,
-                 response, bucket_name=None, object_name=None):
+    def __init__(
+        self,
+        code,
+        message,
+        resource,
+        request_id,
+        host_id,
+        response,
+        bucket_name=None,
+        object_name=None,
+    ):
         self._code = code
         self._message = message
         self._resource = resource
@@ -84,12 +93,10 @@ class S3Error(MinioException):
         self._object_name = object_name
 
         bucket_message = (
-            (", bucket_name: " + self._bucket_name)
-            if self._bucket_name else ""
+            (", bucket_name: " + self._bucket_name) if self._bucket_name else ""
         )
         object_message = (
-            (", object_name: " + self._object_name)
-            if self._object_name else ""
+            (", object_name: " + self._object_name) if self._object_name else ""
         )
         super().__init__(
             f"S3 operation failed; code: {code}, message: {message}, "
@@ -98,9 +105,16 @@ class S3Error(MinioException):
         )
 
     def __reduce__(self):
-        return type(self), (self._code, self._message, self._resource,
-                            self._request_id, self._host_id, self._response,
-                            self._bucket_name, self._object_name)
+        return type(self), (
+            self._code,
+            self._message,
+            self._resource,
+            self._request_id,
+            self._host_id,
+            self._response,
+            self._bucket_name,
+            self._object_name,
+        )
 
     @property
     def code(self):

--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -37,39 +37,46 @@ MAX_MULTIPART_OBJECT_SIZE = 5 * 1024 * 1024 * 1024 * 1024  # 5TiB
 MAX_PART_SIZE = 5 * 1024 * 1024 * 1024  # 5GiB
 MIN_PART_SIZE = 5 * 1024 * 1024  # 5MiB
 
-_AWS_S3_PREFIX = (r'^(((bucket\.|accesspoint\.)'
-                  r'vpce(-(?!_)[a-z_\d]+(?<!-)(?<!_))+\.s3\.)|'
-                  r'((?!s3)(?!-)(?!_)[a-z_\d-]{1,63}(?<!-)(?<!_)\.)'
-                  r's3-control(-(?!_)[a-z_\d]+(?<!-)(?<!_))*\.|'
-                  r'(s3(-(?!_)[a-z_\d]+(?<!-)(?<!_))*\.))')
+_AWS_S3_PREFIX = (
+    r"^(((bucket\.|accesspoint\.)"
+    r"vpce(-(?!_)[a-z_\d]+(?<!-)(?<!_))+\.s3\.)|"
+    r"((?!s3)(?!-)(?!_)[a-z_\d-]{1,63}(?<!-)(?<!_)\.)"
+    r"s3-control(-(?!_)[a-z_\d]+(?<!-)(?<!_))*\.|"
+    r"(s3(-(?!_)[a-z_\d]+(?<!-)(?<!_))*\.))"
+)
 
-_BUCKET_NAME_REGEX = re.compile(r'^[a-z0-9][a-z0-9\.\-]{1,61}[a-z0-9]$')
-_OLD_BUCKET_NAME_REGEX = re.compile(r'^[a-z0-9][a-z0-9_\.\-\:]{1,61}[a-z0-9]$',
-                                    re.IGNORECASE)
+_BUCKET_NAME_REGEX = re.compile(r"^[a-z0-9][a-z0-9\.\-]{1,61}[a-z0-9]$")
+_OLD_BUCKET_NAME_REGEX = re.compile(
+    r"^[a-z0-9][a-z0-9_\.\-\:]{1,61}[a-z0-9]$", re.IGNORECASE
+)
 _IPV4_REGEX = re.compile(
-    r'^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}'
-    r'(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$')
+    r"^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}"
+    r"(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$"
+)
 _HOSTNAME_REGEX = re.compile(
-    r'^((?!-)(?!_)[a-z_\d-]{1,63}(?<!-)(?<!_)\.)*'
-    r'((?!_)(?!-)[a-z_\d-]{1,63}(?<!-)(?<!_))$',
-    re.IGNORECASE)
-_AWS_ENDPOINT_REGEX = re.compile(r'.*\.amazonaws\.com(|\.cn)$', re.IGNORECASE)
+    r"^((?!-)(?!_)[a-z_\d-]{1,63}(?<!-)(?<!_)\.)*"
+    r"((?!_)(?!-)[a-z_\d-]{1,63}(?<!-)(?<!_))$",
+    re.IGNORECASE,
+)
+_AWS_ENDPOINT_REGEX = re.compile(r".*\.amazonaws\.com(|\.cn)$", re.IGNORECASE)
 _AWS_S3_ENDPOINT_REGEX = re.compile(
-    _AWS_S3_PREFIX +
-    r'((?!s3)(?!-)(?!_)[a-z_\d-]{1,63}(?<!-)(?<!_)\.)*'
-    r'amazonaws\.com(|\.cn)$',
-    re.IGNORECASE)
+    _AWS_S3_PREFIX + r"((?!s3)(?!-)(?!_)[a-z_\d-]{1,63}(?<!-)(?<!_)\.)*"
+    r"amazonaws\.com(|\.cn)$",
+    re.IGNORECASE,
+)
 _AWS_ELB_ENDPOINT_REGEX = re.compile(
-    r'^(?!-)(?!_)[a-z_\d-]{1,63}(?<!-)(?<!_)\.'
-    r'(?!-)(?!_)[a-z_\d-]{1,63}(?<!-)(?<!_)\.'
-    r'elb\.amazonaws\.com$',
-    re.IGNORECASE)
+    r"^(?!-)(?!_)[a-z_\d-]{1,63}(?<!-)(?<!_)\."
+    r"(?!-)(?!_)[a-z_\d-]{1,63}(?<!-)(?<!_)\."
+    r"elb\.amazonaws\.com$",
+    re.IGNORECASE,
+)
 _AWS_S3_PREFIX_REGEX = re.compile(_AWS_S3_PREFIX, re.IGNORECASE)
-_REGION_REGEX = re.compile(r'^((?!_)(?!-)[a-z_\d-]{1,63}(?<!-)(?<!_))$',
-                           re.IGNORECASE)
+_REGION_REGEX = re.compile(
+    r"^((?!_)(?!-)[a-z_\d-]{1,63}(?<!-)(?<!_))$", re.IGNORECASE
+)
 
 
-def quote(resource, safe='/', encoding=None, errors=None):
+def quote(resource, safe="/", encoding=None, errors=None):
     """
     Wrapper to urllib.parse.quote() replacing back to '~' for older python
     versions.
@@ -82,26 +89,31 @@ def quote(resource, safe='/', encoding=None, errors=None):
     ).replace("%7E", "~")
 
 
-def queryencode(query, safe='', encoding=None, errors=None):
+def queryencode(query, safe="", encoding=None, errors=None):
     """Encode query parameter value."""
     return quote(query, safe, encoding, errors)
 
 
 def headers_to_strings(headers, titled_key=False):
     """Convert HTTP headers to multi-line string."""
+
     def _get_key(key):
         return key.title() if titled_key else key
 
     def _get_value(value):
-        return re.sub(
-            r"Credential=([^/]+)",
-            "Credential=*REDACTED*",
+        return (
             re.sub(
-                r"Signature=([0-9a-f]+)",
-                "Signature=*REDACTED*",
-                value if isinstance(value, str) else str(value),
-            ),
-        ) if titled_key else value
+                r"Credential=([^/]+)",
+                "Credential=*REDACTED*",
+                re.sub(
+                    r"Signature=([0-9a-f]+)",
+                    "Signature=*REDACTED*",
+                    value if isinstance(value, str) else str(value),
+                ),
+            )
+            if titled_key
+            else value
+        )
 
     return "\n".join(
         [
@@ -146,9 +158,12 @@ def _get_part_info(object_size, part_size):
         part_size = min(part_size, object_size)
         return part_size, math.ceil(object_size / part_size) if part_size else 1
 
-    part_size = math.ceil(
-        math.ceil(object_size / MAX_MULTIPART_COUNT) / MIN_PART_SIZE,
-    ) * MIN_PART_SIZE
+    part_size = (
+        math.ceil(
+            math.ceil(object_size / MAX_MULTIPART_COUNT) / MIN_PART_SIZE,
+        )
+        * MIN_PART_SIZE
+    )
     return part_size, math.ceil(object_size / part_size) if part_size else 1
 
 
@@ -163,7 +178,7 @@ def get_part_info(object_size, part_size):
     return part_size, part_count
 
 
-def read_part_data(stream, size, part_data=b'', progress=None):
+def read_part_data(stream, size, part_data=b"", progress=None):
     """Read part data of given size from stream."""
     size -= len(part_data)
     while size:
@@ -197,29 +212,35 @@ def check_bucket_name(bucket_name, strict=False, s3_check=False):
 
     if strict:
         if not _BUCKET_NAME_REGEX.match(bucket_name):
-            raise ValueError('invalid bucket name {bucket_name}')
+            raise ValueError("invalid bucket name {bucket_name}")
     else:
         if not _OLD_BUCKET_NAME_REGEX.match(bucket_name):
-            raise ValueError('invalid bucket name {bucket_name}')
+            raise ValueError("invalid bucket name {bucket_name}")
 
     if _IPV4_REGEX.match(bucket_name):
-        raise ValueError('bucket name {bucket_name} must not be formatted '
-                         'as an IP address')
+        raise ValueError(
+            "bucket name {bucket_name} must not be formatted "
+            "as an IP address"
+        )
 
-    unallowed_successive_chars = ['..', '.-', '-.']
+    unallowed_successive_chars = ["..", ".-", "-."]
     if any(x in bucket_name for x in unallowed_successive_chars):
-        raise ValueError('bucket name {bucket_name} contains invalid '
-                         'successive characters')
+        raise ValueError(
+            "bucket name {bucket_name} contains invalid "
+            "successive characters"
+        )
 
     if (
-            s3_check and
-            bucket_name.startswith("xn--") or
-            bucket_name.endswith("-s3alias") or
-            bucket_name.endswith("--ol-s3")
+        s3_check
+        and bucket_name.startswith("xn--")
+        or bucket_name.endswith("-s3alias")
+        or bucket_name.endswith("--ol-s3")
     ):
-        raise ValueError("bucket name {bucket_name} must not start with "
-                         "'xn--' and must not end with '--s3alias' or "
-                         "'--ol-s3'")
+        raise ValueError(
+            "bucket name {bucket_name} must not start with "
+            "'xn--' and must not end with '--s3alias' or "
+            "'--ol-s3'"
+        )
 
 
 def check_non_empty_string(string):
@@ -282,7 +303,7 @@ def sha256_hash(data):
 
 
 def url_replace(
-        url, scheme=None, netloc=None, path=None, query=None, fragment=None
+    url, scheme=None, netloc=None, path=None, query=None, fragment=None
 ):
     """Return new URL with replaced properties in given URL."""
     return urllib.parse.SplitResult(
@@ -296,6 +317,7 @@ def url_replace(
 
 def _metadata_to_headers(metadata):
     """Convert user metadata to headers."""
+
     def normalize_key(key):
         if not key.lower().startswith("x-amz-meta-"):
             key = "X-Amz-Meta-" + key
@@ -330,8 +352,9 @@ def normalize_headers(headers):
     def guess_user_metadata(key):
         key = key.lower()
         return not (
-            key.startswith("x-amz-") or
-            key in [
+            key.startswith("x-amz-")
+            or key
+            in [
                 "cache-control",
                 "content-encoding",
                 "content-type",
@@ -341,8 +364,7 @@ def normalize_headers(headers):
         )
 
     user_metadata = {
-        key: value for key, value in headers.items()
-        if guess_user_metadata(key)
+        key: value for key, value in headers.items() if guess_user_metadata(key)
     }
 
     # Remove guessed user metadata.
@@ -366,8 +388,8 @@ def genheaders(headers, sse, tags, retention, legal_hold):
         headers["x-amz-tagging"] = tagging
     if retention and retention.mode:
         headers["x-amz-object-lock-mode"] = retention.mode
-        headers["x-amz-object-lock-retain-until-date"] = (
-            to_iso8601utc(retention.retain_until_date)
+        headers["x-amz-object-lock-retain-until-date"] = to_iso8601utc(
+            retention.retain_until_date
         )
     if legal_hold:
         headers["x-amz-object-lock-legal-hold"] = "ON"
@@ -375,7 +397,7 @@ def genheaders(headers, sse, tags, retention, legal_hold):
 
 
 def _get_aws_info(host, https, region):
-    """Extract AWS domain information. """
+    """Extract AWS domain information."""
 
     if not _HOSTNAME_REGEX.match(host):
         return (None, None)
@@ -409,22 +431,31 @@ def _get_aws_info(host, https, region):
     if host in "s3-external-1.amazonaws.com":
         region_in_host = "us-east-1"
 
-    if host in ["s3-us-gov-west-1.amazonaws.com",
-                "s3-fips-us-gov-west-1.amazonaws.com"]:
+    if host in [
+        "s3-us-gov-west-1.amazonaws.com",
+        "s3-fips-us-gov-west-1.amazonaws.com",
+    ]:
         region_in_host = "us-gov-west-1"
 
-    if (aws_domain_suffix.endswith(".cn") and
-        not aws_s3_prefix.endswith("s3-accelerate.") and
-        not region_in_host and
-            not region):
+    if (
+        aws_domain_suffix.endswith(".cn")
+        and not aws_s3_prefix.endswith("s3-accelerate.")
+        and not region_in_host
+        and not region
+    ):
         raise ValueError(
             f"region missing in Amazon S3 China endpoint {host}",
         )
 
-    return ({"s3_prefix": aws_s3_prefix,
-             "domain_suffix": aws_domain_suffix,
-             "region": region or region_in_host,
-             "dualstack": dualstack}, None)
+    return (
+        {
+            "s3_prefix": aws_s3_prefix,
+            "domain_suffix": aws_domain_suffix,
+            "region": region or region_in_host,
+            "dualstack": dualstack,
+        },
+        None,
+    )
 
 
 class BaseURL:
@@ -461,9 +492,8 @@ class BaseURL:
         if url.password:
             raise ValueError("password in endpoint is not allowed")
 
-        if (
-                (url.scheme == "http" and url.port == 80) or
-                (url.scheme == "https" and url.port == 443)
+        if (url.scheme == "http" and url.port == 80) or (
+            url.scheme == "https" and url.port == 443
         ):
             url = url_replace(url, netloc=host)
 
@@ -471,17 +501,18 @@ class BaseURL:
             raise ValueError(f"invalid region {region}")
 
         self._aws_info, region_in_host = _get_aws_info(
-            host, url.scheme == "https", region)
-        self._virtual_style_flag = (
-            self._aws_info or host.endswith("aliyuncs.com")
+            host, url.scheme == "https", region
+        )
+        self._virtual_style_flag = self._aws_info or host.endswith(
+            "aliyuncs.com"
         )
         self._url = url
         self._region = region or region_in_host
         self._accelerate_host_flag = False
         if self._aws_info:
             self._region = self._aws_info["region"]
-            self._accelerate_host_flag = (
-                self._aws_info["s3_prefix"].endswith("s3-accelerate.")
+            self._accelerate_host_flag = self._aws_info["s3_prefix"].endswith(
+                "s3-accelerate."
             )
 
     @property
@@ -554,9 +585,11 @@ class BaseURL:
         domain_suffix = self._aws_info["domain_suffix"]
 
         host = f"{s3_prefix}{domain_suffix}"
-        if host in ["s3-external-1.amazonaws.com",
-                    "s3-us-gov-west-1.amazonaws.com",
-                    "s3-fips-us-gov-west-1.amazonaws.com"]:
+        if host in [
+            "s3-external-1.amazonaws.com",
+            "s3-us-gov-west-1.amazonaws.com",
+            "s3-fips-us-gov-west-1.amazonaws.com",
+        ]:
             return url_replace(url, netloc=host)
 
         netloc = s3_prefix
@@ -586,9 +619,11 @@ class BaseURL:
         domain_suffix = self._aws_info["domain_suffix"]
 
         host = f"{s3_prefix}{domain_suffix}"
-        if host in ["s3-external-1.amazonaws.com",
-                    "s3-us-gov-west-1.amazonaws.com",
-                    "s3-fips-us-gov-west-1.amazonaws.com"]:
+        if host in [
+            "s3-external-1.amazonaws.com",
+            "s3-us-gov-west-1.amazonaws.com",
+            "s3-fips-us-gov-west-1.amazonaws.com",
+        ]:
             return url_replace(url, netloc=host)
 
         if s3_prefix.startswith("s3.") or s3_prefix.startswith("s3-"):
@@ -598,8 +633,12 @@ class BaseURL:
         return url_replace(url, netloc=f"{s3_prefix}{region}.{domain_suffix}")
 
     def build(
-            self, method, region,
-            bucket_name=None, object_name=None, query_params=None,
+        self,
+        method,
+        region,
+        bucket_name=None,
+        object_name=None,
+        query_params=None,
     ):
         """Build URL for given information."""
         if not bucket_name and object_name:
@@ -623,11 +662,11 @@ class BaseURL:
 
         enforce_path_style = (
             # CreateBucket API requires path style in Amazon AWS S3.
-            (method == "PUT" and not object_name and not query_params) or
-
+            (method == "PUT" and not object_name and not query_params)
+            or
             # GetBucketLocation API requires path style in Amazon AWS S3.
-            (query_params and "location" in query_params) or
-
+            (query_params and "location" in query_params)
+            or
             # Use path style for bucket name containing '.' which causes
             # SSL certificate validation error.
             ("." in bucket_name and self._url.scheme == "https")
@@ -635,7 +674,8 @@ class BaseURL:
 
         if self._aws_info:
             url = self._build_aws_url(
-                url, bucket_name, enforce_path_style, region)
+                url, bucket_name, enforce_path_style, region
+            )
 
         netloc = url.netloc
         path = "/"
@@ -654,8 +694,14 @@ class ObjectWriteResult:
     """Result class of any APIs doing object creation."""
 
     def __init__(
-            self, bucket_name, object_name, version_id, etag, http_headers,
-            last_modified=None, location=None,
+        self,
+        bucket_name,
+        object_name,
+        version_id,
+        etag,
+        http_headers,
+        last_modified=None,
+        location=None,
     ):
         self._bucket_name = bucket_name
         self._object_name = object_name
@@ -702,7 +748,7 @@ class ObjectWriteResult:
 
 
 class Worker(Thread):
-    """ Thread executing tasks from a given tasks queue """
+    """Thread executing tasks from a given tasks queue"""
 
     def __init__(self, tasks_queue, results_queue, exceptions_queue):
         Thread.__init__(self, daemon=True)
@@ -712,7 +758,7 @@ class Worker(Thread):
         self.start()
 
     def run(self):
-        """ Continuously receive tasks and execute them """
+        """Continuously receive tasks and execute them"""
         while True:
             task = self._tasks_queue.get()
             if not task:
@@ -735,7 +781,7 @@ class Worker(Thread):
 
 
 class ThreadPool:
-    """ Pool of threads consuming tasks from a queue """
+    """Pool of threads consuming tasks from a queue"""
 
     def __init__(self, num_threads):
         self._results_queue = Queue()
@@ -756,14 +802,16 @@ class ThreadPool:
         self._tasks_queue.put((func, args, kargs, cleanup_func))
 
     def start_parallel(self):
-        """ Prepare threads to run tasks"""
+        """Prepare threads to run tasks"""
         for _ in range(self._num_threads):
             Worker(
-                self._tasks_queue, self._results_queue, self._exceptions_queue,
+                self._tasks_queue,
+                self._results_queue,
+                self._exceptions_queue,
             )
 
     def result(self):
-        """ Stop threads and return the result of all called tasks """
+        """Stop threads and return the result of all called tasks"""
         # Send None to all threads to cleanly stop them
         for _ in range(self._num_threads):
             self._tasks_queue.put(None)

--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -71,9 +71,7 @@ _AWS_ELB_ENDPOINT_REGEX = re.compile(
     re.IGNORECASE,
 )
 _AWS_S3_PREFIX_REGEX = re.compile(_AWS_S3_PREFIX, re.IGNORECASE)
-_REGION_REGEX = re.compile(
-    r"^((?!_)(?!-)[a-z_\d-]{1,63}(?<!-)(?<!_))$", re.IGNORECASE
-)
+_REGION_REGEX = re.compile(r"^((?!_)(?!-)[a-z_\d-]{1,63}(?<!-)(?<!_))$", re.IGNORECASE)
 
 
 def quote(resource, safe="/", encoding=None, errors=None):
@@ -116,10 +114,7 @@ def headers_to_strings(headers, titled_key=False):
         )
 
     return "\n".join(
-        [
-            f"{_get_key(key)}: {_get_value(value)}"
-            for key, value in headers.items()
-        ]
+        [f"{_get_key(key)}: {_get_value(value)}" for key, value in headers.items()]
     )
 
 
@@ -138,8 +133,7 @@ def _validate_sizes(object_size, part_size):
     if object_size >= 0:
         if object_size > MAX_MULTIPART_OBJECT_SIZE:
             raise ValueError(
-                f"object size {object_size} is not supported; "
-                f"maximum allowed 5TiB"
+                f"object size {object_size} is not supported; " f"maximum allowed 5TiB"
             )
     elif part_size <= 0:
         raise ValueError(
@@ -219,15 +213,13 @@ def check_bucket_name(bucket_name, strict=False, s3_check=False):
 
     if _IPV4_REGEX.match(bucket_name):
         raise ValueError(
-            "bucket name {bucket_name} must not be formatted "
-            "as an IP address"
+            "bucket name {bucket_name} must not be formatted " "as an IP address"
         )
 
     unallowed_successive_chars = ["..", ".-", "-."]
     if any(x in bucket_name for x in unallowed_successive_chars):
         raise ValueError(
-            "bucket name {bucket_name} contains invalid "
-            "successive characters"
+            "bucket name {bucket_name} contains invalid " "successive characters"
         )
 
     if (
@@ -302,9 +294,7 @@ def sha256_hash(data):
     return sha256sum.decode() if isinstance(sha256sum, bytes) else sha256sum
 
 
-def url_replace(
-    url, scheme=None, netloc=None, path=None, query=None, fragment=None
-):
+def url_replace(url, scheme=None, netloc=None, path=None, query=None, fragment=None):
     """Return new URL with replaced properties in given URL."""
     return urllib.parse.SplitResult(
         scheme if scheme is not None else url.scheme,
@@ -503,9 +493,7 @@ class BaseURL:
         self._aws_info, region_in_host = _get_aws_info(
             host, url.scheme == "https", region
         )
-        self._virtual_style_flag = self._aws_info or host.endswith(
-            "aliyuncs.com"
-        )
+        self._virtual_style_flag = self._aws_info or host.endswith("aliyuncs.com")
         self._url = url
         self._region = region or region_in_host
         self._accelerate_host_flag = False
@@ -652,8 +640,7 @@ class BaseURL:
         for key, values in sorted((query_params or {}).items()):
             values = values if isinstance(values, (list, tuple)) else [values]
             query += [
-                f"{queryencode(key)}={queryencode(value)}"
-                for value in sorted(values)
+                f"{queryencode(key)}={queryencode(value)}" for value in sorted(values)
             ]
         url = url_replace(url, query="&".join(query))
 
@@ -673,9 +660,7 @@ class BaseURL:
         )
 
         if self._aws_info:
-            url = self._build_aws_url(
-                url, bucket_name, enforce_path_style, region
-            )
+            url = self._build_aws_url(url, bucket_name, enforce_path_style, region)
 
         netloc = url.netloc
         path = "/"

--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -213,13 +213,13 @@ def check_bucket_name(bucket_name, strict=False, s3_check=False):
 
     if _IPV4_REGEX.match(bucket_name):
         raise ValueError(
-            "bucket name {bucket_name} must not be formatted " "as an IP address"
+            "bucket name {bucket_name} must not be formatted as an IP address"
         )
 
     unallowed_successive_chars = ["..", ".-", "-."]
     if any(x in bucket_name for x in unallowed_successive_chars):
         raise ValueError(
-            "bucket name {bucket_name} contains invalid " "successive characters"
+            "bucket name {bucket_name} contains invalid successive characters"
         )
 
     if (

--- a/minio/lifecycleconfig.py
+++ b/minio/lifecycleconfig.py
@@ -186,7 +186,7 @@ class Expiration(DateDays):
         if expired_object_delete_marker is not None:
             if expired_object_delete_marker.title() not in ["False", "True"]:
                 raise ValueError(
-                    "value of ExpiredObjectDeleteMarker must be " "'True' or 'False'",
+                    "value of ExpiredObjectDeleteMarker must be 'True' or 'False'",
                 )
             expired_object_delete_marker = (
                 expired_object_delete_marker.title() == "True"

--- a/minio/lifecycleconfig.py
+++ b/minio/lifecycleconfig.py
@@ -31,6 +31,7 @@ from .xml import Element, SubElement, find, findall, findtext
 
 class DateDays:
     """Base class holds date and days of Transition and Expiration."""
+
     __metaclass__ = ABCMeta
 
     def __init__(self, date=None, days=None):
@@ -60,7 +61,9 @@ class DateDays:
         """Convert to XML."""
         if self._date is not None:
             SubElement(
-                element, "Date", to_iso8601utc(self._date),
+                element,
+                "Date",
+                to_iso8601utc(self._date),
             )
         if self._days:
             SubElement(element, "Days", str(self._days))
@@ -162,8 +165,7 @@ class NoncurrentVersionExpiration:
 class Expiration(DateDays):
     """Expiration."""
 
-    def __init__(self, date=None, days=None,
-                 expired_object_delete_marker=None):
+    def __init__(self, date=None, days=None, expired_object_delete_marker=None):
         super().__init__(date, days)
         self._expired_object_delete_marker = expired_object_delete_marker
 
@@ -178,7 +180,8 @@ class Expiration(DateDays):
         element = find(element, "Expiration")
         date, days = cls.parsexml(element)
         expired_object_delete_marker = findtext(
-            element, "ExpiredObjectDeleteMarker",
+            element,
+            "ExpiredObjectDeleteMarker",
         )
         if expired_object_delete_marker is not None:
             if expired_object_delete_marker.title() not in ["False", "True"]:
@@ -238,23 +241,33 @@ class AbortIncompleteMultipartUpload:
 
 
 class Rule(BaseRule):
-    """Lifecycle rule. """
+    """Lifecycle rule."""
 
-    def __init__(self, status, abort_incomplete_multipart_upload=None,
-                 expiration=None, rule_filter=None, rule_id=None,
-                 noncurrent_version_expiration=None,
-                 noncurrent_version_transition=None,
-                 transition=None):
+    def __init__(
+        self,
+        status,
+        abort_incomplete_multipart_upload=None,
+        expiration=None,
+        rule_filter=None,
+        rule_id=None,
+        noncurrent_version_expiration=None,
+        noncurrent_version_transition=None,
+        transition=None,
+    ):
         check_status(status)
-        if (not abort_incomplete_multipart_upload and not expiration
+        if (
+            not abort_incomplete_multipart_upload
+            and not expiration
             and not noncurrent_version_expiration
             and not noncurrent_version_transition
-                and not transition):
+            and not transition
+        ):
             raise ValueError(
                 "at least one of action (AbortIncompleteMultipartUpload, "
                 "Expiration, NoncurrentVersionExpiration, "
                 "NoncurrentVersionTransition or Transition) must be specified "
-                "in a rule")
+                "in a rule"
+            )
         if not rule_filter:
             raise ValueError("Rule filter must be provided")
 
@@ -304,24 +317,29 @@ class Rule(BaseRule):
         """Create new object with values from XML element."""
         status = findtext(element, "Status", True)
         abort_incomplete_multipart_upload = (
-            None if find(element, "AbortIncompleteMultipartUpload") is None
+            None
+            if find(element, "AbortIncompleteMultipartUpload") is None
             else AbortIncompleteMultipartUpload.fromxml(element)
         )
         expiration = (
-            None if find(element, "Expiration") is None
+            None
+            if find(element, "Expiration") is None
             else Expiration.fromxml(element)
         )
         rule_filter, rule_id = cls.parsexml(element)
         noncurrent_version_expiration = (
-            None if find(element, "NoncurrentVersionExpiration") is None
+            None
+            if find(element, "NoncurrentVersionExpiration") is None
             else NoncurrentVersionExpiration.fromxml(element)
         )
         noncurrent_version_transition = (
-            None if find(element, "NoncurrentVersionTransition") is None
+            None
+            if find(element, "NoncurrentVersionTransition") is None
             else NoncurrentVersionTransition.fromxml(element)
         )
         transition = (
-            None if find(element, "Transition") is None
+            None
+            if find(element, "Transition") is None
             else Transition.fromxml(element)
         )
 

--- a/minio/lifecycleconfig.py
+++ b/minio/lifecycleconfig.py
@@ -186,8 +186,7 @@ class Expiration(DateDays):
         if expired_object_delete_marker is not None:
             if expired_object_delete_marker.title() not in ["False", "True"]:
                 raise ValueError(
-                    "value of ExpiredObjectDeleteMarker must be "
-                    "'True' or 'False'",
+                    "value of ExpiredObjectDeleteMarker must be " "'True' or 'False'",
                 )
             expired_object_delete_marker = (
                 expired_object_delete_marker.title() == "True"
@@ -274,9 +273,7 @@ class Rule(BaseRule):
         super().__init__(rule_filter, rule_id)
 
         self._status = status
-        self._abort_incomplete_multipart_upload = (
-            abort_incomplete_multipart_upload
-        )
+        self._abort_incomplete_multipart_upload = abort_incomplete_multipart_upload
         self._expiration = expiration
         self._noncurrent_version_expiration = noncurrent_version_expiration
         self._noncurrent_version_transition = noncurrent_version_transition
@@ -322,9 +319,7 @@ class Rule(BaseRule):
             else AbortIncompleteMultipartUpload.fromxml(element)
         )
         expiration = (
-            None
-            if find(element, "Expiration") is None
-            else Expiration.fromxml(element)
+            None if find(element, "Expiration") is None else Expiration.fromxml(element)
         )
         rule_filter, rule_id = cls.parsexml(element)
         noncurrent_version_expiration = (
@@ -338,16 +333,12 @@ class Rule(BaseRule):
             else NoncurrentVersionTransition.fromxml(element)
         )
         transition = (
-            None
-            if find(element, "Transition") is None
-            else Transition.fromxml(element)
+            None if find(element, "Transition") is None else Transition.fromxml(element)
         )
 
         return cls(
             status,
-            abort_incomplete_multipart_upload=(
-                abort_incomplete_multipart_upload
-            ),
+            abort_incomplete_multipart_upload=(abort_incomplete_multipart_upload),
             expiration=expiration,
             rule_filter=rule_filter,
             rule_id=rule_id,

--- a/minio/minioadmin.py
+++ b/minio/minioadmin.py
@@ -229,15 +229,13 @@ class MinioAdmin:
     def kms_key_create(self, key=None):
         """Create a new KMS master key."""
         return self._run(
-            ["kms", "key", "create", self._target, key]
-            + ([key] if key else []),
+            ["kms", "key", "create", self._target, key] + ([key] if key else []),
         )
 
     def kms_key_status(self, key=None):
         """Get status information of a KMS master key."""
         return self._run(
-            ["kms", "key", "status", self._target, key]
-            + ([key] if key else []),
+            ["kms", "key", "status", self._target, key] + ([key] if key else []),
         )
 
     def bucket_remote_add(

--- a/minio/minioadmin.py
+++ b/minio/minioadmin.py
@@ -28,9 +28,13 @@ class MinioAdmin:
     """MinIO Admin wrapper using MinIO Client (mc) tool."""
 
     def __init__(
-            self, target,
-            binary_path=None, config_dir=None, ignore_cert_check=False,
-            timeout=None, env=None,
+        self,
+        target,
+        binary_path=None,
+        config_dir=None,
+        ignore_cert_check=False,
+        timeout=None,
+        env=None,
     ):
         self._target = target
         self._timeout = timeout
@@ -147,8 +151,12 @@ class MinioAdmin:
         if (user is not None) ^ (group is not None):
             return self._run(
                 [
-                    "policy", "attach", self._target, policy_name,
-                    "--user" if user else "--group", user or group,
+                    "policy",
+                    "attach",
+                    self._target,
+                    policy_name,
+                    "--user" if user else "--group",
+                    user or group,
                 ],
             )
         raise ValueError("either user or group must be set")
@@ -158,8 +166,12 @@ class MinioAdmin:
         if (user is not None) ^ (group is not None):
             return self._run(
                 [
-                    "policy", "detach", self._target, policy_name,
-                    "--user" if user else "--group", user or group,
+                    "policy",
+                    "detach",
+                    self._target,
+                    policy_name,
+                    "--user" if user else "--group",
+                    user or group,
                 ],
             )
         raise ValueError("either user or group must be set")
@@ -217,27 +229,35 @@ class MinioAdmin:
     def kms_key_create(self, key=None):
         """Create a new KMS master key."""
         return self._run(
-            [
-                "kms", "key", "create", self._target, key
-            ] + ([key] if key else []),
+            ["kms", "key", "create", self._target, key]
+            + ([key] if key else []),
         )
 
     def kms_key_status(self, key=None):
         """Get status information of a KMS master key."""
         return self._run(
-            [
-                "kms", "key", "status", self._target, key
-            ] + ([key] if key else []),
+            ["kms", "key", "status", self._target, key]
+            + ([key] if key else []),
         )
 
     def bucket_remote_add(
-            self, src_bucket, dest_url,
-            path=None, region=None, bandwidth=None, service=None,
+        self,
+        src_bucket,
+        dest_url,
+        path=None,
+        region=None,
+        bandwidth=None,
+        service=None,
     ):
         """Add a new remote target."""
         args = [
-            "bucket", "remote", "add", self._target + "/" + src_bucket,
-            dest_url, "--service", service or "replication",
+            "bucket",
+            "remote",
+            "add",
+            self._target + "/" + src_bucket,
+            dest_url,
+            "--service",
+            service or "replication",
         ]
         if path:
             args += ["--path", path]
@@ -251,8 +271,13 @@ class MinioAdmin:
         """Edit credentials of remote target."""
         return self._run(
             [
-                "bucket", "remote", "edit", self._target + "/" + src_bucket,
-                dest_url, "--arn", arn,
+                "bucket",
+                "remote",
+                "edit",
+                self._target + "/" + src_bucket,
+                dest_url,
+                "--arn",
+                arn,
             ],
         )
 
@@ -260,9 +285,12 @@ class MinioAdmin:
         """List remote targets."""
         return self._run(
             [
-                "bucket", "remote", "ls",
+                "bucket",
+                "remote",
+                "ls",
                 self._target + ("/" + src_bucket if src_bucket else ""),
-                "--service", service or "replication",
+                "--service",
+                service or "replication",
             ],
         )
 
@@ -270,8 +298,12 @@ class MinioAdmin:
         """Remove configured remote target."""
         return self._run(
             [
-                "bucket", "remote", "rm", self._target + "/" + src_bucket,
-                "--arn", arn,
+                "bucket",
+                "remote",
+                "rm",
+                self._target + "/" + src_bucket,
+                "--arn",
+                arn,
             ],
         )
 

--- a/minio/notificationconfig.py
+++ b/minio/notificationconfig.py
@@ -79,8 +79,9 @@ class CommonConfig:
 
     __metaclass__ = ABCMeta
 
-    def __init__(self, events, config_id, prefix_filter_rule,
-                 suffix_filter_rule):
+    def __init__(
+        self, events, config_id, prefix_filter_rule, suffix_filter_rule
+    ):
         if not events:
             raise ValueError("events must be provided")
         self._events = events
@@ -147,13 +148,22 @@ class CommonConfig:
 class CloudFuncConfig(CommonConfig):
     """Cloud function configuration."""
 
-    def __init__(self, cloud_func, events, config_id=None,
-                 prefix_filter_rule=None, suffix_filter_rule=None):
+    def __init__(
+        self,
+        cloud_func,
+        events,
+        config_id=None,
+        prefix_filter_rule=None,
+        suffix_filter_rule=None,
+    ):
         if not cloud_func:
             raise ValueError("cloud function must be provided")
         self._cloud_func = cloud_func
         super().__init__(
-            events, config_id, prefix_filter_rule, suffix_filter_rule,
+            events,
+            config_id,
+            prefix_filter_rule,
+            suffix_filter_rule,
         )
 
     @property
@@ -165,14 +175,18 @@ class CloudFuncConfig(CommonConfig):
     def fromxml(cls, element):
         """Create new object with values from XML element."""
         cloud_func = findtext(element, "CloudFunction", True)
-        (events, config_id, prefix_filter_rule,
-         suffix_filter_rule) = cls.parsexml(element)
+        (
+            events,
+            config_id,
+            prefix_filter_rule,
+            suffix_filter_rule,
+        ) = cls.parsexml(element)
         return cls(
             cloud_func,
             events,
             config_id,
             prefix_filter_rule,
-            suffix_filter_rule
+            suffix_filter_rule,
         )
 
     def toxml(self, element):
@@ -186,13 +200,22 @@ class CloudFuncConfig(CommonConfig):
 class QueueConfig(CommonConfig):
     """Queue configuration."""
 
-    def __init__(self, queue, events, config_id=None,
-                 prefix_filter_rule=None, suffix_filter_rule=None):
+    def __init__(
+        self,
+        queue,
+        events,
+        config_id=None,
+        prefix_filter_rule=None,
+        suffix_filter_rule=None,
+    ):
         if not queue:
             raise ValueError("queue must be provided")
         self._queue = queue
         super().__init__(
-            events, config_id, prefix_filter_rule, suffix_filter_rule,
+            events,
+            config_id,
+            prefix_filter_rule,
+            suffix_filter_rule,
         )
 
     @property
@@ -204,14 +227,14 @@ class QueueConfig(CommonConfig):
     def fromxml(cls, element):
         """Create new object with values from XML element."""
         queue = findtext(element, "Queue", True)
-        (events, config_id, prefix_filter_rule,
-         suffix_filter_rule) = cls.parsexml(element)
-        return cls(
-            queue,
+        (
             events,
             config_id,
             prefix_filter_rule,
-            suffix_filter_rule
+            suffix_filter_rule,
+        ) = cls.parsexml(element)
+        return cls(
+            queue, events, config_id, prefix_filter_rule, suffix_filter_rule
         )
 
     def toxml(self, element):
@@ -225,13 +248,22 @@ class QueueConfig(CommonConfig):
 class TopicConfig(CommonConfig):
     """Get topic configuration."""
 
-    def __init__(self, topic, events, config_id=None,
-                 prefix_filter_rule=None, suffix_filter_rule=None):
+    def __init__(
+        self,
+        topic,
+        events,
+        config_id=None,
+        prefix_filter_rule=None,
+        suffix_filter_rule=None,
+    ):
         if not topic:
             raise ValueError("topic must be provided")
         self._topic = topic
         super().__init__(
-            events, config_id, prefix_filter_rule, suffix_filter_rule,
+            events,
+            config_id,
+            prefix_filter_rule,
+            suffix_filter_rule,
         )
 
     @property
@@ -243,14 +275,14 @@ class TopicConfig(CommonConfig):
     def fromxml(cls, element):
         """Create new object with values from XML element."""
         topic = findtext(element, "Topic", True)
-        (events, config_id, prefix_filter_rule,
-         suffix_filter_rule) = cls.parsexml(element)
-        return cls(
-            topic,
+        (
             events,
             config_id,
             prefix_filter_rule,
-            suffix_filter_rule
+            suffix_filter_rule,
+        ) = cls.parsexml(element)
+        return cls(
+            topic, events, config_id, prefix_filter_rule, suffix_filter_rule
         )
 
     def toxml(self, element):
@@ -264,8 +296,12 @@ class TopicConfig(CommonConfig):
 class NotificationConfig:
     """Notification configuration."""
 
-    def __init__(self, cloud_func_config_list=None, queue_config_list=None,
-                 topic_config_list=None):
+    def __init__(
+        self,
+        cloud_func_config_list=None,
+        queue_config_list=None,
+        topic_config_list=None,
+    ):
         self._cloud_func_config_list = cloud_func_config_list or []
         self._queue_config_list = queue_config_list or []
         self._topic_config_list = topic_config_list or []
@@ -301,7 +337,9 @@ class NotificationConfig:
         for tag in elements:
             topic_config_list.append(TopicConfig.fromxml(tag))
         return cls(
-            cloud_func_config_list, queue_config_list, topic_config_list,
+            cloud_func_config_list,
+            queue_config_list,
+            topic_config_list,
         )
 
     def toxml(self, element):

--- a/minio/notificationconfig.py
+++ b/minio/notificationconfig.py
@@ -79,9 +79,7 @@ class CommonConfig:
 
     __metaclass__ = ABCMeta
 
-    def __init__(
-        self, events, config_id, prefix_filter_rule, suffix_filter_rule
-    ):
+    def __init__(self, events, config_id, prefix_filter_rule, suffix_filter_rule):
         if not events:
             raise ValueError("events must be provided")
         self._events = events
@@ -233,9 +231,7 @@ class QueueConfig(CommonConfig):
             prefix_filter_rule,
             suffix_filter_rule,
         ) = cls.parsexml(element)
-        return cls(
-            queue, events, config_id, prefix_filter_rule, suffix_filter_rule
-        )
+        return cls(queue, events, config_id, prefix_filter_rule, suffix_filter_rule)
 
     def toxml(self, element):
         """Convert to XML."""
@@ -281,9 +277,7 @@ class TopicConfig(CommonConfig):
             prefix_filter_rule,
             suffix_filter_rule,
         ) = cls.parsexml(element)
-        return cls(
-            topic, events, config_id, prefix_filter_rule, suffix_filter_rule
-        )
+        return cls(topic, events, config_id, prefix_filter_rule, suffix_filter_rule)
 
     def toxml(self, element):
         """Convert to XML."""

--- a/minio/replicationconfig.py
+++ b/minio/replicationconfig.py
@@ -26,6 +26,7 @@ from .xml import Element, SubElement, find, findall, findtext
 
 class Status:
     """Status."""
+
     __metaclass__ = ABCMeta
 
     def __init__(self, status):
@@ -70,7 +71,8 @@ class SourceSelectionCriteria:
         """Create new object with values from XML element."""
         element = find(element, "SourceSelectionCriteria")
         return cls(
-            None if find(element, "SseKmsEncryptedObjects") is None
+            None
+            if find(element, "SseKmsEncryptedObjects") is None
             else SseKmsEncryptedObjects.fromxml(element)
         )
 
@@ -95,6 +97,7 @@ class DeleteMarkerReplication(Status):
 
 class ReplicationTimeValue:
     """Replication time value."""
+
     __metaclass__ = ABCMeta
 
     def __init__(self, minutes=15):
@@ -255,10 +258,16 @@ class AccessControlTranslation:
 class Destination:
     """Replication destination."""
 
-    def __init__(self, bucket_arn,
-                 access_control_translation=None, account=None,
-                 encryption_config=None, metrics=None,
-                 replication_time=None, storage_class=None):
+    def __init__(
+        self,
+        bucket_arn,
+        access_control_translation=None,
+        account=None,
+        encryption_config=None,
+        metrics=None,
+        replication_time=None,
+        storage_class=None,
+    ):
         if not bucket_arn:
             raise ValueError("bucket ARN must be provided")
         self._bucket_arn = bucket_arn
@@ -276,7 +285,7 @@ class Destination:
 
     @property
     def access_control_translation(self):
-        """Get access control translation. """
+        """Get access control translation."""
         return self._access_control_translation
 
     @property
@@ -309,26 +318,37 @@ class Destination:
         """Create new object with values from XML element."""
         element = find(element, "Destination")
         access_control_translation = (
-            None if find(element, "AccessControlTranslation") is None
+            None
+            if find(element, "AccessControlTranslation") is None
             else AccessControlTranslation.fromxml(element)
         )
         account = findtext(element, "Account")
         bucket_arn = findtext(element, "Bucket", True)
         encryption_config = (
-            None if find(element, "EncryptionConfiguration") is None
+            None
+            if find(element, "EncryptionConfiguration") is None
             else EncryptionConfig.fromxml(element)
         )
         metrics = (
-            None if find(element, "Metrics") is None
+            None
+            if find(element, "Metrics") is None
             else Metrics.fromxml(element)
         )
         replication_time = (
-            None if find(element, "ReplicationTime") is None
+            None
+            if find(element, "ReplicationTime") is None
             else ReplicationTime.fromxml(element)
         )
         storage_class = findtext(element, "StorageClass")
-        return cls(bucket_arn, access_control_translation, account,
-                   encryption_config, metrics, replication_time, storage_class)
+        return cls(
+            bucket_arn,
+            access_control_translation,
+            account,
+            encryption_config,
+            metrics,
+            replication_time,
+            storage_class,
+        )
 
     def toxml(self, element):
         """Convert to XML."""
@@ -350,13 +370,20 @@ class Destination:
 
 
 class Rule(BaseRule):
-    """Replication rule. """
+    """Replication rule."""
 
-    def __init__(self, destination, status,
-                 delete_marker_replication=None,
-                 existing_object_replication=None,
-                 rule_filter=None, rule_id=None, prefix=None,
-                 priority=None, source_selection_criteria=None):
+    def __init__(
+        self,
+        destination,
+        status,
+        delete_marker_replication=None,
+        existing_object_replication=None,
+        rule_filter=None,
+        rule_id=None,
+        prefix=None,
+        priority=None,
+        source_selection_criteria=None,
+    ):
         if not destination:
             raise ValueError("destination must be provided")
 
@@ -413,12 +440,14 @@ class Rule(BaseRule):
     def fromxml(cls, element):
         """Create new object with values from XML element."""
         delete_marker_replication = (
-            None if find(element, "DeleteMarkerReplication") is None
+            None
+            if find(element, "DeleteMarkerReplication") is None
             else DeleteMarkerReplication.fromxml(element)
         )
         destination = Destination.fromxml(element)
         existing_object_replication = (
-            None if find(element, "ExistingObjectReplication") is None
+            None
+            if find(element, "ExistingObjectReplication") is None
             else ExistingObjectReplication.fromxml(element)
         )
         rule_filter, rule_id = cls.parsexml(element)
@@ -427,14 +456,23 @@ class Rule(BaseRule):
         if priority:
             priority = int(priority)
         source_selection_criteria = (
-            None if find(element, "SourceSelectionCriteria") is None
+            None
+            if find(element, "SourceSelectionCriteria") is None
             else SourceSelectionCriteria.fromxml(element)
         )
         status = findtext(element, "Status", True)
 
-        return cls(destination, status, delete_marker_replication,
-                   existing_object_replication, rule_filter,
-                   rule_id, prefix, priority, source_selection_criteria)
+        return cls(
+            destination,
+            status,
+            delete_marker_replication,
+            existing_object_replication,
+            rule_filter,
+            rule_id,
+            prefix,
+            priority,
+            source_selection_criteria,
+        )
 
     def toxml(self, element):
         """Convert to XML."""

--- a/minio/replicationconfig.py
+++ b/minio/replicationconfig.py
@@ -329,11 +329,7 @@ class Destination:
             if find(element, "EncryptionConfiguration") is None
             else EncryptionConfig.fromxml(element)
         )
-        metrics = (
-            None
-            if find(element, "Metrics") is None
-            else Metrics.fromxml(element)
-        )
+        metrics = None if find(element, "Metrics") is None else Metrics.fromxml(element)
         replication_time = (
             None
             if find(element, "ReplicationTime") is None

--- a/minio/select.py
+++ b/minio/select.py
@@ -47,14 +47,11 @@ class InputSerialization:
     __metaclass__ = ABCMeta
 
     def __init__(self, compression_type):
-        if (
-                compression_type is not None and
-                compression_type not in [
-                    COMPRESSION_TYPE_NONE,
-                    COMPRESSION_TYPE_GZIP,
-                    COMPRESSION_TYPE_BZIP2,
-                ]
-        ):
+        if compression_type is not None and compression_type not in [
+            COMPRESSION_TYPE_NONE,
+            COMPRESSION_TYPE_GZIP,
+            COMPRESSION_TYPE_BZIP2,
+        ]:
             raise ValueError(
                 f"compression type must be {COMPRESSION_TYPE_NONE}, "
                 f"{COMPRESSION_TYPE_GZIP} or {COMPRESSION_TYPE_BZIP2}"
@@ -71,23 +68,26 @@ class InputSerialization:
 class CSVInputSerialization(InputSerialization):
     """CSV input serialization."""
 
-    def __init__(self, compression_type=None,
-                 allow_quoted_record_delimiter=None, comments=None,
-                 field_delimiter=None, file_header_info=None,
-                 quote_character=None, quote_escape_character=None,
-                 record_delimiter=None):
+    def __init__(
+        self,
+        compression_type=None,
+        allow_quoted_record_delimiter=None,
+        comments=None,
+        field_delimiter=None,
+        file_header_info=None,
+        quote_character=None,
+        quote_escape_character=None,
+        record_delimiter=None,
+    ):
         super().__init__(compression_type)
         self._allow_quoted_record_delimiter = allow_quoted_record_delimiter
         self._comments = comments
         self._field_delimiter = field_delimiter
-        if (
-                file_header_info is not None and
-                file_header_info not in [
-                    FILE_HEADER_INFO_USE,
-                    FILE_HEADER_INFO_IGNORE,
-                    FILE_HEADER_INFO_NONE,
-                ]
-        ):
+        if file_header_info is not None and file_header_info not in [
+            FILE_HEADER_INFO_USE,
+            FILE_HEADER_INFO_IGNORE,
+            FILE_HEADER_INFO_NONE,
+        ]:
             raise ValueError(
                 f"file header info must be {FILE_HEADER_INFO_USE}, "
                 f"{FILE_HEADER_INFO_IGNORE} or {FILE_HEADER_INFO_NONE}"
@@ -130,10 +130,10 @@ class JSONInputSerialization(InputSerialization):
 
     def __init__(self, compression_type=None, json_type=None):
         super().__init__(compression_type)
-        if (
-                json_type is not None and
-                json_type not in [JSON_TYPE_DOCUMENT, JSON_TYPE_LINES]
-        ):
+        if json_type is not None and json_type not in [
+            JSON_TYPE_DOCUMENT,
+            JSON_TYPE_LINES,
+        ]:
             raise ValueError(
                 f"json type must be {JSON_TYPE_DOCUMENT} or {JSON_TYPE_LINES}"
             )
@@ -162,18 +162,21 @@ class ParquetInputSerialization(InputSerialization):
 class CSVOutputSerialization:
     """CSV output serialization."""
 
-    def __init__(self, field_delimiter=None, quote_character=None,
-                 quote_escape_character=None, quote_fields=None,
-                 record_delimiter=None):
+    def __init__(
+        self,
+        field_delimiter=None,
+        quote_character=None,
+        quote_escape_character=None,
+        quote_fields=None,
+        record_delimiter=None,
+    ):
         self._field_delimiter = field_delimiter
         self._quote_character = quote_character
         self._quote_escape_character = quote_escape_character
-        if (
-                quote_fields is not None and
-                quote_fields not in [
-                    QUOTE_FIELDS_ALWAYS, QUOTE_FIELDS_ASNEEDED,
-                ]
-        ):
+        if quote_fields is not None and quote_fields not in [
+            QUOTE_FIELDS_ALWAYS,
+            QUOTE_FIELDS_ASNEEDED,
+        ]:
             raise ValueError(
                 f"quote fields must be {QUOTE_FIELDS_ALWAYS} or "
                 f"{QUOTE_FIELDS_ASNEEDED}"
@@ -216,17 +219,23 @@ class JSONOutputSerialization:
 class SelectRequest:
     """Select object content request."""
 
-    def __init__(self, expression, input_serialization, output_serialization,
-                 request_progress=False, scan_start_range=None,
-                 scan_end_range=None):
+    def __init__(
+        self,
+        expression,
+        input_serialization,
+        output_serialization,
+        request_progress=False,
+        scan_start_range=None,
+        scan_end_range=None,
+    ):
         self._expression = expression
         if not isinstance(
-                input_serialization,
-                (
-                    CSVInputSerialization,
-                    JSONInputSerialization,
-                    ParquetInputSerialization,
-                ),
+            input_serialization,
+            (
+                CSVInputSerialization,
+                JSONInputSerialization,
+                ParquetInputSerialization,
+            ),
         ):
             raise ValueError(
                 "input serialization must be CSVInputSerialization, "
@@ -234,8 +243,8 @@ class SelectRequest:
             )
         self._input_serialization = input_serialization
         if not isinstance(
-                output_serialization,
-                (CSVOutputSerialization, JSONOutputSerialization),
+            output_serialization,
+            (CSVOutputSerialization, JSONOutputSerialization),
         ):
             raise ValueError(
                 "output serialization must be CSVOutputSerialization or "
@@ -259,7 +268,9 @@ class SelectRequest:
         )
         if self._request_progress:
             SubElement(
-                SubElement(element, "RequestProgress"), "Enabled", "true",
+                SubElement(element, "RequestProgress"),
+                "Enabled",
+                "true",
             )
         if self._scan_start_range or self._scan_end_range:
             tag = SubElement(element, "ScanRange")
@@ -285,7 +296,7 @@ def _int(data):
 
 def _crc32(data):
     """Wrapper to binascii.crc32()."""
-    return crc32(data) & 0xffffffff
+    return crc32(data) & 0xFFFFFFFF
 
 
 def _decode_header(data):
@@ -401,7 +412,7 @@ class SelectObjectReader:
         if headers.get(":event-type") == "Cont" or payload_length < 1:
             return self._read()
 
-        payload = data[header_length:header_length+payload_length]
+        payload = data[header_length : header_length + payload_length]
 
         if headers.get(":event-type") in ["Progress", "Stats"]:
             self._stats = Stats(payload)
@@ -415,7 +426,7 @@ class SelectObjectReader:
             f"unknown event-type {headers.get(':event-type')}",
         )
 
-    def stream(self, num_bytes=32*1024):
+    def stream(self, num_bytes=32 * 1024):
         """
         Stream extracted payload from response data. Upon completion, caller
         should call self.close() to release network resources.
@@ -425,5 +436,5 @@ class SelectObjectReader:
                 result = self._payload
                 if num_bytes < len(self._payload):
                     result = self._payload[:num_bytes]
-                self._payload = self._payload[len(result):]
+                self._payload = self._payload[len(result) :]
                 yield result

--- a/minio/sse.py
+++ b/minio/sse.py
@@ -31,6 +31,7 @@ from abc import ABCMeta, abstractmethod
 
 class Sse:
     """Server-side encryption base class."""
+
     __metaclass__ = ABCMeta
 
     @abstractmethod
@@ -47,7 +48,7 @@ class Sse:
 
 
 class SseCustomerKey(Sse):
-    """ Server-side encryption - customer key type."""
+    """Server-side encryption - customer key type."""
 
     def __init__(self, key):
         if len(key) != 32:
@@ -55,8 +56,10 @@ class SseCustomerKey(Sse):
                 "SSE-C keys need to be 256 bit base64 encoded",
             )
         b64key = base64.b64encode(key).decode()
-        from .helpers import \
-            md5sum_hash  # pylint: disable=import-outside-toplevel
+        from .helpers import (
+            md5sum_hash,
+        )  # pylint: disable=import-outside-toplevel
+
         md5key = md5sum_hash(key)
         self._headers = {
             "X-Amz-Server-Side-Encryption-Customer-Algorithm": "AES256",
@@ -64,11 +67,9 @@ class SseCustomerKey(Sse):
             "X-Amz-Server-Side-Encryption-Customer-Key-MD5": md5key,
         }
         self._copy_headers = {
-            "X-Amz-Copy-Source-Server-Side-Encryption-Customer-Algorithm":
-            "AES256",
+            "X-Amz-Copy-Source-Server-Side-Encryption-Customer-Algorithm": "AES256",
             "X-Amz-Copy-Source-Server-Side-Encryption-Customer-Key": b64key,
-            "X-Amz-Copy-Source-Server-Side-Encryption-Customer-Key-MD5":
-            md5key,
+            "X-Amz-Copy-Source-Server-Side-Encryption-Customer-Key-MD5": md5key,
         }
 
     def headers(self):
@@ -84,13 +85,13 @@ class SseKMS(Sse):
     def __init__(self, key, context):
         self._headers = {
             "X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id": key,
-            "X-Amz-Server-Side-Encryption": "aws:kms"
+            "X-Amz-Server-Side-Encryption": "aws:kms",
         }
         if context:
             data = bytes(json.dumps(context), "utf-8")
-            self._headers["X-Amz-Server-Side-Encryption-Context"] = (
-                base64.b64encode(data).decode()
-            )
+            self._headers[
+                "X-Amz-Server-Side-Encryption-Context"
+            ] = base64.b64encode(data).decode()
 
     def headers(self):
         return self._headers.copy()
@@ -100,9 +101,7 @@ class SseS3(Sse):
     """Server-side encryption - S3 type."""
 
     def headers(self):
-        return {
-            "X-Amz-Server-Side-Encryption": "AES256"
-        }
+        return {"X-Amz-Server-Side-Encryption": "AES256"}
 
     def tls_required(self):
         return False

--- a/minio/sse.py
+++ b/minio/sse.py
@@ -89,9 +89,9 @@ class SseKMS(Sse):
         }
         if context:
             data = bytes(json.dumps(context), "utf-8")
-            self._headers[
-                "X-Amz-Server-Side-Encryption-Context"
-            ] = base64.b64encode(data).decode()
+            self._headers["X-Amz-Server-Side-Encryption-Context"] = base64.b64encode(
+                data
+            ).decode()
 
     def headers(self):
         return self._headers.copy()

--- a/minio/sse.py
+++ b/minio/sse.py
@@ -56,9 +56,7 @@ class SseCustomerKey(Sse):
                 "SSE-C keys need to be 256 bit base64 encoded",
             )
         b64key = base64.b64encode(key).decode()
-        from .helpers import (
-            md5sum_hash,
-        )  # pylint: disable=import-outside-toplevel
+        from .helpers import md5sum_hash  # pylint: disable=import-outside-toplevel
 
         md5key = md5sum_hash(key)
         self._headers = {

--- a/minio/sseconfig.py
+++ b/minio/sseconfig.py
@@ -27,7 +27,8 @@ AWS_KMS = "aws:kms"
 
 
 class Rule:
-    """Server-side encryption rule. """
+    """Server-side encryption rule."""
+
     __metaclass__ = ABCMeta
 
     def __init__(self, sse_algorithm, kms_master_key_id=None):

--- a/minio/tagging.py
+++ b/minio/tagging.py
@@ -37,10 +37,7 @@ class Tagging:
     def fromxml(cls, element):
         """Create new object with values from XML element."""
         element = find(element, "TagSet")
-        tags = (
-            None if find(element, "Tag") is None
-            else Tags.fromxml(element)
-        )
+        tags = None if find(element, "Tag") is None else Tags.fromxml(element)
         return cls(tags)
 
     def toxml(self, element):

--- a/minio/time.py
+++ b/minio/time.py
@@ -22,15 +22,28 @@ import time as ctime
 from datetime import datetime, timezone
 
 _WEEK_DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
-_MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct",
-           "Nov", "Dec"]
+_MONTHS = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+]
 
 
 def _to_utc(value):
     """Convert to UTC time if value is not naive."""
     return (
         value.astimezone(timezone.utc).replace(tzinfo=None)
-        if value.tzinfo else value
+        if value.tzinfo
+        else value
     )
 
 
@@ -52,35 +65,29 @@ def to_iso8601utc(value):
         return None
 
     value = _to_utc(value)
-    return (
-        value.strftime("%Y-%m-%dT%H:%M:%S.") + value.strftime("%f")[:3] + "Z"
-    )
+    return value.strftime("%Y-%m-%dT%H:%M:%S.") + value.strftime("%f")[:3] + "Z"
 
 
 def from_http_header(value):
     """Parse HTTP header date formatted string to datetime."""
     if len(value) != 29:
-        raise ValueError(
-            f"time data {value} does not match HTTP header format")
+        raise ValueError(f"time data {value} does not match HTTP header format")
 
     if value[0:3] not in _WEEK_DAYS or value[3] != ",":
-        raise ValueError(
-            f"time data {value} does not match HTTP header format")
+        raise ValueError(f"time data {value} does not match HTTP header format")
     weekday = _WEEK_DAYS.index(value[0:3])
 
     day = datetime.strptime(value[4:8], " %d ").day
 
     if value[8:11] not in _MONTHS:
-        raise ValueError(
-            f"time data {value} does not match HTTP header format")
+        raise ValueError(f"time data {value} does not match HTTP header format")
     month = _MONTHS.index(value[8:11])
 
     time = datetime.strptime(value[11:], " %Y %H:%M:%S GMT")
-    time = time.replace(day=day, month=month+1, tzinfo=timezone.utc)
+    time = time.replace(day=day, month=month + 1, tzinfo=timezone.utc)
 
     if weekday != time.weekday():
-        raise ValueError(
-            f"time data {value} does not match HTTP header format")
+        raise ValueError(f"time data {value} does not match HTTP header format")
 
     return time
 

--- a/minio/time.py
+++ b/minio/time.py
@@ -41,9 +41,7 @@ _MONTHS = [
 def _to_utc(value):
     """Convert to UTC time if value is not naive."""
     return (
-        value.astimezone(timezone.utc).replace(tzinfo=None)
-        if value.tzinfo
-        else value
+        value.astimezone(timezone.utc).replace(tzinfo=None) if value.tzinfo else value
     )
 
 

--- a/minio/xml.py
+++ b/minio/xml.py
@@ -26,7 +26,7 @@ _S3_NAMESPACE = "http://s3.amazonaws.com/doc/2006-03-01/"
 
 def Element(tag, namespace=_S3_NAMESPACE):  # pylint: disable=invalid-name
     """Create ElementTree.Element with tag and namespace."""
-    return ET.Element(tag, {'xmlns': namespace} if namespace else {})
+    return ET.Element(tag, {"xmlns": namespace} if namespace else {})
 
 
 def SubElement(parent, tag, text=None):  # pylint: disable=invalid-name
@@ -89,7 +89,9 @@ def getbytes(element):
     """Convert ElementTree.Element to bytes."""
     data = io.BytesIO()
     ET.ElementTree(element).write(
-        data, encoding=None, xml_declaration=False,
+        data,
+        encoding=None,
+        xml_declaration=False,
     )
     return data.getvalue()
 

--- a/pylintrc
+++ b/pylintrc
@@ -1,11 +1,11 @@
 # lint Python modules using external checkers.
-# 
+#
 # This is the main checker controlling the other ones and the reports
 # generation. It is itself both a raw checker and an astng checker in order
 # to:
 # * handle message activation / deactivation at the module level
 # * handle some basic but necessary stats'data (number of classes, methods...)
-# 
+#
 [MASTER]
 
 
@@ -89,7 +89,7 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 # * undefined variables
 # * redefinition of variable from builtins or from an outer scope
 # * use of variable before assignment
-# 
+#
 [VARIABLES]
 
 # Tells whether we should check for unused import in __init__ files.
@@ -104,7 +104,7 @@ additional-builtins=
 
 
 # try to find bugs in the code using type inference
-# 
+#
 [TYPECHECK]
 
 # Tells whether missing members accessed in mixin class should be ignored. A
@@ -129,7 +129,7 @@ ignore-mixin-members=yes
 # * dangerous default values as arguments
 # * redefinition of function / method / class
 # * uses of the global statement
-# 
+#
 [BASIC]
 
 # Required attributes for module, separated by a comma
@@ -180,7 +180,7 @@ bad-names=foo,bar,baz,toto,tutu,tata
 # checks for sign of poor/misdesign:
 # * number of methods, attributes, local variables...
 # * size, complexity of functions, methods
-# 
+#
 [DESIGN]
 
 # Maximum number of arguments for function / method
@@ -216,7 +216,7 @@ max-public-methods=20
 # * relative / wildcard imports
 # * cyclic imports
 # * uses of deprecated modules
-# 
+#
 [IMPORTS]
 
 # Deprecated modules which should not be used, separated by a comma
@@ -242,7 +242,7 @@ int-import-graph=
 # * attributes not defined in the __init__ method
 # * supported interfaces implementation
 # * unreachable code
-# 
+#
 [CLASSES]
 
 # List of interface methods to ignore, separated by a comma. This is used for
@@ -256,7 +256,7 @@ defining-attr-methods=__init__,__new__,setUp
 # checks for similarities and duplicated code. This computation may be
 # memory / CPU intensive, so you should disable it if you experiments some
 # problems.
-# 
+#
 [SIMILARITIES]
 
 # Minimum lines number of a similarity.
@@ -272,7 +272,7 @@ ignore-docstrings=yes
 # checks for:
 # * warning notes in the code like FIXME, XXX
 # * PEP 263: source code with non ascii character but no encoding declaration
-# 
+#
 [MISCELLANEOUS]
 
 # List of note tags to take in consideration, separated by a comma.
@@ -284,11 +284,11 @@ notes=FIXME,XXX,TODO,BUG:
 # * strict indentation
 # * line length
 # * use of <> instead of !=
-# 
+#
 [FORMAT]
 
 # Maximum number of characters on a single line.
-max-line-length=80
+max-line-length=88
 
 # Maximum number of lines in a module
 max-module-lines=1000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 80
+target-version = ['py37']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,2 @@
 [tool.black]
-line-length = 80
 target-version = ['py37']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
 [tool.black]
 target-version = ['py37']
+
+[tool.isort]
+profile = 'black'

--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -45,11 +45,7 @@ from minio.commonconfig import ENABLED, REPLACE, CopySource, SnowballObject
 from minio.datatypes import PostPolicy
 from minio.deleteobjects import DeleteObject
 from minio.error import S3Error
-from minio.select import (
-    CSVInputSerialization,
-    CSVOutputSerialization,
-    SelectRequest,
-)
+from minio.select import CSVInputSerialization, CSVOutputSerialization, SelectRequest
 from minio.sse import SseCustomerKey
 from minio.time import to_http_header
 from minio.versioningconfig import VersioningConfig

--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -45,8 +45,11 @@ from minio.commonconfig import ENABLED, REPLACE, CopySource, SnowballObject
 from minio.datatypes import PostPolicy
 from minio.deleteobjects import DeleteObject
 from minio.error import S3Error
-from minio.select import (CSVInputSerialization, CSVOutputSerialization,
-                          SelectRequest)
+from minio.select import (
+    CSVInputSerialization,
+    CSVOutputSerialization,
+    SelectRequest,
+)
 from minio.sse import SseCustomerKey
 from minio.time import to_http_header
 from minio.versioningconfig import VersioningConfig
@@ -58,8 +61,8 @@ _IS_AWS = None  # initialized in main().
 KB = 1024
 MB = 1024 * KB
 HTTP = urllib3.PoolManager(
-    cert_reqs='CERT_REQUIRED',
-    ca_certs=os.environ.get('SSL_CERT_FILE') or certifi.where()
+    cert_reqs="CERT_REQUIRED",
+    ca_certs=os.environ.get("SSL_CERT_FILE") or certifi.where(),
 )
 
 
@@ -70,7 +73,7 @@ def _gen_bucket_name():
 
 def _get_sha256sum(filename):
     """Get SHA-256 checksum of given file."""
-    with open(filename, 'rb') as file:
+    with open(filename, "rb") as file:
         contents = file.read()
         return hashlib.sha256(contents).hexdigest()
 
@@ -93,7 +96,7 @@ class LimitedRandomReader:  # pylint: disable=too-few-public-methods
     def __init__(self, limit):
         self._limit = limit
 
-    def read(self, size=64*KB):
+    def read(self, size=64 * KB):
         """Read random data of specified size."""
         if size < 0 or size > self._limit:
             size = self._limit
@@ -139,14 +142,13 @@ def _call_test(func, *args, **kwargs):
 
     if log_entry.get("method"):
         # pylint: disable=deprecated-method
-        args_string = ', '.join(getfullargspec(log_entry["method"]).args[1:])
+        args_string = ", ".join(getfullargspec(log_entry["method"]).args[1:])
         log_entry["function"] = f"{log_entry['method'].__name__}({args_string})"
     log_entry["args"] = {
         k: v for k, v in log_entry.get("args", {}).items() if v
     }
-    log_entry["duration"] = int(
-        round((time.time() - start_time) * 1000))
-    log_entry["name"] = 'minio-py:' + log_entry["name"]
+    log_entry["duration"] = int(round((time.time() - start_time) * 1000))
+    log_entry["name"] = "minio-py:" + log_entry["name"]
     log_entry["method"] = None
     print(json.dumps({k: v for k, v in log_entry.items() if v}))
     if log_entry["status"] == "FAIL":
@@ -184,7 +186,7 @@ def test_make_bucket_with_region(log_entry):
     # Get a unique bucket_name
     bucket_name = _gen_bucket_name()
     # A non-default location
-    location = 'us-west-1'
+    location = "us-west-1"
 
     log_entry["args"] = {
         "bucket_name": bucket_name,
@@ -202,7 +204,8 @@ def test_make_bucket_with_region(log_entry):
 
 
 def test_negative_make_bucket_invalid_name(  # pylint: disable=invalid-name
-        log_entry):
+    log_entry,
+):
     """Test make_bucket() with invalid bucket name."""
 
     # Get a unique bucket_name
@@ -213,9 +216,9 @@ def test_negative_make_bucket_invalid_name(  # pylint: disable=invalid-name
     }
     # Create an array of invalid bucket names to test
     invalid_bucket_name_list = [
-        bucket_name + '.',
-        '.' + bucket_name,
-        bucket_name + '...abcd'
+        bucket_name + ".",
+        "." + bucket_name,
+        bucket_name + "...abcd",
     ]
     for name in invalid_bucket_name_list:
         log_entry["args"]["bucket_name"] = name
@@ -230,7 +233,7 @@ def test_negative_make_bucket_invalid_name(  # pylint: disable=invalid-name
             pass
     # Test passes
     log_entry["method"] = _CLIENT.make_bucket
-    log_entry["args"]['bucket_name'] = invalid_bucket_name_list
+    log_entry["args"]["bucket_name"] = invalid_bucket_name_list
 
 
 def test_list_buckets(log_entry):
@@ -248,7 +251,7 @@ def test_list_buckets(log_entry):
             # bucket object should be of a valid value.
             if bucket.name and bucket.creation_date:
                 continue
-            raise ValueError('list_bucket api failure')
+            raise ValueError("list_bucket api failure")
     finally:
         # Remove bucket
         _call(log_entry, _CLIENT.remove_bucket, bucket_name)
@@ -259,7 +262,7 @@ def test_select_object_content(log_entry):
 
     # Get a unique bucket_name and object_name
     bucket_name = _gen_bucket_name()
-    csvfile = 'test.csv'
+    csvfile = "test.csv"
 
     log_entry["args"] = {
         "bucket_name": bucket_name,
@@ -269,8 +272,9 @@ def test_select_object_content(log_entry):
     try:
         _CLIENT.make_bucket(bucket_name)
         content = io.BytesIO(b"col1,col2,col3\none,two,three\nX,Y,Z\n")
-        _CLIENT.put_object(bucket_name, csvfile, content,
-                           len(content.getvalue()))
+        _CLIENT.put_object(
+            bucket_name, csvfile, content, len(content.getvalue())
+        )
 
         request = SelectRequest(
             "select * from s3object",
@@ -284,13 +288,14 @@ def test_select_object_content(log_entry):
         for data_bytes in data.stream(16):
             records.write(data_bytes)
 
-        expected_crc = crc32(content.getvalue()) & 0xffffffff
-        generated_crc = crc32(records.getvalue()) & 0xffffffff
+        expected_crc = crc32(content.getvalue()) & 0xFFFFFFFF
+        generated_crc = crc32(records.getvalue()) & 0xFFFFFFFF
         if expected_crc != generated_crc:
             raise ValueError(
-                'Data mismatch Expected : '
+                "Data mismatch Expected : "
                 '"col1,col2,col3\none,two,three\nX,Y,Z\n"',
-                f"Received {records.getvalue().decode()}")
+                f"Received {records.getvalue().decode()}",
+            )
     finally:
         _CLIENT.remove_object(bucket_name, csvfile)
         _CLIENT.remove_bucket(bucket_name)
@@ -301,8 +306,9 @@ def _test_fput_object(bucket_name, object_name, filename, metadata, sse):
     try:
         _CLIENT.make_bucket(bucket_name)
         if _IS_AWS:
-            _CLIENT.fput_object(bucket_name, object_name, filename,
-                                metadata=metadata, sse=sse)
+            _CLIENT.fput_object(
+                bucket_name, object_name, filename, metadata=metadata, sse=sse
+            )
         else:
             _CLIENT.fput_object(bucket_name, object_name, filename, sse=sse)
 
@@ -321,7 +327,7 @@ def test_fput_object_small_file(log_entry, sse=None):
     # Get a unique bucket_name and object_name
     bucket_name = _gen_bucket_name()
     object_name = f"{uuid4()}-f"
-    metadata = {'x-amz-storage-class': 'STANDARD_IA'}
+    metadata = {"x-amz-storage-class": "STANDARD_IA"}
 
     log_entry["args"] = {
         "bucket_name": bucket_name,
@@ -342,7 +348,7 @@ def test_fput_object_large_file(log_entry, sse=None):
     # Get a unique bucket_name and object_name
     bucket_name = _gen_bucket_name()
     object_name = f"{uuid4()}-large"
-    metadata = {'x-amz-storage-class': 'STANDARD_IA'}
+    metadata = {"x-amz-storage-class": "STANDARD_IA"}
 
     log_entry["args"] = {
         "bucket_name": bucket_name,
@@ -356,14 +362,15 @@ def test_fput_object_large_file(log_entry, sse=None):
 
 
 def test_fput_object_with_content_type(  # pylint: disable=invalid-name
-        log_entry):
+    log_entry,
+):
     """Test fput_object() with content-type."""
 
     # Get a unique bucket_name and object_name
     bucket_name = _gen_bucket_name()
     object_name = f"{uuid4()}-f"
-    metadata = {'x-amz-storage-class': 'STANDARD_IA'}
-    content_type = 'application/octet-stream'
+    metadata = {"x-amz-storage-class": "STANDARD_IA"}
+    content_type = "application/octet-stream"
 
     log_entry["args"] = {
         "bucket_name": bucket_name,
@@ -391,7 +398,7 @@ def _validate_stat(st_obj, expected_size, expected_meta, version_id=None):
     received_is_dir = st_obj.is_dir
 
     if not received_etag:
-        raise ValueError('No Etag value is returned.')
+        raise ValueError("No Etag value is returned.")
 
     if st_obj.version_id != version_id:
         raise ValueError(
@@ -402,25 +409,37 @@ def _validate_stat(st_obj, expected_size, expected_meta, version_id=None):
     # content_type by default can be either application/octet-stream or
     # binary/octet-stream
     if received_content_type not in [
-            'application/octet-stream', 'binary/octet-stream']:
-        raise ValueError('Incorrect content type. Expected: ',
-                         "'application/octet-stream' or 'binary/octet-stream',"
-                         " received: ", received_content_type)
+        "application/octet-stream",
+        "binary/octet-stream",
+    ]:
+        raise ValueError(
+            "Incorrect content type. Expected: ",
+            "'application/octet-stream' or 'binary/octet-stream',"
+            " received: ",
+            received_content_type,
+        )
 
     if received_size != expected_size:
-        raise ValueError('Incorrect file size. Expected: 11534336',
-                         ', received: ', received_size)
+        raise ValueError(
+            "Incorrect file size. Expected: 11534336",
+            ", received: ",
+            received_size,
+        )
 
     if received_is_dir:
-        raise ValueError('Incorrect file type. Expected: is_dir=False',
-                         ', received: is_dir=', received_is_dir)
+        raise ValueError(
+            "Incorrect file type. Expected: is_dir=False",
+            ", received: is_dir=",
+            received_is_dir,
+        )
 
     if not all(i in received_metadata.items() for i in expected_meta.items()):
         raise ValueError("Metadata key 'x-amz-meta-testing' not found")
 
 
 def test_copy_object_no_copy_condition(  # pylint: disable=invalid-name
-        log_entry, ssec_copy=None, ssec=None):
+    log_entry, ssec_copy=None, ssec=None
+):
     """Test copy_object() with no conditiions."""
 
     if ssec_copy or ssec:
@@ -445,7 +464,9 @@ def test_copy_object_no_copy_condition(  # pylint: disable=invalid-name
         reader = LimitedRandomReader(size)
         _CLIENT.put_object(bucket_name, object_source, reader, size, sse=ssec)
         _CLIENT.copy_object(
-            bucket_name, object_copy, sse=ssec,
+            bucket_name,
+            object_copy,
+            sse=ssec,
             source=CopySource(bucket_name, object_source, ssec=ssec_copy),
         )
         st_obj = _CLIENT.stat_object(bucket_name, object_copy, ssec=ssec)
@@ -467,7 +488,7 @@ def test_copy_object_with_metadata(log_entry):
     metadata = {
         "testing-string": "string",
         "testing-int": 1,
-        10: 'value',
+        10: "value",
     }
 
     log_entry["args"] = {
@@ -485,14 +506,19 @@ def test_copy_object_with_metadata(log_entry):
         _CLIENT.put_object(bucket_name, object_source, reader, size)
         # Perform a server side copy of an object
         _CLIENT.copy_object(
-            bucket_name, object_copy, CopySource(bucket_name, object_source),
-            metadata=metadata, metadata_directive=REPLACE,
+            bucket_name,
+            object_copy,
+            CopySource(bucket_name, object_source),
+            metadata=metadata,
+            metadata_directive=REPLACE,
         )
         # Verification
         st_obj = _CLIENT.stat_object(bucket_name, object_copy)
-        expected_metadata = {'x-amz-meta-testing-int': '1',
-                             'x-amz-meta-testing-string': 'string',
-                             'x-amz-meta-10': 'value'}
+        expected_metadata = {
+            "x-amz-meta-testing-int": "1",
+            "x-amz-meta-testing-string": "string",
+            "x-amz-meta-10": "value",
+        }
         _validate_stat(st_obj, size, expected_metadata)
     finally:
         _CLIENT.remove_object(bucket_name, object_source)
@@ -523,13 +549,16 @@ def test_copy_object_etag_match(log_entry):
         _CLIENT.put_object(bucket_name, object_source, reader, size)
         # Perform a server side copy of an object
         _CLIENT.copy_object(
-            bucket_name, object_copy, CopySource(bucket_name, object_source),
+            bucket_name,
+            object_copy,
+            CopySource(bucket_name, object_source),
         )
         # Verification
         source_etag = _CLIENT.stat_object(bucket_name, object_source).etag
-        log_entry["args"]["conditions"] = {'set_match_etag': source_etag}
+        log_entry["args"]["conditions"] = {"set_match_etag": source_etag}
         _CLIENT.copy_object(
-            bucket_name, object_copy,
+            bucket_name,
+            object_copy,
             CopySource(bucket_name, object_source, match_etag=source_etag),
         )
     finally:
@@ -539,7 +568,8 @@ def test_copy_object_etag_match(log_entry):
 
 
 def test_copy_object_negative_etag_match(  # pylint: disable=invalid-name
-        log_entry):
+    log_entry,
+):
     """Test copy_object() with etag not match condition."""
 
     # Get a unique bucket_name and object_name
@@ -563,10 +593,11 @@ def test_copy_object_negative_etag_match(  # pylint: disable=invalid-name
         try:
             # Perform a server side copy of an object
             # with incorrect pre-conditions and fail
-            etag = 'test-etag'
-            log_entry["args"]["conditions"] = {'set_match_etag': etag}
+            etag = "test-etag"
+            log_entry["args"]["conditions"] = {"set_match_etag": etag}
             _CLIENT.copy_object(
-                bucket_name, object_copy,
+                bucket_name,
+                object_copy,
                 CopySource(bucket_name, object_source, match_etag=etag),
             )
         except S3Error as exc:
@@ -602,11 +633,13 @@ def test_copy_object_modified_since(log_entry):
         # Set up the 'modified_since' copy condition
         mod_since = datetime(2014, 4, 1, tzinfo=timezone.utc)
         log_entry["args"]["conditions"] = {
-            'set_modified_since': to_http_header(mod_since)}
+            "set_modified_since": to_http_header(mod_since)
+        }
         # Perform a server side copy of an object
         # and expect the copy to complete successfully
         _CLIENT.copy_object(
-            bucket_name, object_copy,
+            bucket_name,
+            object_copy,
             CopySource(bucket_name, object_source, modified_since=mod_since),
         )
     finally:
@@ -616,7 +649,8 @@ def test_copy_object_modified_since(log_entry):
 
 
 def test_copy_object_unmodified_since(  # pylint: disable=invalid-name
-        log_entry):
+    log_entry,
+):
     """Test copy_object() with unmodified since condition."""
 
     # Get a unique bucket_name and object_name
@@ -640,15 +674,19 @@ def test_copy_object_unmodified_since(  # pylint: disable=invalid-name
         # Set up the 'unmodified_since' copy condition
         unmod_since = datetime(2014, 4, 1, tzinfo=timezone.utc)
         log_entry["args"]["conditions"] = {
-            'set_unmodified_since': to_http_header(unmod_since)}
+            "set_unmodified_since": to_http_header(unmod_since)
+        }
         try:
             # Perform a server side copy of an object and expect
             # the copy to fail since the creation/modification
             # time is now, way later than unmodification time, April 1st, 2014
             _CLIENT.copy_object(
-                bucket_name, object_copy,
+                bucket_name,
+                object_copy,
                 CopySource(
-                    bucket_name, object_source, unmodified_since=unmod_since,
+                    bucket_name,
+                    object_source,
+                    unmodified_since=unmod_since,
                 ),
             )
         except S3Error as exc:
@@ -675,7 +713,7 @@ def test_put_object(log_entry, sse=None):
         "bucket_name": bucket_name,
         "object_name": object_name,
         "length": length,
-        "data": "LimitedRandomReader(1 * MB)"
+        "data": "LimitedRandomReader(1 * MB)",
     }
 
     try:
@@ -690,36 +728,47 @@ def test_put_object(log_entry, sse=None):
         reader = LimitedRandomReader(length)
         log_entry["args"]["data"] = "LimitedRandomReader(11 * MB)"
         log_entry["args"]["metadata"] = metadata = {
-            'x-amz-meta-testing': 'value', 'test-key': 'value2'}
-        log_entry["args"]["content_type"] = content_type = (
-            "application/octet-stream")
+            "x-amz-meta-testing": "value",
+            "test-key": "value2",
+        }
+        log_entry["args"][
+            "content_type"
+        ] = content_type = "application/octet-stream"
         log_entry["args"]["object_name"] = object_name + "-metadata"
-        _CLIENT.put_object(bucket_name, object_name + "-metadata", reader,
-                           length, content_type, metadata, sse=sse)
+        _CLIENT.put_object(
+            bucket_name,
+            object_name + "-metadata",
+            reader,
+            length,
+            content_type,
+            metadata,
+            sse=sse,
+        )
         # Stat on the uploaded object to check if it exists
         # Fetch saved stat metadata on a previously uploaded object with
         # metadata.
-        st_obj = _CLIENT.stat_object(bucket_name, object_name + "-metadata",
-                                     ssec=sse)
+        st_obj = _CLIENT.stat_object(
+            bucket_name, object_name + "-metadata", ssec=sse
+        )
         normalized_meta = {
-            key.lower(): value for key, value in (
-                st_obj.metadata or {}).items()
+            key.lower(): value for key, value in (st_obj.metadata or {}).items()
         }
-        if 'x-amz-meta-testing' not in normalized_meta:
+        if "x-amz-meta-testing" not in normalized_meta:
             raise ValueError("Metadata key 'x-amz-meta-testing' not found")
-        value = normalized_meta['x-amz-meta-testing']
-        if value != 'value':
+        value = normalized_meta["x-amz-meta-testing"]
+        if value != "value":
             raise ValueError(f"Metadata key has unexpected value {value}")
-        if 'x-amz-meta-test-key' not in normalized_meta:
+        if "x-amz-meta-test-key" not in normalized_meta:
             raise ValueError("Metadata key 'x-amz-meta-test-key' not found")
     finally:
         _CLIENT.remove_object(bucket_name, object_name)
-        _CLIENT.remove_object(bucket_name, object_name+'-metadata')
+        _CLIENT.remove_object(bucket_name, object_name + "-metadata")
         _CLIENT.remove_bucket(bucket_name)
 
 
 def test_negative_put_object_with_path_segment(  # pylint: disable=invalid-name
-        log_entry):
+    log_entry,
+):
     """Test put_object() failure with path segment."""
 
     # Get a unique bucket_name and object_name
@@ -736,10 +785,10 @@ def test_negative_put_object_with_path_segment(  # pylint: disable=invalid-name
 
     try:
         _CLIENT.make_bucket(bucket_name)
-        _CLIENT.put_object(bucket_name, object_name, io.BytesIO(b''), 0)
+        _CLIENT.put_object(bucket_name, object_name, io.BytesIO(b""), 0)
         _CLIENT.remove_object(bucket_name, object_name)
     except S3Error as err:
-        if err.code != 'XMinioInvalidObjectName':
+        if err.code != "XMinioInvalidObjectName":
             raise
     finally:
         _CLIENT.remove_bucket(bucket_name)
@@ -760,7 +809,7 @@ def _test_stat_object(log_entry, sse=None, version_check=False):
         "bucket_name": bucket_name,
         "object_name": object_name,
         "length": length,
-        "data": "LimitedRandomReader(1 * MB)"
+        "data": "LimitedRandomReader(1 * MB)",
     }
 
     version_id1 = None
@@ -770,16 +819,24 @@ def _test_stat_object(log_entry, sse=None, version_check=False):
     try:
         if version_check:
             _CLIENT.set_bucket_versioning(
-                bucket_name, VersioningConfig(ENABLED),
+                bucket_name,
+                VersioningConfig(ENABLED),
             )
         # Put/Upload a streaming object of 1 MiB
         reader = LimitedRandomReader(length)
         result = _CLIENT.put_object(
-            bucket_name, object_name, reader, length, sse=sse,
+            bucket_name,
+            object_name,
+            reader,
+            length,
+            sse=sse,
         )
         version_id1 = result.version_id
         _CLIENT.stat_object(
-            bucket_name, object_name, ssec=sse, version_id=version_id1,
+            bucket_name,
+            object_name,
+            ssec=sse,
+            version_id=version_id1,
         )
 
         # Put/Upload a streaming object of 11 MiB
@@ -787,30 +844,44 @@ def _test_stat_object(log_entry, sse=None, version_check=False):
         reader = LimitedRandomReader(length)
         log_entry["args"]["data"] = "LimitedRandomReader(11 * MB)"
         log_entry["args"]["metadata"] = metadata = {
-            'X-Amz-Meta-Testing': 'value'}
-        log_entry["args"]["content_type"] = content_type = (
-            "application/octet-stream")
+            "X-Amz-Meta-Testing": "value"
+        }
+        log_entry["args"][
+            "content_type"
+        ] = content_type = "application/octet-stream"
         log_entry["args"]["object_name"] = object_name + "-metadata"
         result = _CLIENT.put_object(
-            bucket_name, object_name + "-metadata", reader,
-            length, content_type, metadata, sse=sse,
+            bucket_name,
+            object_name + "-metadata",
+            reader,
+            length,
+            content_type,
+            metadata,
+            sse=sse,
         )
         version_id2 = result.version_id
         # Stat on the uploaded object to check if it exists
         # Fetch saved stat metadata on a previously uploaded object with
         # metadata.
         st_obj = _CLIENT.stat_object(
-            bucket_name, object_name + "-metadata",
-            ssec=sse, version_id=version_id2,
+            bucket_name,
+            object_name + "-metadata",
+            ssec=sse,
+            version_id=version_id2,
         )
         # Verify the collected stat data.
         _validate_stat(
-            st_obj, length, metadata, version_id=version_id2,
+            st_obj,
+            length,
+            metadata,
+            version_id=version_id2,
         )
     finally:
         _CLIENT.remove_object(bucket_name, object_name, version_id=version_id1)
         _CLIENT.remove_object(
-            bucket_name, object_name+'-metadata', version_id=version_id2,
+            bucket_name,
+            object_name + "-metadata",
+            version_id=version_id2,
         )
         _CLIENT.remove_bucket(bucket_name)
 
@@ -842,13 +913,19 @@ def _test_remove_object(log_entry, version_check=False):
     try:
         if version_check:
             _CLIENT.set_bucket_versioning(
-                bucket_name, VersioningConfig(ENABLED),
+                bucket_name,
+                VersioningConfig(ENABLED),
             )
         result = _CLIENT.put_object(
-            bucket_name, object_name, LimitedRandomReader(length), length,
+            bucket_name,
+            object_name,
+            LimitedRandomReader(length),
+            length,
         )
         _CLIENT.remove_object(
-            bucket_name, object_name, version_id=result.version_id,
+            bucket_name,
+            object_name,
+            version_id=result.version_id,
         )
     finally:
         _CLIENT.remove_bucket(bucket_name)
@@ -885,19 +962,26 @@ def _test_get_object(log_entry, sse=None, version_check=False):
     try:
         if version_check:
             _CLIENT.set_bucket_versioning(
-                bucket_name, VersioningConfig(ENABLED),
+                bucket_name,
+                VersioningConfig(ENABLED),
             )
         result = _CLIENT.put_object(
-            bucket_name, object_name, LimitedRandomReader(length),
-            length, sse=sse,
+            bucket_name,
+            object_name,
+            LimitedRandomReader(length),
+            length,
+            sse=sse,
         )
         version_id = result.version_id
         # Get/Download a full object, iterate on response to save to disk
         object_data = _CLIENT.get_object(
-            bucket_name, object_name, ssec=sse, version_id=version_id,
+            bucket_name,
+            object_name,
+            ssec=sse,
+            version_id=version_id,
         )
-        newfile = 'newfile جديد'
-        with open(newfile, 'wb') as file_data:
+        newfile = "newfile جديد"
+        with open(newfile, "wb") as file_data:
             shutil.copyfileobj(object_data, file_data)
         os.remove(newfile)
     finally:
@@ -931,7 +1015,7 @@ def _test_fget_object(log_entry, sse=None, version_check=False):
     log_entry["args"] = {
         "bucket_name": bucket_name,
         "object_name": object_name,
-        "file_path": tmpfile
+        "file_path": tmpfile,
     }
 
     _CLIENT.make_bucket(bucket_name)
@@ -939,16 +1023,24 @@ def _test_fget_object(log_entry, sse=None, version_check=False):
     try:
         if version_check:
             _CLIENT.set_bucket_versioning(
-                bucket_name, VersioningConfig(ENABLED),
+                bucket_name,
+                VersioningConfig(ENABLED),
             )
         result = _CLIENT.put_object(
-            bucket_name, object_name, LimitedRandomReader(length),
-            length, sse=sse,
+            bucket_name,
+            object_name,
+            LimitedRandomReader(length),
+            length,
+            sse=sse,
         )
         version_id = result.version_id
         # Get/Download a full object and save locally at path
         _CLIENT.fget_object(
-            bucket_name, object_name, tmpfile, ssec=sse, version_id=version_id,
+            bucket_name,
+            object_name,
+            tmpfile,
+            ssec=sse,
+            version_id=version_id,
         )
         os.remove(tmpfile)
     finally:
@@ -967,7 +1059,8 @@ def test_fget_object_version(log_entry, sse=None):
 
 
 def test_get_object_with_default_length(  # pylint: disable=invalid-name
-        log_entry, sse=None):
+    log_entry, sse=None
+):
     """Test get_object() with default length."""
 
     if sse:
@@ -983,25 +1076,27 @@ def test_get_object_with_default_length(  # pylint: disable=invalid-name
     log_entry["args"] = {
         "bucket_name": bucket_name,
         "object_name": object_name,
-        "offset": offset
+        "offset": offset,
     }
 
     _CLIENT.make_bucket(bucket_name)
     try:
-        _CLIENT.put_object(bucket_name, object_name,
-                           LimitedRandomReader(size), size, sse=sse)
+        _CLIENT.put_object(
+            bucket_name, object_name, LimitedRandomReader(size), size, sse=sse
+        )
         # Get half of the object
-        object_data = _CLIENT.get_object(bucket_name, object_name,
-                                         offset=offset, ssec=sse)
-        newfile = 'newfile'
-        with open(newfile, 'wb') as file_data:
+        object_data = _CLIENT.get_object(
+            bucket_name, object_name, offset=offset, ssec=sse
+        )
+        newfile = "newfile"
+        with open(newfile, "wb") as file_data:
             for data in object_data:
                 file_data.write(data)
         # Check if the new file is the right size
         new_file_size = os.path.getsize(newfile)
         os.remove(newfile)
         if new_file_size != length:
-            raise ValueError('Unexpected file size after running ')
+            raise ValueError("Unexpected file size after running ")
     finally:
         _CLIENT.remove_object(bucket_name, object_name)
         _CLIENT.remove_bucket(bucket_name)
@@ -1023,25 +1118,27 @@ def test_get_partial_object(log_entry, sse=None):
     log_entry["args"] = {
         "bucket_name": bucket_name,
         "object_name": object_name,
-        "offset": offset
+        "offset": offset,
     }
 
     _CLIENT.make_bucket(bucket_name)
     try:
-        _CLIENT.put_object(bucket_name, object_name,
-                           LimitedRandomReader(size), size, sse=sse)
+        _CLIENT.put_object(
+            bucket_name, object_name, LimitedRandomReader(size), size, sse=sse
+        )
         # Get half of the object
-        object_data = _CLIENT.get_object(bucket_name, object_name,
-                                         offset=offset, length=length, ssec=sse)
-        newfile = 'newfile'
-        with open(newfile, 'wb') as file_data:
+        object_data = _CLIENT.get_object(
+            bucket_name, object_name, offset=offset, length=length, ssec=sse
+        )
+        newfile = "newfile"
+        with open(newfile, "wb") as file_data:
             for data in object_data:
                 file_data.write(data)
         # Check if the new file is the right size
         new_file_size = os.path.getsize(newfile)
         os.remove(newfile)
         if new_file_size != length:
-            raise ValueError('Unexpected file size after running ')
+            raise ValueError("Unexpected file size after running ")
     finally:
         _CLIENT.remove_object(bucket_name, object_name)
         _CLIENT.remove_bucket(bucket_name)
@@ -1067,25 +1164,41 @@ def _test_list_objects(log_entry, use_api_v1=False, version_check=False):
     try:
         if version_check:
             _CLIENT.set_bucket_versioning(
-                bucket_name, VersioningConfig(ENABLED),
+                bucket_name,
+                VersioningConfig(ENABLED),
             )
         size = 1 * KB
         result = _CLIENT.put_object(
-            bucket_name, object_name + "-1", LimitedRandomReader(size), size,
+            bucket_name,
+            object_name + "-1",
+            LimitedRandomReader(size),
+            size,
         )
         version_id1 = result.version_id
         result = _CLIENT.put_object(
-            bucket_name, object_name + "-2", LimitedRandomReader(size), size,
+            bucket_name,
+            object_name + "-2",
+            LimitedRandomReader(size),
+            size,
         )
         version_id2 = result.version_id
         # List all object paths in bucket.
         objects = _CLIENT.list_objects(
-            bucket_name, '', is_recursive, include_version=version_check,
+            bucket_name,
+            "",
+            is_recursive,
+            include_version=version_check,
             use_api_v1=use_api_v1,
         )
         for obj in objects:
-            _ = (obj.bucket_name, obj.object_name, obj.last_modified,
-                 obj.etag, obj.size, obj.content_type)
+            _ = (
+                obj.bucket_name,
+                obj.object_name,
+                obj.last_modified,
+                obj.etag,
+                obj.size,
+                obj.content_type,
+            )
             if obj.version_id not in [version_id1, version_id2]:
                 raise ValueError(
                     f"version ID mismatch. "
@@ -1094,10 +1207,14 @@ def _test_list_objects(log_entry, use_api_v1=False, version_check=False):
                 )
     finally:
         _CLIENT.remove_object(
-            bucket_name, object_name + "-1", version_id=version_id1,
+            bucket_name,
+            object_name + "-1",
+            version_id=version_id1,
         )
         _CLIENT.remove_object(
-            bucket_name, object_name + "-2", version_id=version_id2,
+            bucket_name,
+            object_name + "-2",
+            version_id=version_id2,
         )
         _CLIENT.remove_bucket(bucket_name)
 
@@ -1122,8 +1239,14 @@ def _test_list_objects_api(bucket_name, expected_no, *argv):
     # expect all objects to be listed
     no_of_files = 0
     for obj in objects:
-        _ = (obj.bucket_name, obj.object_name, obj.last_modified, obj.etag,
-             obj.size, obj.content_type)
+        _ = (
+            obj.bucket_name,
+            obj.object_name,
+            obj.last_modified,
+            obj.etag,
+            obj.size,
+            obj.content_type,
+        )
         no_of_files += 1
 
     if expected_no != no_of_files:
@@ -1152,8 +1275,12 @@ def test_list_objects_with_prefix(log_entry):
         path_prefix = ""
         # Create files and directories
         for i in range(no_of_created_files):
-            _CLIENT.put_object(bucket_name, f"{path_prefix}{i}_{object_name}",
-                               LimitedRandomReader(size), size)
+            _CLIENT.put_object(
+                bucket_name,
+                f"{path_prefix}{i}_{object_name}",
+                LimitedRandomReader(size),
+                size,
+            )
             path_prefix = f"{path_prefix}{i}/"
 
         # Created files and directory structure
@@ -1202,19 +1329,23 @@ def test_list_objects_with_prefix(log_entry):
         path_prefix = ""
         for i in range(no_of_created_files):
             _CLIENT.remove_object(
-                bucket_name, f"{path_prefix}{i}_{object_name}",
+                bucket_name,
+                f"{path_prefix}{i}_{object_name}",
             )
             path_prefix = f"{path_prefix}{i}/"
         _CLIENT.remove_bucket(bucket_name)
     # Test passes
-    log_entry["args"]["prefix"] = (
-        "Several prefix/recursive combinations are tested")
-    log_entry["args"]["recursive"] = (
-        'Several prefix/recursive combinations are tested')
+    log_entry["args"][
+        "prefix"
+    ] = "Several prefix/recursive combinations are tested"
+    log_entry["args"][
+        "recursive"
+    ] = "Several prefix/recursive combinations are tested"
 
 
 def test_list_objects_with_1001_files(  # pylint: disable=invalid-name
-        log_entry):
+    log_entry,
+):
     """Test list_objects() with more 1000 objects."""
 
     # Get a unique bucket_name and object_name
@@ -1232,8 +1363,12 @@ def test_list_objects_with_1001_files(  # pylint: disable=invalid-name
         no_of_created_files = 2000
         # Create files and directories
         for i in range(no_of_created_files):
-            _CLIENT.put_object(bucket_name, f"{object_name}_{i}",
-                               LimitedRandomReader(size), size)
+            _CLIENT.put_object(
+                bucket_name,
+                f"{object_name}_{i}",
+                LimitedRandomReader(size),
+                size,
+            )
 
         # List objects and check if 1001 files are returned
         _test_list_objects_api(bucket_name, no_of_created_files)
@@ -1254,7 +1389,8 @@ def test_list_object_versions(log_entry):
 
 
 def test_presigned_get_object_default_expiry(  # pylint: disable=invalid-name
-        log_entry):
+    log_entry,
+):
     """Test presigned_get_object() with default expiry."""
 
     # Get a unique bucket_name and object_name
@@ -1269,11 +1405,13 @@ def test_presigned_get_object_default_expiry(  # pylint: disable=invalid-name
     _CLIENT.make_bucket(bucket_name)
     try:
         size = 1 * KB
-        _CLIENT.put_object(bucket_name, object_name, LimitedRandomReader(size),
-                           size)
+        _CLIENT.put_object(
+            bucket_name, object_name, LimitedRandomReader(size), size
+        )
         presigned_get_object_url = _CLIENT.presigned_get_object(
-            bucket_name, object_name)
-        response = HTTP.urlopen('GET', presigned_get_object_url)
+            bucket_name, object_name
+        )
+        response = HTTP.urlopen("GET", presigned_get_object_url)
         if response.status != 200:
             raise Exception(
                 f"Presigned GET object URL {presigned_get_object_url} failed; "
@@ -1284,8 +1422,7 @@ def test_presigned_get_object_default_expiry(  # pylint: disable=invalid-name
         _CLIENT.remove_bucket(bucket_name)
 
 
-def test_presigned_get_object_expiry(  # pylint: disable=invalid-name
-        log_entry):
+def test_presigned_get_object_expiry(log_entry):  # pylint: disable=invalid-name
     """Test presigned_get_object() with expiry."""
 
     # Get a unique bucket_name and object_name
@@ -1300,28 +1437,30 @@ def test_presigned_get_object_expiry(  # pylint: disable=invalid-name
     _CLIENT.make_bucket(bucket_name)
     try:
         size = 1 * KB
-        _CLIENT.put_object(bucket_name, object_name, LimitedRandomReader(size),
-                           size)
+        _CLIENT.put_object(
+            bucket_name, object_name, LimitedRandomReader(size), size
+        )
         presigned_get_object_url = _CLIENT.presigned_get_object(
-            bucket_name, object_name, timedelta(seconds=120))
-        response = HTTP.urlopen('GET', presigned_get_object_url)
+            bucket_name, object_name, timedelta(seconds=120)
+        )
+        response = HTTP.urlopen("GET", presigned_get_object_url)
         if response.status != 200:
             raise Exception(
                 f"Presigned GET object URL {presigned_get_object_url} failed; "
                 f"code: {response.code}, error: {response.data}"
             )
 
-        log_entry["args"]["presigned_get_object_url"] = (
-            presigned_get_object_url)
+        log_entry["args"]["presigned_get_object_url"] = presigned_get_object_url
 
-        response = HTTP.urlopen('GET', presigned_get_object_url)
+        response = HTTP.urlopen("GET", presigned_get_object_url)
 
-        log_entry["args"]['response.status'] = response.status
-        log_entry["args"]['response.reason'] = response.reason
-        log_entry["args"]['response.headers'] = json.dumps(
-            response.headers.__dict__)
+        log_entry["args"]["response.status"] = response.status
+        log_entry["args"]["response.reason"] = response.reason
+        log_entry["args"]["response.headers"] = json.dumps(
+            response.headers.__dict__
+        )
         # pylint: disable=protected-access
-        log_entry["args"]['response._body'] = response._body.decode('utf-8')
+        log_entry["args"]["response._body"] = response._body.decode("utf-8")
 
         if response.status != 200:
             raise Exception(
@@ -1330,35 +1469,38 @@ def test_presigned_get_object_expiry(  # pylint: disable=invalid-name
             )
 
         presigned_get_object_url = _CLIENT.presigned_get_object(
-            bucket_name, object_name, timedelta(seconds=1))
+            bucket_name, object_name, timedelta(seconds=1)
+        )
 
         # Wait for 2 seconds for the presigned url to expire
         time.sleep(2)
-        response = HTTP.urlopen('GET', presigned_get_object_url)
+        response = HTTP.urlopen("GET", presigned_get_object_url)
 
-        log_entry["args"]['response.status-2'] = response.status
-        log_entry["args"]['response.reason-2'] = response.reason
-        log_entry["args"]['response.headers-2'] = json.dumps(
-            response.headers.__dict__)
-        log_entry["args"]['response._body-2'] = response._body.decode('utf-8')
+        log_entry["args"]["response.status-2"] = response.status
+        log_entry["args"]["response.reason-2"] = response.reason
+        log_entry["args"]["response.headers-2"] = json.dumps(
+            response.headers.__dict__
+        )
+        log_entry["args"]["response._body-2"] = response._body.decode("utf-8")
 
         # Success with an expired url is considered to be a failure
         if response.status == 200:
-            raise ValueError('Presigned get url failed to expire!')
+            raise ValueError("Presigned get url failed to expire!")
     finally:
         _CLIENT.remove_object(bucket_name, object_name)
         _CLIENT.remove_bucket(bucket_name)
 
 
 def test_presigned_get_object_response_headers(  # pylint: disable=invalid-name
-        log_entry):
+    log_entry,
+):
     """Test presigned_get_object() with headers."""
 
     # Get a unique bucket_name and object_name
     bucket_name = _gen_bucket_name()
     object_name = f"{uuid4()}"
-    content_type = 'text/plain'
-    content_language = 'en_US'
+    content_type = "text/plain"
+    content_language = "en_US"
 
     log_entry["args"] = {
         "bucket_name": bucket_name,
@@ -1370,38 +1512,44 @@ def test_presigned_get_object_response_headers(  # pylint: disable=invalid-name
     _CLIENT.make_bucket(bucket_name)
     try:
         size = 1 * KB
-        _CLIENT.put_object(bucket_name, object_name, LimitedRandomReader(size),
-                           size)
+        _CLIENT.put_object(
+            bucket_name, object_name, LimitedRandomReader(size), size
+        )
         presigned_get_object_url = _CLIENT.presigned_get_object(
-            bucket_name, object_name, timedelta(seconds=120))
+            bucket_name, object_name, timedelta(seconds=120)
+        )
 
         response_headers = {
-            'response-content-type': content_type,
-            'response-content-language': content_language
+            "response-content-type": content_type,
+            "response-content-language": content_language,
         }
         presigned_get_object_url = _CLIENT.presigned_get_object(
-            bucket_name, object_name, timedelta(seconds=120), response_headers)
+            bucket_name, object_name, timedelta(seconds=120), response_headers
+        )
 
-        log_entry["args"]["presigned_get_object_url"] = (
-            presigned_get_object_url)
+        log_entry["args"]["presigned_get_object_url"] = presigned_get_object_url
 
-        response = HTTP.urlopen('GET', presigned_get_object_url)
-        returned_content_type = response.headers['Content-Type']
-        returned_content_language = response.headers['Content-Language']
+        response = HTTP.urlopen("GET", presigned_get_object_url)
+        returned_content_type = response.headers["Content-Type"]
+        returned_content_language = response.headers["Content-Language"]
 
-        log_entry["args"]['response.status'] = response.status
-        log_entry["args"]['response.reason'] = response.reason
-        log_entry["args"]['response.headers'] = json.dumps(
-            response.headers.__dict__)
+        log_entry["args"]["response.status"] = response.status
+        log_entry["args"]["response.reason"] = response.reason
+        log_entry["args"]["response.headers"] = json.dumps(
+            response.headers.__dict__
+        )
         # pylint: disable=protected-access
-        log_entry["args"]['response._body'] = response._body.decode('utf-8')
-        log_entry["args"]['returned_content_type'] = returned_content_type
-        log_entry["args"]['returned_content_language'] = (
-            returned_content_language)
+        log_entry["args"]["response._body"] = response._body.decode("utf-8")
+        log_entry["args"]["returned_content_type"] = returned_content_type
+        log_entry["args"][
+            "returned_content_language"
+        ] = returned_content_language
 
-        if (response.status != 200 or
-                returned_content_type != content_type or
-                returned_content_language != content_language):
+        if (
+            response.status != 200
+            or returned_content_type != content_type
+            or returned_content_language != content_language
+        ):
             raise Exception(
                 "Presigned GET object URL {presigned_get_object_url} failed; "
                 "code: {response.code}, error: {response.data}"
@@ -1412,7 +1560,8 @@ def test_presigned_get_object_response_headers(  # pylint: disable=invalid-name
 
 
 def test_presigned_get_object_version(  # pylint: disable=invalid-name
-        log_entry):
+    log_entry,
+):
     """Test presigned_get_object() of versioned object."""
 
     # Get a unique bucket_name and object_name
@@ -1430,13 +1579,18 @@ def test_presigned_get_object_version(  # pylint: disable=invalid-name
         _CLIENT.set_bucket_versioning(bucket_name, VersioningConfig(ENABLED))
         size = 1 * KB
         result = _CLIENT.put_object(
-            bucket_name, object_name, LimitedRandomReader(size), size,
+            bucket_name,
+            object_name,
+            LimitedRandomReader(size),
+            size,
         )
         version_id = result.version_id
         presigned_get_object_url = _CLIENT.presigned_get_object(
-            bucket_name, object_name, version_id=version_id,
+            bucket_name,
+            object_name,
+            version_id=version_id,
         )
-        response = HTTP.urlopen('GET', presigned_get_object_url)
+        response = HTTP.urlopen("GET", presigned_get_object_url)
         if response.status != 200:
             raise Exception(
                 f"Presigned GET object URL {presigned_get_object_url} failed; "
@@ -1448,7 +1602,8 @@ def test_presigned_get_object_version(  # pylint: disable=invalid-name
 
 
 def test_presigned_put_object_default_expiry(  # pylint: disable=invalid-name
-        log_entry):
+    log_entry,
+):
     """Test presigned_put_object() with default expiry."""
 
     # Get a unique bucket_name and object_name
@@ -1463,10 +1618,11 @@ def test_presigned_put_object_default_expiry(  # pylint: disable=invalid-name
     _CLIENT.make_bucket(bucket_name)
     try:
         presigned_put_object_url = _CLIENT.presigned_put_object(
-            bucket_name, object_name)
-        response = HTTP.urlopen('PUT',
-                                presigned_put_object_url,
-                                LimitedRandomReader(1 * KB))
+            bucket_name, object_name
+        )
+        response = HTTP.urlopen(
+            "PUT", presigned_put_object_url, LimitedRandomReader(1 * KB)
+        )
         if response.status != 200:
             raise Exception(
                 f"Presigned PUT object URL {presigned_put_object_url} failed; "
@@ -1478,8 +1634,7 @@ def test_presigned_put_object_default_expiry(  # pylint: disable=invalid-name
         _CLIENT.remove_bucket(bucket_name)
 
 
-def test_presigned_put_object_expiry(  # pylint: disable=invalid-name
-        log_entry):
+def test_presigned_put_object_expiry(log_entry):  # pylint: disable=invalid-name
     """Test presigned_put_object() with expiry."""
 
     # Get a unique bucket_name and object_name
@@ -1494,14 +1649,15 @@ def test_presigned_put_object_expiry(  # pylint: disable=invalid-name
     _CLIENT.make_bucket(bucket_name)
     try:
         presigned_put_object_url = _CLIENT.presigned_put_object(
-            bucket_name, object_name, timedelta(seconds=1))
+            bucket_name, object_name, timedelta(seconds=1)
+        )
         # Wait for 2 seconds for the presigned url to expire
         time.sleep(2)
-        response = HTTP.urlopen('PUT',
-                                presigned_put_object_url,
-                                LimitedRandomReader(1 * KB))
+        response = HTTP.urlopen(
+            "PUT", presigned_put_object_url, LimitedRandomReader(1 * KB)
+        )
         if response.status == 200:
-            raise ValueError('Presigned put url failed to expire!')
+            raise ValueError("Presigned put url failed to expire!")
     finally:
         _CLIENT.remove_object(bucket_name, object_name)
         _CLIENT.remove_bucket(bucket_name)
@@ -1520,13 +1676,14 @@ def test_presigned_post_policy(log_entry):
     _CLIENT.make_bucket(bucket_name)
     try:
         no_of_days = 10
-        prefix = 'objectPrefix/'
+        prefix = "objectPrefix/"
 
         policy = PostPolicy(
-            bucket_name, datetime.utcnow() + timedelta(days=no_of_days),
+            bucket_name,
+            datetime.utcnow() + timedelta(days=no_of_days),
         )
         policy.add_starts_with_condition("key", prefix)
-        policy.add_content_length_range_condition(64*KB, 10*MB)
+        policy.add_content_length_range_condition(64 * KB, 10 * MB)
         policy.add_starts_with_condition("Content-Type", "image/")
         log_entry["args"]["post_policy"] = {
             "prefix": prefix,
@@ -1570,8 +1727,8 @@ def test_thread_safe(log_entry):
             # Compare sha-sum values of the source file and the copied one
             if test_file_sha_sum != copied_file_sha_sum:
                 raise ValueError(
-                    'Sha-sum mismatch on multi-threaded put and '
-                    'get objects')
+                    "Sha-sum mismatch on multi-threaded put and " "get objects"
+                )
         except Exception as exc:  # pylint: disable=broad-except
             exceptions.append(exc)
         finally:
@@ -1584,8 +1741,10 @@ def test_thread_safe(log_entry):
         # Put/Upload 'no_of_threads' many objects
         # simultaneously using multi-threading
         for _ in range(no_of_threads):
-            thread = Thread(target=_CLIENT.fput_object,
-                            args=(bucket_name, object_name, _LARGE_FILE))
+            thread = Thread(
+                target=_CLIENT.fput_object,
+                args=(bucket_name, object_name, _LARGE_FILE),
+            )
             thread.start()
             thread.join()
 
@@ -1595,8 +1754,7 @@ def test_thread_safe(log_entry):
         for i in range(no_of_threads):
             # Create dynamic/varying names for to be created threads
             thread_name = f"thread_{i}"
-            vars()[thread_name] = Thread(
-                target=get_object_and_check, args=(i,))
+            vars()[thread_name] = Thread(target=get_object_and_check, args=(i,))
             vars()[thread_name].start()
             thread_list.append(vars()[thread_name])
 
@@ -1634,10 +1792,11 @@ def _get_policy_actions(stat):
 
     def listit(value):
         return value if isinstance(value, list) else [value]
+
     actions = [listit(s.get("Action")) for s in stat if s.get("Action")]
-    actions = list(set(
-        item.replace("s3:", "") for sublist in actions for item in sublist
-    ))
+    actions = list(
+        set(item.replace("s3:", "") for sublist in actions for item in sublist)
+    )
     actions.sort()
     return actions
 
@@ -1645,8 +1804,8 @@ def _get_policy_actions(stat):
 def _validate_policy(bucket_name, policy):
     """Validate policy."""
     policy_dict = json.loads(_CLIENT.get_bucket_policy(bucket_name))
-    actions = _get_policy_actions(policy_dict.get('Statement'))
-    expected_actions = _get_policy_actions(policy.get('Statement'))
+    actions = _get_policy_actions(policy_dict.get("Statement"))
+    expected_actions = _get_policy_actions(policy.get("Statement"))
     return expected_actions == actions
 
 
@@ -1663,8 +1822,9 @@ def test_get_bucket_notification(log_entry):
     try:
         config = _CLIENT.get_bucket_notification(bucket_name)
         if (
-                config.cloud_func_config_list or config.queue_config_list or
-                config.topic_config_list
+            config.cloud_func_config_list
+            or config.queue_config_list
+            or config.topic_config_list
         ):
             raise ValueError("Failed to receive an empty bucket notification")
     finally:
@@ -1691,35 +1851,34 @@ def test_set_bucket_policy_readonly(log_entry):
                     "Effect": "Allow",
                     "Principal": {"AWS": "*"},
                     "Action": "s3:GetBucketLocation",
-                    "Resource": "arn:aws:s3:::" + bucket_name
+                    "Resource": "arn:aws:s3:::" + bucket_name,
                 },
                 {
                     "Sid": "",
                     "Effect": "Allow",
                     "Principal": {"AWS": "*"},
                     "Action": "s3:ListBucket",
-                    "Resource": "arn:aws:s3:::" + bucket_name
+                    "Resource": "arn:aws:s3:::" + bucket_name,
                 },
                 {
                     "Sid": "",
                     "Effect": "Allow",
                     "Principal": {"AWS": "*"},
                     "Action": "s3:GetObject",
-                    "Resource": f"arn:aws:s3:::{bucket_name}/*"
-                }
-            ]
+                    "Resource": f"arn:aws:s3:::{bucket_name}/*",
+                },
+            ],
         }
         # Set read-only policy
         _CLIENT.set_bucket_policy(bucket_name, json.dumps(policy))
         # Validate if the policy is set correctly
         if not _validate_policy(bucket_name, policy):
-            raise ValueError('Failed to set ReadOnly bucket policy')
+            raise ValueError("Failed to set ReadOnly bucket policy")
     finally:
         _CLIENT.remove_bucket(bucket_name)
 
 
-def test_set_bucket_policy_readwrite(  # pylint: disable=invalid-name
-        log_entry):
+def test_set_bucket_policy_readwrite(log_entry):  # pylint: disable=invalid-name
     """Test set_bucket_policy() with read/write policy."""
 
     # Get a unique bucket_name
@@ -1739,40 +1898,42 @@ def test_set_bucket_policy_readwrite(  # pylint: disable=invalid-name
                     "Sid": "",
                     "Resource": ["arn:aws:s3:::" + bucket_name],
                     "Effect": "Allow",
-                    "Principal": {"AWS": "*"}
+                    "Principal": {"AWS": "*"},
                 },
                 {
                     "Action": ["s3:ListBucket"],
                     "Sid": "",
                     "Resource": ["arn:aws:s3:::" + bucket_name],
                     "Effect": "Allow",
-                    "Principal": {"AWS": "*"}
+                    "Principal": {"AWS": "*"},
                 },
                 {
                     "Action": ["s3:ListBucketMultipartUploads"],
                     "Sid": "",
                     "Resource": ["arn:aws:s3:::" + bucket_name],
                     "Effect": "Allow",
-                    "Principal": {"AWS": "*"}
+                    "Principal": {"AWS": "*"},
                 },
                 {
-                    "Action": ["s3:ListMultipartUploadParts",
-                               "s3:GetObject",
-                               "s3:AbortMultipartUpload",
-                               "s3:DeleteObject",
-                               "s3:PutObject"],
+                    "Action": [
+                        "s3:ListMultipartUploadParts",
+                        "s3:GetObject",
+                        "s3:AbortMultipartUpload",
+                        "s3:DeleteObject",
+                        "s3:PutObject",
+                    ],
                     "Sid": "",
                     "Resource": [f"arn:aws:s3:::{bucket_name}/*"],
                     "Effect": "Allow",
-                    "Principal": {"AWS": "*"}
-                }
-            ]
+                    "Principal": {"AWS": "*"},
+                },
+            ],
         }
         # Set read-write policy
         _CLIENT.set_bucket_policy(bucket_name, json.dumps(policy))
         # Validate if the policy is set correctly
         if not _validate_policy(bucket_name, policy):
-            raise ValueError('Failed to set ReadOnly bucket policy')
+            raise ValueError("Failed to set ReadOnly bucket policy")
     finally:
         _CLIENT.remove_bucket(bucket_name)
 
@@ -1792,24 +1953,30 @@ def _test_remove_objects(log_entry, version_check=False):
     try:
         if version_check:
             _CLIENT.set_bucket_versioning(
-                bucket_name, VersioningConfig(ENABLED),
+                bucket_name,
+                VersioningConfig(ENABLED),
             )
         size = 1 * KB
         # Upload some new objects to prepare for multi-object delete test.
         for i in range(10):
             object_name = f"prefix-{i}"
             result = _CLIENT.put_object(
-                bucket_name, object_name, LimitedRandomReader(size), size,
+                bucket_name,
+                object_name,
+                LimitedRandomReader(size),
+                size,
             )
             object_names.append(
-                (object_name, result.version_id) if version_check
+                (object_name, result.version_id)
+                if version_check
                 else object_name,
             )
         log_entry["args"]["delete_object_list"] = object_names
 
         for args in object_names:
             delete_object_list.append(
-                DeleteObject(args) if isinstance(args, str)
+                DeleteObject(args)
+                if isinstance(args, str)
                 else DeleteObject(args[0], args[1])
             )
         # delete the objects in a single library call.
@@ -1876,14 +2043,18 @@ def _test_upload_snowball_objects(log_entry, staging_filename=None):
             [
                 SnowballObject("my-object1", data=io.BytesIO(b"py"), length=2),
                 SnowballObject(
-                    "my-object2", data=reader1, length=size,
+                    "my-object2",
+                    data=reader1,
+                    length=size,
                 ),
                 SnowballObject(
-                    "my-object3", data=reader2, length=size,
+                    "my-object3",
+                    data=reader2,
+                    length=size,
                     mod_time=datetime.now(),
                 ),
             ],
-            staging_filename=staging_filename
+            staging_filename=staging_filename,
         )
         _test_list_objects_api(bucket_name, 3)
     finally:
@@ -1901,7 +2072,8 @@ def test_upload_snowball_objects(log_entry):
 
 
 def test_upload_snowball_objects_with_staging(  # pylint: disable=invalid-name
-        log_entry):
+    log_entry,
+):
     """Test upload_snowball_objects() with staging file."""
     staging_filename = f"{uuid4()}.tar"
     _test_upload_snowball_objects(log_entry, staging_filename)
@@ -1914,47 +2086,47 @@ def main():
     # pylint: disable=global-statement
     global _CLIENT, _TEST_FILE, _LARGE_FILE, _IS_AWS
 
-    access_key = os.getenv('ACCESS_KEY')
-    secret_key = os.getenv('SECRET_KEY')
-    server_endpoint = os.getenv('SERVER_ENDPOINT', 'play.min.io')
-    secure = os.getenv('ENABLE_HTTPS', '1') == '1'
+    access_key = os.getenv("ACCESS_KEY")
+    secret_key = os.getenv("SECRET_KEY")
+    server_endpoint = os.getenv("SERVER_ENDPOINT", "play.min.io")
+    secure = os.getenv("ENABLE_HTTPS", "1") == "1"
 
-    if server_endpoint == 'play.min.io':
-        access_key = 'Q3AM3UQ867SPQQA43P2F'
-        secret_key = 'zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG'
+    if server_endpoint == "play.min.io":
+        access_key = "Q3AM3UQ867SPQQA43P2F"
+        secret_key = "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
         secure = True
 
     _CLIENT = Minio(server_endpoint, access_key, secret_key, secure=secure)
     _IS_AWS = ".amazonaws.com" in server_endpoint
 
     # Check if we are running in the mint environment.
-    data_dir = os.getenv('DATA_DIR', '/mint/data')
+    data_dir = os.getenv("DATA_DIR", "/mint/data")
 
     is_mint_env = (
-        os.path.exists(data_dir) and
-        os.path.exists(os.path.join(data_dir, 'datafile-1-MB')) and
-        os.path.exists(os.path.join(data_dir, 'datafile-11-MB'))
+        os.path.exists(data_dir)
+        and os.path.exists(os.path.join(data_dir, "datafile-1-MB"))
+        and os.path.exists(os.path.join(data_dir, "datafile-11-MB"))
     )
 
     # Enable trace
     # _CLIENT.trace_on(sys.stderr)
 
-    _TEST_FILE = 'datafile-1-MB'
-    _LARGE_FILE = 'datafile-11-MB'
+    _TEST_FILE = "datafile-1-MB"
+    _LARGE_FILE = "datafile-11-MB"
     if is_mint_env:
         # Choose data files
-        _TEST_FILE = os.path.join(data_dir, 'datafile-1-MB')
-        _LARGE_FILE = os.path.join(data_dir, 'datafile-11-MB')
+        _TEST_FILE = os.path.join(data_dir, "datafile-1-MB")
+        _LARGE_FILE = os.path.join(data_dir, "datafile-11-MB")
     else:
-        with open(_TEST_FILE, 'wb') as file_data:
+        with open(_TEST_FILE, "wb") as file_data:
             shutil.copyfileobj(LimitedRandomReader(1 * MB), file_data)
-        with open(_LARGE_FILE, 'wb') as file_data:
+        with open(_LARGE_FILE, "wb") as file_data:
             shutil.copyfileobj(LimitedRandomReader(11 * MB), file_data)
 
     ssec = None
     if secure:
         # Create a Customer Key of 32 Bytes for Server Side Encryption (SSE-C)
-        cust_key = b'AABBCCDDAABBCCDDAABBCCDDAABBCCDD'
+        cust_key = b"AABBCCDDAABBCCDDAABBCCDDAABBCCDD"
         # Create an SSE-C object with provided customer key
         ssec = SseCustomerKey(cust_key)
 
@@ -1968,7 +2140,11 @@ def main():
             test_fput_object_large_file: {"sse": ssec} if ssec else None,
             test_fput_object_with_content_type: None,
             test_copy_object_no_copy_condition: {
-                "ssec_copy": ssec, "ssec": ssec} if ssec else None,
+                "ssec_copy": ssec,
+                "ssec": ssec,
+            }
+            if ssec
+            else None,
             test_copy_object_etag_match: None,
             test_copy_object_with_metadata: None,
             test_copy_object_negative_etag_match: None,
@@ -2020,7 +2196,11 @@ def main():
             test_presigned_put_object_default_expiry: None,
             test_presigned_post_policy: None,
             test_copy_object_no_copy_condition: {
-                "ssec_copy": ssec, "ssec": ssec} if ssec else None,
+                "ssec_copy": ssec,
+                "ssec": ssec,
+            }
+            if ssec
+            else None,
             test_select_object_content: None,
             test_get_bucket_policy: None,
             test_set_bucket_policy_readonly: None,
@@ -2047,7 +2227,8 @@ def main():
             args = ()
             kwargs = arg_list
             _call_test(
-                test_name, *args, **kwargs)  # pylint: disable=not-a-mapping
+                test_name, *args, **kwargs
+            )  # pylint: disable=not-a-mapping
 
     # Remove temporary files.
     if not is_mint_env:

--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -144,9 +144,7 @@ def _call_test(func, *args, **kwargs):
         # pylint: disable=deprecated-method
         args_string = ", ".join(getfullargspec(log_entry["method"]).args[1:])
         log_entry["function"] = f"{log_entry['method'].__name__}({args_string})"
-    log_entry["args"] = {
-        k: v for k, v in log_entry.get("args", {}).items() if v
-    }
+    log_entry["args"] = {k: v for k, v in log_entry.get("args", {}).items() if v}
     log_entry["duration"] = int(round((time.time() - start_time) * 1000))
     log_entry["name"] = "minio-py:" + log_entry["name"]
     log_entry["method"] = None
@@ -272,9 +270,7 @@ def test_select_object_content(log_entry):
     try:
         _CLIENT.make_bucket(bucket_name)
         content = io.BytesIO(b"col1,col2,col3\none,two,three\nX,Y,Z\n")
-        _CLIENT.put_object(
-            bucket_name, csvfile, content, len(content.getvalue())
-        )
+        _CLIENT.put_object(bucket_name, csvfile, content, len(content.getvalue()))
 
         request = SelectRequest(
             "select * from s3object",
@@ -292,8 +288,7 @@ def test_select_object_content(log_entry):
         generated_crc = crc32(records.getvalue()) & 0xFFFFFFFF
         if expected_crc != generated_crc:
             raise ValueError(
-                "Data mismatch Expected : "
-                '"col1,col2,col3\none,two,three\nX,Y,Z\n"',
+                "Data mismatch Expected : " '"col1,col2,col3\none,two,three\nX,Y,Z\n"',
                 f"Received {records.getvalue().decode()}",
             )
     finally:
@@ -386,9 +381,7 @@ def test_fput_object_with_content_type(  # pylint: disable=invalid-name
 def _validate_stat(st_obj, expected_size, expected_meta, version_id=None):
     """Validate stat information."""
 
-    expected_meta = {
-        key.lower(): value for key, value in (expected_meta or {}).items()
-    }
+    expected_meta = {key.lower(): value for key, value in (expected_meta or {}).items()}
     received_etag = st_obj.etag
     received_metadata = {
         key.lower(): value for key, value in (st_obj.metadata or {}).items()
@@ -402,8 +395,7 @@ def _validate_stat(st_obj, expected_size, expected_meta, version_id=None):
 
     if st_obj.version_id != version_id:
         raise ValueError(
-            f"version-id mismatch. expected={version_id}, "
-            f"got={st_obj.version_id}"
+            f"version-id mismatch. expected={version_id}, " f"got={st_obj.version_id}"
         )
 
     # content_type by default can be either application/octet-stream or
@@ -414,8 +406,7 @@ def _validate_stat(st_obj, expected_size, expected_meta, version_id=None):
     ]:
         raise ValueError(
             "Incorrect content type. Expected: ",
-            "'application/octet-stream' or 'binary/octet-stream',"
-            " received: ",
+            "'application/octet-stream' or 'binary/octet-stream'," " received: ",
             received_content_type,
         )
 
@@ -731,9 +722,7 @@ def test_put_object(log_entry, sse=None):
             "x-amz-meta-testing": "value",
             "test-key": "value2",
         }
-        log_entry["args"][
-            "content_type"
-        ] = content_type = "application/octet-stream"
+        log_entry["args"]["content_type"] = content_type = "application/octet-stream"
         log_entry["args"]["object_name"] = object_name + "-metadata"
         _CLIENT.put_object(
             bucket_name,
@@ -747,9 +736,7 @@ def test_put_object(log_entry, sse=None):
         # Stat on the uploaded object to check if it exists
         # Fetch saved stat metadata on a previously uploaded object with
         # metadata.
-        st_obj = _CLIENT.stat_object(
-            bucket_name, object_name + "-metadata", ssec=sse
-        )
+        st_obj = _CLIENT.stat_object(bucket_name, object_name + "-metadata", ssec=sse)
         normalized_meta = {
             key.lower(): value for key, value in (st_obj.metadata or {}).items()
         }
@@ -843,12 +830,8 @@ def _test_stat_object(log_entry, sse=None, version_check=False):
         log_entry["args"]["length"] = length = 11 * MB
         reader = LimitedRandomReader(length)
         log_entry["args"]["data"] = "LimitedRandomReader(11 * MB)"
-        log_entry["args"]["metadata"] = metadata = {
-            "X-Amz-Meta-Testing": "value"
-        }
-        log_entry["args"][
-            "content_type"
-        ] = content_type = "application/octet-stream"
+        log_entry["args"]["metadata"] = metadata = {"X-Amz-Meta-Testing": "value"}
+        log_entry["args"]["content_type"] = content_type = "application/octet-stream"
         log_entry["args"]["object_name"] = object_name + "-metadata"
         result = _CLIENT.put_object(
             bucket_name,
@@ -1335,12 +1318,8 @@ def test_list_objects_with_prefix(log_entry):
             path_prefix = f"{path_prefix}{i}/"
         _CLIENT.remove_bucket(bucket_name)
     # Test passes
-    log_entry["args"][
-        "prefix"
-    ] = "Several prefix/recursive combinations are tested"
-    log_entry["args"][
-        "recursive"
-    ] = "Several prefix/recursive combinations are tested"
+    log_entry["args"]["prefix"] = "Several prefix/recursive combinations are tested"
+    log_entry["args"]["recursive"] = "Several prefix/recursive combinations are tested"
 
 
 def test_list_objects_with_1001_files(  # pylint: disable=invalid-name
@@ -1405,9 +1384,7 @@ def test_presigned_get_object_default_expiry(  # pylint: disable=invalid-name
     _CLIENT.make_bucket(bucket_name)
     try:
         size = 1 * KB
-        _CLIENT.put_object(
-            bucket_name, object_name, LimitedRandomReader(size), size
-        )
+        _CLIENT.put_object(bucket_name, object_name, LimitedRandomReader(size), size)
         presigned_get_object_url = _CLIENT.presigned_get_object(
             bucket_name, object_name
         )
@@ -1437,9 +1414,7 @@ def test_presigned_get_object_expiry(log_entry):  # pylint: disable=invalid-name
     _CLIENT.make_bucket(bucket_name)
     try:
         size = 1 * KB
-        _CLIENT.put_object(
-            bucket_name, object_name, LimitedRandomReader(size), size
-        )
+        _CLIENT.put_object(bucket_name, object_name, LimitedRandomReader(size), size)
         presigned_get_object_url = _CLIENT.presigned_get_object(
             bucket_name, object_name, timedelta(seconds=120)
         )
@@ -1456,9 +1431,7 @@ def test_presigned_get_object_expiry(log_entry):  # pylint: disable=invalid-name
 
         log_entry["args"]["response.status"] = response.status
         log_entry["args"]["response.reason"] = response.reason
-        log_entry["args"]["response.headers"] = json.dumps(
-            response.headers.__dict__
-        )
+        log_entry["args"]["response.headers"] = json.dumps(response.headers.__dict__)
         # pylint: disable=protected-access
         log_entry["args"]["response._body"] = response._body.decode("utf-8")
 
@@ -1478,9 +1451,7 @@ def test_presigned_get_object_expiry(log_entry):  # pylint: disable=invalid-name
 
         log_entry["args"]["response.status-2"] = response.status
         log_entry["args"]["response.reason-2"] = response.reason
-        log_entry["args"]["response.headers-2"] = json.dumps(
-            response.headers.__dict__
-        )
+        log_entry["args"]["response.headers-2"] = json.dumps(response.headers.__dict__)
         log_entry["args"]["response._body-2"] = response._body.decode("utf-8")
 
         # Success with an expired url is considered to be a failure
@@ -1512,9 +1483,7 @@ def test_presigned_get_object_response_headers(  # pylint: disable=invalid-name
     _CLIENT.make_bucket(bucket_name)
     try:
         size = 1 * KB
-        _CLIENT.put_object(
-            bucket_name, object_name, LimitedRandomReader(size), size
-        )
+        _CLIENT.put_object(bucket_name, object_name, LimitedRandomReader(size), size)
         presigned_get_object_url = _CLIENT.presigned_get_object(
             bucket_name, object_name, timedelta(seconds=120)
         )
@@ -1535,15 +1504,11 @@ def test_presigned_get_object_response_headers(  # pylint: disable=invalid-name
 
         log_entry["args"]["response.status"] = response.status
         log_entry["args"]["response.reason"] = response.reason
-        log_entry["args"]["response.headers"] = json.dumps(
-            response.headers.__dict__
-        )
+        log_entry["args"]["response.headers"] = json.dumps(response.headers.__dict__)
         # pylint: disable=protected-access
         log_entry["args"]["response._body"] = response._body.decode("utf-8")
         log_entry["args"]["returned_content_type"] = returned_content_type
-        log_entry["args"][
-            "returned_content_language"
-        ] = returned_content_language
+        log_entry["args"]["returned_content_language"] = returned_content_language
 
         if (
             response.status != 200
@@ -1967,9 +1932,7 @@ def _test_remove_objects(log_entry, version_check=False):
                 size,
             )
             object_names.append(
-                (object_name, result.version_id)
-                if version_check
-                else object_name,
+                (object_name, result.version_id) if version_check else object_name,
             )
         log_entry["args"]["delete_object_list"] = object_names
 
@@ -2226,9 +2189,7 @@ def main():
         if arg_list:
             args = ()
             kwargs = arg_list
-            _call_test(
-                test_name, *args, **kwargs
-            )  # pylint: disable=not-a-mapping
+            _call_test(test_name, *args, **kwargs)  # pylint: disable=not-a-mapping
 
     # Remove temporary files.
     if not is_mint_env:

--- a/tests/unit/bucket_exist_test.py
+++ b/tests/unit/bucket_exist_test.py
@@ -26,48 +26,54 @@ from .minio_mocks import MockConnection, MockResponse
 
 class BucketExists(TestCase):
     def test_bucket_is_string(self):
-        client = Minio('localhost:9000')
+        client = Minio("localhost:9000")
         self.assertRaises(TypeError, client.bucket_exists, 1234)
 
     def test_bucket_is_not_empty_string(self):
-        client = Minio('localhost:9000')
-        self.assertRaises(ValueError, client.bucket_exists, '  \t \n  ')
+        client = Minio("localhost:9000")
+        self.assertRaises(ValueError, client.bucket_exists, "  \t \n  ")
 
     def test_bucket_exists_invalid_name(self):
-        client = Minio('localhost:9000')
-        self.assertRaises(ValueError, client.bucket_exists, 'AB*CD')
+        client = Minio("localhost:9000")
+        self.assertRaises(ValueError, client.bucket_exists, "AB*CD")
 
-    @mock.patch('urllib3.PoolManager')
+    @mock.patch("urllib3.PoolManager")
     def test_bucket_exists_bad_request(self, mock_connection):
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
-            MockResponse('HEAD',
-                         'https://localhost:9000/hello',
-                         {'User-Agent': _DEFAULT_USER_AGENT},
-                         400)
+            MockResponse(
+                "HEAD",
+                "https://localhost:9000/hello",
+                {"User-Agent": _DEFAULT_USER_AGENT},
+                400,
+            )
         )
-        client = Minio('localhost:9000')
-        self.assertRaises(S3Error, client.bucket_exists, 'hello')
+        client = Minio("localhost:9000")
+        self.assertRaises(S3Error, client.bucket_exists, "hello")
 
-    @mock.patch('urllib3.PoolManager')
+    @mock.patch("urllib3.PoolManager")
     def test_bucket_exists_works(self, mock_connection):
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
-            MockResponse('HEAD',
-                         'https://localhost:9000/hello',
-                         {'User-Agent': _DEFAULT_USER_AGENT},
-                         200)
+            MockResponse(
+                "HEAD",
+                "https://localhost:9000/hello",
+                {"User-Agent": _DEFAULT_USER_AGENT},
+                200,
+            )
         )
-        client = Minio('localhost:9000')
-        result = client.bucket_exists('hello')
+        client = Minio("localhost:9000")
+        result = client.bucket_exists("hello")
         self.assertTrue(result)
         mock_server.mock_add_request(
-            MockResponse('HEAD',
-                         'https://localhost:9000/goodbye',
-                         {'User-Agent': _DEFAULT_USER_AGENT},
-                         404)
+            MockResponse(
+                "HEAD",
+                "https://localhost:9000/goodbye",
+                {"User-Agent": _DEFAULT_USER_AGENT},
+                404,
+            )
         )
-        false_result = client.bucket_exists('goodbye')
+        false_result = client.bucket_exists("goodbye")
         self.assertFalse(false_result)

--- a/tests/unit/copy_object_test.py
+++ b/tests/unit/copy_object_test.py
@@ -22,30 +22,39 @@ from minio.commonconfig import CopySource
 
 class CopyObjectTest(TestCase):
     def test_valid_copy_source(self):
-        client = Minio('localhost:9000')
+        client = Minio("localhost:9000")
         self.assertRaises(
-            ValueError,
-            client.copy_object, 'hello', '1', '/testbucket/object'
+            ValueError, client.copy_object, "hello", "1", "/testbucket/object"
         )
 
     def test_valid_match_etag(self):
         self.assertRaises(
-            ValueError, CopySource, "src-bucket", "src-object", match_etag='')
+            ValueError, CopySource, "src-bucket", "src-object", match_etag=""
+        )
 
     def test_not_match_etag(self):
         self.assertRaises(
             ValueError,
-            CopySource, "src-bucket", "src-object", not_match_etag=''
+            CopySource,
+            "src-bucket",
+            "src-object",
+            not_match_etag="",
         )
 
     def test_valid_modified_since(self):
         self.assertRaises(
             ValueError,
-            CopySource, "src-bucket", "src-object", modified_since=''
+            CopySource,
+            "src-bucket",
+            "src-object",
+            modified_since="",
         )
 
     def test_valid_unmodified_since(self):
         self.assertRaises(
             ValueError,
-            CopySource, "src-bucket", "src-object", unmodified_since=''
+            CopySource,
+            "src-bucket",
+            "src-object",
+            unmodified_since="",
         )

--- a/tests/unit/credentials_test.py
+++ b/tests/unit/credentials_test.py
@@ -21,11 +21,15 @@ from datetime import datetime, timedelta
 from unittest import TestCase
 
 from minio.credentials.credentials import Credentials
-from minio.credentials.providers import (AWSConfigProvider, ChainedProvider,
-                                         EnvAWSProvider, EnvMinioProvider,
-                                         IamAwsProvider,
-                                         MinioClientConfigProvider,
-                                         StaticProvider)
+from minio.credentials.providers import (
+    AWSConfigProvider,
+    ChainedProvider,
+    EnvAWSProvider,
+    EnvMinioProvider,
+    IamAwsProvider,
+    MinioClientConfigProvider,
+    StaticProvider,
+)
 
 CONFIG_JSON_SAMPLE = "tests/unit/config.json.sample"
 CREDENTIALS_SAMPLE = "tests/unit/credentials.sample"
@@ -40,8 +44,9 @@ class CredentialsTest(TestCase):
         )
         creds = provider.retrieve()
         self.assertEqual(creds.access_key, "Q3AM3UQ867SPQQA43P2F")
-        self.assertEqual(creds.secret_key,
-                         "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+        self.assertEqual(
+            creds.secret_key, "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
+        )
         self.assertEqual(creds.session_token, None)
 
 
@@ -52,15 +57,17 @@ class CredListResponse(object):
 
 class CredsResponse(object):
     status = 200
-    data = json.dumps({
-        "Code": "Success",
-        "Type": "AWS-HMAC",
-        "AccessKeyId": "accessKey",
-        "SecretAccessKey": "secret",
-        "Token": "token",
-        "Expiration": "2014-12-16T01:51:37Z",
-        "LastUpdated": "2009-11-23T0:00:00Z"
-    })
+    data = json.dumps(
+        {
+            "Code": "Success",
+            "Type": "AWS-HMAC",
+            "AccessKeyId": "accessKey",
+            "SecretAccessKey": "secret",
+            "Token": "token",
+            "Expiration": "2014-12-16T01:51:37Z",
+            "LastUpdated": "2009-11-23T0:00:00Z",
+        }
+    )
 
 
 class IamAwsProviderTest(TestCase):
@@ -90,7 +97,8 @@ class ChainedProviderTest(TestCase):
 
         provider = ChainedProvider(
             [
-                EnvAWSProvider(), EnvMinioProvider(),
+                EnvAWSProvider(),
+                EnvMinioProvider(),
             ]
         )
         # retrieve provider (env_aws) has priority
@@ -110,7 +118,8 @@ class ChainedProviderTest(TestCase):
 
         provider = ChainedProvider(
             [
-                EnvAWSProvider(), EnvMinioProvider(),
+                EnvAWSProvider(),
+                EnvMinioProvider(),
             ]
         )
         # retrieve provider: (env_minio) will be retrieved
@@ -147,7 +156,7 @@ class EnvAWSProviderTest(TestCase):
 class EnvMinioTest(TestCase):
     def test_env_minio_retrieve(self):
         os.environ.clear()
-        os.environ['MINIO_ACCESS_KEY'] = "access"
+        os.environ["MINIO_ACCESS_KEY"] = "access"
         os.environ["MINIO_SECRET_KEY"] = "secret"
         provider = EnvMinioProvider()
         creds = provider.retrieve()
@@ -167,9 +176,7 @@ class AWSConfigProviderTest(TestCase):
 
     def test_file_aws_from_env(self):
         os.environ.clear()
-        os.environ["AWS_SHARED_CREDENTIALS_FILE"] = (
-            CREDENTIALS_SAMPLE
-        )
+        os.environ["AWS_SHARED_CREDENTIALS_FILE"] = CREDENTIALS_SAMPLE
         provider = AWSConfigProvider()
         creds = provider.retrieve()
         self.assertEqual(creds.access_key, "accessKey")
@@ -223,8 +230,9 @@ class MinioClientConfigProviderTest(TestCase):
         provider = MinioClientConfigProvider(filename=CONFIG_JSON_SAMPLE)
         creds = provider.retrieve()
         self.assertEqual(creds.access_key, "Q3AM3UQ867SPQQA43P2F")
-        self.assertEqual(creds.secret_key,
-                         "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+        self.assertEqual(
+            creds.secret_key, "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
+        )
         self.assertEqual(creds.session_token, None)
 
     def test_file_minio_arg_alias(self):
@@ -235,8 +243,9 @@ class MinioClientConfigProviderTest(TestCase):
         )
         creds = provider.retrieve()
         self.assertEqual(creds.access_key, "Q3AM3UQ867SPQQA43P2F")
-        self.assertEqual(creds.secret_key,
-                         "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+        self.assertEqual(
+            creds.secret_key, "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
+        )
         self.assertEqual(creds.session_token, None)
 
 

--- a/tests/unit/credentials_test.py
+++ b/tests/unit/credentials_test.py
@@ -44,9 +44,7 @@ class CredentialsTest(TestCase):
         )
         creds = provider.retrieve()
         self.assertEqual(creds.access_key, "Q3AM3UQ867SPQQA43P2F")
-        self.assertEqual(
-            creds.secret_key, "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
-        )
+        self.assertEqual(creds.secret_key, "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
         self.assertEqual(creds.session_token, None)
 
 
@@ -230,9 +228,7 @@ class MinioClientConfigProviderTest(TestCase):
         provider = MinioClientConfigProvider(filename=CONFIG_JSON_SAMPLE)
         creds = provider.retrieve()
         self.assertEqual(creds.access_key, "Q3AM3UQ867SPQQA43P2F")
-        self.assertEqual(
-            creds.secret_key, "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
-        )
+        self.assertEqual(creds.secret_key, "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
         self.assertEqual(creds.session_token, None)
 
     def test_file_minio_arg_alias(self):
@@ -243,9 +239,7 @@ class MinioClientConfigProviderTest(TestCase):
         )
         creds = provider.retrieve()
         self.assertEqual(creds.access_key, "Q3AM3UQ867SPQQA43P2F")
-        self.assertEqual(
-            creds.secret_key, "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
-        )
+        self.assertEqual(creds.secret_key, "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
         self.assertEqual(creds.session_token, None)
 
 

--- a/tests/unit/get_bucket_policy_test.py
+++ b/tests/unit/get_bucket_policy_test.py
@@ -26,71 +26,75 @@ from tests.unit.minio_mocks import MockConnection, MockResponse
 
 
 class GetBucketPolicyTest(TestCase):
-    @mock.patch('urllib3.PoolManager')
+    @mock.patch("urllib3.PoolManager")
     def test_get_policy_for_non_existent_bucket(self, mock_connection):
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
-        bucket_name = 'non-existent-bucket'
-        error = ("<ErrorResponse>"
-                 "<Code>NoSuchBucket</Code>"
-                 "<Message>No such bucket</Message><RequestId>1234</RequestId>"
-                 "<Resource>/non-existent-bucket</Resource>"
-                 "<HostId>abcd</HostId>"
-                 "<BucketName>non-existent-bucket</BucketName>"
-                 "</ErrorResponse>")
+        bucket_name = "non-existent-bucket"
+        error = (
+            "<ErrorResponse>"
+            "<Code>NoSuchBucket</Code>"
+            "<Message>No such bucket</Message><RequestId>1234</RequestId>"
+            "<Resource>/non-existent-bucket</Resource>"
+            "<HostId>abcd</HostId>"
+            "<BucketName>non-existent-bucket</BucketName>"
+            "</ErrorResponse>"
+        )
         mock_server.mock_add_request(
             MockResponse(
-                'GET',
-                'https://localhost:9000/' + bucket_name + '?policy=',
-                {'User-Agent': _DEFAULT_USER_AGENT},
+                "GET",
+                "https://localhost:9000/" + bucket_name + "?policy=",
+                {"User-Agent": _DEFAULT_USER_AGENT},
                 404,
                 response_headers={"Content-Type": "application/xml"},
-                content=error.encode()
+                content=error.encode(),
             )
         )
-        client = Minio('localhost:9000')
+        client = Minio("localhost:9000")
         self.assertRaises(S3Error, client.get_bucket_policy, bucket_name)
 
-    @mock.patch('urllib3.PoolManager')
+    @mock.patch("urllib3.PoolManager")
     def test_get_policy_for_existent_bucket(self, mock_connection):
-        mock_data = json.dumps({
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Sid": "",
-                    "Effect": "Allow",
-                    "Principal": {"AWS": "*"},
-                    "Action": "s3:GetBucketLocation",
-                    "Resource": "arn:aws:s3:::test-bucket"
-                },
-                {
-                    "Sid": "",
-                    "Effect": "Allow",
-                    "Principal": {"AWS": "*"},
-                    "Action": "s3:ListBucket",
-                    "Resource": "arn:aws:s3:::test-bucket"
-                },
-                {
-                    "Sid": "",
-                    "Effect": "Allow",
-                    "Principal": {"AWS": "*"},
-                    "Action": "s3:GetObject",
-                    "Resource": "arn:aws:s3:::test-bucket/*"
-                }
-            ]
-        }).encode()
+        mock_data = json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Sid": "",
+                        "Effect": "Allow",
+                        "Principal": {"AWS": "*"},
+                        "Action": "s3:GetBucketLocation",
+                        "Resource": "arn:aws:s3:::test-bucket",
+                    },
+                    {
+                        "Sid": "",
+                        "Effect": "Allow",
+                        "Principal": {"AWS": "*"},
+                        "Action": "s3:ListBucket",
+                        "Resource": "arn:aws:s3:::test-bucket",
+                    },
+                    {
+                        "Sid": "",
+                        "Effect": "Allow",
+                        "Principal": {"AWS": "*"},
+                        "Action": "s3:GetObject",
+                        "Resource": "arn:aws:s3:::test-bucket/*",
+                    },
+                ],
+            }
+        ).encode()
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
-        bucket_name = 'test-bucket'
+        bucket_name = "test-bucket"
         mock_server.mock_add_request(
             MockResponse(
-                'GET',
-                'https://localhost:9000/' + bucket_name + '?policy=',
-                {'User-Agent': _DEFAULT_USER_AGENT},
+                "GET",
+                "https://localhost:9000/" + bucket_name + "?policy=",
+                {"User-Agent": _DEFAULT_USER_AGENT},
                 200,
-                content=mock_data
+                content=mock_data,
             )
         )
-        client = Minio('localhost:9000')
+        client = Minio("localhost:9000")
         response = client.get_bucket_policy(bucket_name)
         self.assertEqual(response, mock_data.decode())

--- a/tests/unit/get_object_test.py
+++ b/tests/unit/get_object_test.py
@@ -27,27 +27,35 @@ from .minio_mocks import MockConnection, MockResponse
 
 class GetObjectTest(TestCase):
     def test_object_is_string(self):
-        client = Minio('localhost:9000')
-        self.assertRaises(TypeError, client.get_object, 'hello', 1234)
+        client = Minio("localhost:9000")
+        self.assertRaises(TypeError, client.get_object, "hello", 1234)
 
     def test_object_is_not_empty_string(self):
-        client = Minio('localhost:9000')
-        self.assertRaises(ValueError, client.get_object, 'hello', ' \t \n ')
+        client = Minio("localhost:9000")
+        self.assertRaises(ValueError, client.get_object, "hello", " \t \n ")
 
-    @mock.patch('urllib3.PoolManager')
+    @mock.patch("urllib3.PoolManager")
     def test_get_object_throws_fail(self, mock_connection):
-        error_xml = generate_error('code', 'message', 'request_id',
-                                   'host_id', 'resource', 'bucket',
-                                   'object')
+        error_xml = generate_error(
+            "code",
+            "message",
+            "request_id",
+            "host_id",
+            "resource",
+            "bucket",
+            "object",
+        )
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
-            MockResponse('GET',
-                         'https://localhost:9000/hello/key',
-                         {'User-Agent': _DEFAULT_USER_AGENT},
-                         404,
-                         response_headers={"Content-Type": "application/xml"},
-                         content=error_xml.encode())
+            MockResponse(
+                "GET",
+                "https://localhost:9000/hello/key",
+                {"User-Agent": _DEFAULT_USER_AGENT},
+                404,
+                response_headers={"Content-Type": "application/xml"},
+                content=error_xml.encode(),
+            )
         )
-        client = Minio('localhost:9000')
-        self.assertRaises(S3Error, client.get_object, 'hello', 'key')
+        client = Minio("localhost:9000")
+        self.assertRaises(S3Error, client.get_object, "hello", "key")

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -622,8 +622,7 @@ class BaseURLTests(TestCase):
             ),
             Case(
                 (
-                    "https://s3-accesspoint.dualstack.us-gov-east-1."
-                    "amazonaws.com",
+                    "https://s3-accesspoint.dualstack.us-gov-east-1." "amazonaws.com",
                     None,
                 ),
                 {
@@ -635,8 +634,7 @@ class BaseURLTests(TestCase):
             ),
             Case(
                 (
-                    "https://s3-accesspoint.dualstack.us-gov-east-1."
-                    "amazonaws.com",
+                    "https://s3-accesspoint.dualstack.us-gov-east-1." "amazonaws.com",
                     "cn-northwest-1",
                 ),
                 {
@@ -667,8 +665,7 @@ class BaseURLTests(TestCase):
             ),
             Case(
                 (
-                    "https://s3-accesspoint-fips.us-gov-east-1."
-                    "amazonaws.com",
+                    "https://s3-accesspoint-fips.us-gov-east-1." "amazonaws.com",
                     None,
                 ),
                 {
@@ -680,8 +677,7 @@ class BaseURLTests(TestCase):
             ),
             Case(
                 (
-                    "https://s3-accesspoint-fips.us-gov-east-1."
-                    "amazonaws.com",
+                    "https://s3-accesspoint-fips.us-gov-east-1." "amazonaws.com",
                     "cn-northwest-1",
                 ),
                 {
@@ -896,8 +892,7 @@ class BaseURLTests(TestCase):
                     "vpce.amazonaws.com",
                     None,
                 ),
-                "https://bucket.vpce-1a2b3c4d-5e6f.s3.us-east-1."
-                "vpce.amazonaws.com/",
+                "https://bucket.vpce-1a2b3c4d-5e6f.s3.us-east-1." "vpce.amazonaws.com/",
             ),
             Case(
                 (
@@ -955,8 +950,7 @@ class BaseURLTests(TestCase):
                     "amazonaws.com",
                     None,
                 ),
-                "https://012345678901.s3-control.us-gov-east-1."
-                "amazonaws.com/",
+                "https://012345678901.s3-control.us-gov-east-1." "amazonaws.com/",
             ),
             Case(
                 (
@@ -964,8 +958,7 @@ class BaseURLTests(TestCase):
                     "amazonaws.com",
                     "cn-northwest-1",
                 ),
-                "https://012345678901.s3-control.cn-northwest-1."
-                "amazonaws.com/",
+                "https://012345678901.s3-control.cn-northwest-1." "amazonaws.com/",
             ),
             ###
             Case(
@@ -977,8 +970,7 @@ class BaseURLTests(TestCase):
                     "https://012345678901.s3-control-fips.amazonaws.com",
                     "ap-south-1a",
                 ),
-                "https://012345678901.s3-control-fips.ap-south-1a."
-                "amazonaws.com/",
+                "https://012345678901.s3-control-fips.ap-south-1a." "amazonaws.com/",
             ),
             Case(
                 (
@@ -986,8 +978,7 @@ class BaseURLTests(TestCase):
                     "amazonaws.com",
                     None,
                 ),
-                "https://012345678901.s3-control-fips.us-gov-east-1."
-                "amazonaws.com/",
+                "https://012345678901.s3-control-fips.us-gov-east-1." "amazonaws.com/",
             ),
             Case(
                 (
@@ -995,8 +986,7 @@ class BaseURLTests(TestCase):
                     "amazonaws.com",
                     "cn-northwest-1",
                 ),
-                "https://012345678901.s3-control-fips.cn-northwest-1."
-                "amazonaws.com/",
+                "https://012345678901.s3-control-fips.cn-northwest-1." "amazonaws.com/",
             ),
             ###
             Case(
@@ -1004,16 +994,14 @@ class BaseURLTests(TestCase):
                     "https://012345678901.s3-control-fips.dualstack.amazonaws.com",
                     None,
                 ),
-                "https://012345678901.s3-control-fips.us-east-1."
-                "amazonaws.com/",
+                "https://012345678901.s3-control-fips.us-east-1." "amazonaws.com/",
             ),
             Case(
                 (
                     "https://012345678901.s3-control-fips.dualstack.amazonaws.com",
                     "ap-south-1a",
                 ),
-                "https://012345678901.s3-control-fips.ap-south-1a."
-                "amazonaws.com/",
+                "https://012345678901.s3-control-fips.ap-south-1a." "amazonaws.com/",
             ),
             Case(
                 (
@@ -1021,8 +1009,7 @@ class BaseURLTests(TestCase):
                     "amazonaws.com",
                     None,
                 ),
-                "https://012345678901.s3-control-fips.us-gov-east-1."
-                "amazonaws.com/",
+                "https://012345678901.s3-control-fips.us-gov-east-1." "amazonaws.com/",
             ),
             Case(
                 (
@@ -1030,8 +1017,7 @@ class BaseURLTests(TestCase):
                     "amazonaws.com",
                     "cn-northwest-1",
                 ),
-                "https://012345678901.s3-control-fips.cn-northwest-1."
-                "amazonaws.com/",
+                "https://012345678901.s3-control-fips.cn-northwest-1." "amazonaws.com/",
             ),
             ###
             Case(
@@ -1067,16 +1053,14 @@ class BaseURLTests(TestCase):
             ),
             Case(
                 (
-                    "https://s3-accesspoint.dualstack.us-gov-east-1."
-                    "amazonaws.com",
+                    "https://s3-accesspoint.dualstack.us-gov-east-1." "amazonaws.com",
                     None,
                 ),
                 "https://s3.us-gov-east-1.amazonaws.com/",
             ),
             Case(
                 (
-                    "https://s3-accesspoint.dualstack.us-gov-east-1."
-                    "amazonaws.com",
+                    "https://s3-accesspoint.dualstack.us-gov-east-1." "amazonaws.com",
                     "cn-northwest-1",
                 ),
                 "https://s3.cn-northwest-1.amazonaws.com/",
@@ -1092,16 +1076,14 @@ class BaseURLTests(TestCase):
             ),
             Case(
                 (
-                    "https://s3-accesspoint-fips.us-gov-east-1."
-                    "amazonaws.com",
+                    "https://s3-accesspoint-fips.us-gov-east-1." "amazonaws.com",
                     None,
                 ),
                 "https://s3.us-gov-east-1.amazonaws.com/",
             ),
             Case(
                 (
-                    "https://s3-accesspoint-fips.us-gov-east-1."
-                    "amazonaws.com",
+                    "https://s3-accesspoint-fips.us-gov-east-1." "amazonaws.com",
                     "cn-northwest-1",
                 ),
                 "https://s3.cn-northwest-1.amazonaws.com/",
@@ -1141,16 +1123,13 @@ class BaseURLTests(TestCase):
                     "amazonaws.com",
                     "us-west-2",
                 ),
-                "https://my-load-balancer-1234567890.us-west-2.elb."
-                "amazonaws.com/",
+                "https://my-load-balancer-1234567890.us-west-2.elb." "amazonaws.com/",
             ),
         ]
 
         for case in cases:
             base_url = BaseURL(*case.args)
-            url = urlunsplit(
-                base_url.build("GET", base_url.region or "us-east-1")
-            )
+            url = urlunsplit(base_url.build("GET", base_url.region or "us-east-1"))
             self.assertEqual(str(url), case.result)
 
     def test_aws_bucket_build(self):
@@ -1262,21 +1241,18 @@ class BaseURLTests(TestCase):
             ),
             Case(
                 ("https://s3-fips.dualstack.amazonaws.com", "ap-south-1a"),
-                "https://my-bucket.s3-fips.dualstack.ap-south-1a."
-                "amazonaws.com/",
+                "https://my-bucket.s3-fips.dualstack.ap-south-1a." "amazonaws.com/",
             ),
             Case(
                 ("https://s3-fips.dualstack.us-gov-east-1.amazonaws.com", None),
-                "https://my-bucket.s3-fips.dualstack.us-gov-east-1."
-                "amazonaws.com/",
+                "https://my-bucket.s3-fips.dualstack.us-gov-east-1." "amazonaws.com/",
             ),
             Case(
                 (
                     "https://s3-fips.dualstack.me-south-1.amazonaws.com",
                     "cn-northwest-1",
                 ),
-                "https://my-bucket.s3-fips.dualstack.cn-northwest-1."
-                "amazonaws.com/",
+                "https://my-bucket.s3-fips.dualstack.cn-northwest-1." "amazonaws.com/",
             ),
             ###
             Case(
@@ -1313,8 +1289,7 @@ class BaseURLTests(TestCase):
             ###
             Case(
                 ("https://012345678901.s3-control.amazonaws.com", None),
-                "https://my-bucket.012345678901.s3-control.us-east-1."
-                "amazonaws.com/",
+                "https://my-bucket.012345678901.s3-control.us-east-1." "amazonaws.com/",
             ),
             Case(
                 (
@@ -1460,8 +1435,7 @@ class BaseURLTests(TestCase):
                     "https://s3-accesspoint.us-gov-east-1.amazonaws.com",
                     "cn-northwest-1",
                 ),
-                "https://my-bucket.s3-accesspoint.cn-northwest-1."
-                "amazonaws.com/",
+                "https://my-bucket.s3-accesspoint.cn-northwest-1." "amazonaws.com/",
             ),
             ###
             Case(
@@ -1479,8 +1453,7 @@ class BaseURLTests(TestCase):
             ),
             Case(
                 (
-                    "https://s3-accesspoint.dualstack.us-gov-east-1."
-                    "amazonaws.com",
+                    "https://s3-accesspoint.dualstack.us-gov-east-1." "amazonaws.com",
                     None,
                 ),
                 "https://my-bucket.s3-accesspoint.dualstack.us-gov-east-1."
@@ -1488,8 +1461,7 @@ class BaseURLTests(TestCase):
             ),
             Case(
                 (
-                    "https://s3-accesspoint.dualstack.us-gov-east-1."
-                    "amazonaws.com",
+                    "https://s3-accesspoint.dualstack.us-gov-east-1." "amazonaws.com",
                     "cn-northwest-1",
                 ),
                 "https://my-bucket.s3-accesspoint.dualstack.cn-northwest-1."
@@ -1498,27 +1470,22 @@ class BaseURLTests(TestCase):
             ###
             Case(
                 ("https://s3-accesspoint-fips.amazonaws.com", None),
-                "https://my-bucket.s3-accesspoint-fips.us-east-1."
-                "amazonaws.com/",
+                "https://my-bucket.s3-accesspoint-fips.us-east-1." "amazonaws.com/",
             ),
             Case(
                 ("https://s3-accesspoint-fips.amazonaws.com", "ap-south-1a"),
-                "https://my-bucket.s3-accesspoint-fips.ap-south-1a."
-                "amazonaws.com/",
+                "https://my-bucket.s3-accesspoint-fips.ap-south-1a." "amazonaws.com/",
             ),
             Case(
                 (
-                    "https://s3-accesspoint-fips.us-gov-east-1."
-                    "amazonaws.com",
+                    "https://s3-accesspoint-fips.us-gov-east-1." "amazonaws.com",
                     None,
                 ),
-                "https://my-bucket.s3-accesspoint-fips.us-gov-east-1."
-                "amazonaws.com/",
+                "https://my-bucket.s3-accesspoint-fips.us-gov-east-1." "amazonaws.com/",
             ),
             Case(
                 (
-                    "https://s3-accesspoint-fips.us-gov-east-1."
-                    "amazonaws.com",
+                    "https://s3-accesspoint-fips.us-gov-east-1." "amazonaws.com",
                     "cn-northwest-1",
                 ),
                 "https://my-bucket.s3-accesspoint-fips.cn-northwest-1."
@@ -1584,18 +1551,15 @@ class BaseURLTests(TestCase):
         cases = [
             Case(
                 ("https://s3.amazonaws.com", None),
-                "https://my-bucket.s3.us-east-1.amazonaws.com/"
-                "path/to/my/object",
+                "https://my-bucket.s3.us-east-1.amazonaws.com/" "path/to/my/object",
             ),
             Case(
                 ("https://s3.amazonaws.com", "ap-south-1a"),
-                "https://my-bucket.s3.ap-south-1a.amazonaws.com/"
-                "path/to/my/object",
+                "https://my-bucket.s3.ap-south-1a.amazonaws.com/" "path/to/my/object",
             ),
             Case(
                 ("https://s3.us-gov-east-1.amazonaws.com", None),
-                "https://my-bucket.s3.us-gov-east-1.amazonaws.com/"
-                "path/to/my/object",
+                "https://my-bucket.s3.us-gov-east-1.amazonaws.com/" "path/to/my/object",
             ),
             Case(
                 ("https://s3.me-south-1.amazonaws.com", "cn-northwest-1"),
@@ -1629,26 +1593,22 @@ class BaseURLTests(TestCase):
             ###
             Case(
                 ("https://s3-accelerate.amazonaws.com", None),
-                "https://my-bucket.s3-accelerate.amazonaws.com/"
-                "path/to/my/object",
+                "https://my-bucket.s3-accelerate.amazonaws.com/" "path/to/my/object",
             ),
             Case(
                 ("https://s3-accelerate.amazonaws.com", "ap-south-1a"),
-                "https://my-bucket.s3-accelerate.amazonaws.com/"
-                "path/to/my/object",
+                "https://my-bucket.s3-accelerate.amazonaws.com/" "path/to/my/object",
             ),
             Case(
                 ("https://s3-accelerate.us-gov-east-1.amazonaws.com", None),
-                "https://my-bucket.s3-accelerate.amazonaws.com/"
-                "path/to/my/object",
+                "https://my-bucket.s3-accelerate.amazonaws.com/" "path/to/my/object",
             ),
             Case(
                 (
                     "https://s3-accelerate.me-south-1.amazonaws.com",
                     "cn-northwest-1",
                 ),
-                "https://my-bucket.s3-accelerate.amazonaws.com/"
-                "path/to/my/object",
+                "https://my-bucket.s3-accelerate.amazonaws.com/" "path/to/my/object",
             ),
             ###
             Case(
@@ -1728,13 +1688,11 @@ class BaseURLTests(TestCase):
             ###
             Case(
                 ("https://s3-external-1.amazonaws.com", None),
-                "https://my-bucket.s3-external-1.amazonaws.com/"
-                "path/to/my/object",
+                "https://my-bucket.s3-external-1.amazonaws.com/" "path/to/my/object",
             ),
             Case(
                 ("https://s3-us-gov-west-1.amazonaws.com", None),
-                "https://my-bucket.s3-us-gov-west-1.amazonaws.com/"
-                "path/to/my/object",
+                "https://my-bucket.s3-us-gov-west-1.amazonaws.com/" "path/to/my/object",
             ),
             Case(
                 ("https://s3-fips-us-gov-west-1.amazonaws.com", None),
@@ -1932,8 +1890,7 @@ class BaseURLTests(TestCase):
             ),
             Case(
                 (
-                    "https://s3-accesspoint.dualstack.us-gov-east-1."
-                    "amazonaws.com",
+                    "https://s3-accesspoint.dualstack.us-gov-east-1." "amazonaws.com",
                     None,
                 ),
                 "https://my-bucket.s3-accesspoint.dualstack.us-gov-east-1."
@@ -1941,8 +1898,7 @@ class BaseURLTests(TestCase):
             ),
             Case(
                 (
-                    "https://s3-accesspoint.dualstack.us-gov-east-1."
-                    "amazonaws.com",
+                    "https://s3-accesspoint.dualstack.us-gov-east-1." "amazonaws.com",
                     "cn-northwest-1",
                 ),
                 "https://my-bucket.s3-accesspoint.dualstack.cn-northwest-1."
@@ -1961,8 +1917,7 @@ class BaseURLTests(TestCase):
             ),
             Case(
                 (
-                    "https://s3-accesspoint-fips.us-gov-east-1."
-                    "amazonaws.com",
+                    "https://s3-accesspoint-fips.us-gov-east-1." "amazonaws.com",
                     None,
                 ),
                 "https://my-bucket.s3-accesspoint-fips.us-gov-east-1."
@@ -1970,8 +1925,7 @@ class BaseURLTests(TestCase):
             ),
             Case(
                 (
-                    "https://s3-accesspoint-fips.us-gov-east-1."
-                    "amazonaws.com",
+                    "https://s3-accesspoint-fips.us-gov-east-1." "amazonaws.com",
                     "cn-northwest-1",
                 ),
                 "https://my-bucket.s3-accesspoint-fips.cn-northwest-1."

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -21,9 +21,10 @@ from urllib.parse import urlunsplit
 from minio.helpers import BaseURL
 
 
-def generate_error(code, message, request_id, host_id,
-                   resource, bucket_name, object_name):
-    return '''
+def generate_error(
+    code, message, request_id, host_id, resource, bucket_name, object_name
+):
+    return """
     <Error>
       <Code>{0}</Code>
       <Message>{1}</Message>
@@ -33,8 +34,9 @@ def generate_error(code, message, request_id, host_id,
       <BucketName>{5}</BucketName>
       <Key>{6}</Key>
     </Error>
-    '''.format(code, message, request_id, host_id,
-               resource, bucket_name, object_name)
+    """.format(
+        code, message, request_id, host_id, resource, bucket_name, object_name
+    )
 
 
 class BaseURLTests(TestCase):
@@ -131,8 +133,10 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://s3.dualstack.me-south-1.amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3.dualstack.me-south-1.amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 {
                     "s3_prefix": "s3.",
                     "domain_suffix": "amazonaws.com",
@@ -169,8 +173,10 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://s3-accelerate.me-south-1.amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-accelerate.me-south-1.amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 {
                     "s3_prefix": "s3-accelerate.",
                     "domain_suffix": "amazonaws.com",
@@ -189,8 +195,10 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://s3-accelerate.dualstack.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://s3-accelerate.dualstack.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 {
                     "s3_prefix": "s3-accelerate.",
                     "domain_suffix": "amazonaws.com",
@@ -199,8 +207,10 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://s3-accelerate.dualstack.us-gov-east-1.amazonaws.com",
-                 None),
+                (
+                    "https://s3-accelerate.dualstack.us-gov-east-1.amazonaws.com",
+                    None,
+                ),
                 {
                     "s3_prefix": "s3-accelerate.",
                     "domain_suffix": "amazonaws.com",
@@ -209,8 +219,10 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://s3-accelerate.dualstack.me-south-1.amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-accelerate.dualstack.me-south-1.amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 {
                     "s3_prefix": "s3-accelerate.",
                     "domain_suffix": "amazonaws.com",
@@ -284,8 +296,10 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://s3-fips.dualstack.me-south-1.amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-fips.dualstack.me-south-1.amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 {
                     "s3_prefix": "s3-fips.",
                     "domain_suffix": "amazonaws.com",
@@ -323,8 +337,11 @@ class BaseURLTests(TestCase):
             ),
             ###
             Case(
-                ("https://bucket.vpce-1a2b3c4d-5e6f.s3.us-east-1."
-                 "vpce.amazonaws.com", None),
+                (
+                    "https://bucket.vpce-1a2b3c4d-5e6f.s3.us-east-1."
+                    "vpce.amazonaws.com",
+                    None,
+                ),
                 {
                     "s3_prefix": "bucket.vpce-1a2b3c4d-5e6f.s3.",
                     "domain_suffix": "vpce.amazonaws.com",
@@ -333,8 +350,11 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://accesspoint.vpce-1a2b3c4d-5e6f.s3.us-east-1."
-                 "vpce.amazonaws.com", None),
+                (
+                    "https://accesspoint.vpce-1a2b3c4d-5e6f.s3.us-east-1."
+                    "vpce.amazonaws.com",
+                    None,
+                ),
                 {
                     "s3_prefix": "accesspoint.vpce-1a2b3c4d-5e6f.s3.",
                     "domain_suffix": "vpce.amazonaws.com",
@@ -353,8 +373,10 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://012345678901.s3-control.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://012345678901.s3-control.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 {
                     "s3_prefix": "012345678901.s3-control.",
                     "domain_suffix": "amazonaws.com",
@@ -363,8 +385,10 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://012345678901.s3-control.us-gov-east-1.amazonaws.com",
-                 None),
+                (
+                    "https://012345678901.s3-control.us-gov-east-1.amazonaws.com",
+                    None,
+                ),
                 {
                     "s3_prefix": "012345678901.s3-control.",
                     "domain_suffix": "amazonaws.com",
@@ -373,8 +397,10 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://012345678901.s3-control.us-gov-east-1.amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://012345678901.s3-control.us-gov-east-1.amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 {
                     "s3_prefix": "012345678901.s3-control.",
                     "domain_suffix": "amazonaws.com",
@@ -384,8 +410,10 @@ class BaseURLTests(TestCase):
             ),
             ###
             Case(
-                ("https://012345678901.s3-control.dualstack.amazonaws.com",
-                 None),
+                (
+                    "https://012345678901.s3-control.dualstack.amazonaws.com",
+                    None,
+                ),
                 {
                     "s3_prefix": "012345678901.s3-control.",
                     "domain_suffix": "amazonaws.com",
@@ -394,8 +422,10 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://012345678901.s3-control.dualstack.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://012345678901.s3-control.dualstack.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 {
                     "s3_prefix": "012345678901.s3-control.",
                     "domain_suffix": "amazonaws.com",
@@ -404,9 +434,11 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://012345678901.s3-control.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 None),
+                (
+                    "https://012345678901.s3-control.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    None,
+                ),
                 {
                     "s3_prefix": "012345678901.s3-control.",
                     "domain_suffix": "amazonaws.com",
@@ -415,9 +447,11 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://012345678901.s3-control.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://012345678901.s3-control.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 {
                     "s3_prefix": "012345678901.s3-control.",
                     "domain_suffix": "amazonaws.com",
@@ -436,8 +470,10 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://012345678901.s3-control-fips.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://012345678901.s3-control-fips.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 {
                     "s3_prefix": "012345678901.s3-control-fips.",
                     "domain_suffix": "amazonaws.com",
@@ -446,9 +482,11 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://012345678901.s3-control-fips.us-gov-east-1."
-                 "amazonaws.com",
-                 None),
+                (
+                    "https://012345678901.s3-control-fips.us-gov-east-1."
+                    "amazonaws.com",
+                    None,
+                ),
                 {
                     "s3_prefix": "012345678901.s3-control-fips.",
                     "domain_suffix": "amazonaws.com",
@@ -457,9 +495,11 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://012345678901.s3-control-fips.us-gov-east-1."
-                 "amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://012345678901.s3-control-fips.us-gov-east-1."
+                    "amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 {
                     "s3_prefix": "012345678901.s3-control-fips.",
                     "domain_suffix": "amazonaws.com",
@@ -469,8 +509,10 @@ class BaseURLTests(TestCase):
             ),
             ###
             Case(
-                ("https://012345678901.s3-control-fips.dualstack.amazonaws.com",
-                 None),
+                (
+                    "https://012345678901.s3-control-fips.dualstack.amazonaws.com",
+                    None,
+                ),
                 {
                     "s3_prefix": "012345678901.s3-control-fips.",
                     "domain_suffix": "amazonaws.com",
@@ -479,8 +521,10 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://012345678901.s3-control-fips.dualstack.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://012345678901.s3-control-fips.dualstack.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 {
                     "s3_prefix": "012345678901.s3-control-fips.",
                     "domain_suffix": "amazonaws.com",
@@ -489,9 +533,11 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://012345678901.s3-control-fips.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 None),
+                (
+                    "https://012345678901.s3-control-fips.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    None,
+                ),
                 {
                     "s3_prefix": "012345678901.s3-control-fips.",
                     "domain_suffix": "amazonaws.com",
@@ -500,9 +546,11 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://012345678901.s3-control-fips.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://012345678901.s3-control-fips.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 {
                     "s3_prefix": "012345678901.s3-control-fips.",
                     "domain_suffix": "amazonaws.com",
@@ -521,8 +569,7 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://s3-accesspoint.amazonaws.com",
-                 "ap-south-1a"),
+                ("https://s3-accesspoint.amazonaws.com", "ap-south-1a"),
                 {
                     "s3_prefix": "s3-accesspoint.",
                     "domain_suffix": "amazonaws.com",
@@ -531,8 +578,7 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://s3-accesspoint.us-gov-east-1.amazonaws.com",
-                 None),
+                ("https://s3-accesspoint.us-gov-east-1.amazonaws.com", None),
                 {
                     "s3_prefix": "s3-accesspoint.",
                     "domain_suffix": "amazonaws.com",
@@ -541,8 +587,10 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://s3-accesspoint.us-gov-east-1.amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-accesspoint.us-gov-east-1.amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 {
                     "s3_prefix": "s3-accesspoint.",
                     "domain_suffix": "amazonaws.com",
@@ -552,8 +600,7 @@ class BaseURLTests(TestCase):
             ),
             ###
             Case(
-                ("https://s3-accesspoint.dualstack.amazonaws.com",
-                 None),
+                ("https://s3-accesspoint.dualstack.amazonaws.com", None),
                 {
                     "s3_prefix": "s3-accesspoint.",
                     "domain_suffix": "amazonaws.com",
@@ -562,8 +609,10 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://s3-accesspoint.dualstack.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://s3-accesspoint.dualstack.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 {
                     "s3_prefix": "s3-accesspoint.",
                     "domain_suffix": "amazonaws.com",
@@ -572,9 +621,11 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://s3-accesspoint.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 None),
+                (
+                    "https://s3-accesspoint.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    None,
+                ),
                 {
                     "s3_prefix": "s3-accesspoint.",
                     "domain_suffix": "amazonaws.com",
@@ -583,9 +634,11 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://s3-accesspoint.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-accesspoint.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 {
                     "s3_prefix": "s3-accesspoint.",
                     "domain_suffix": "amazonaws.com",
@@ -604,8 +657,7 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://s3-accesspoint-fips.amazonaws.com",
-                 "ap-south-1a"),
+                ("https://s3-accesspoint-fips.amazonaws.com", "ap-south-1a"),
                 {
                     "s3_prefix": "s3-accesspoint-fips.",
                     "domain_suffix": "amazonaws.com",
@@ -614,9 +666,11 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://s3-accesspoint-fips.us-gov-east-1."
-                 "amazonaws.com",
-                 None),
+                (
+                    "https://s3-accesspoint-fips.us-gov-east-1."
+                    "amazonaws.com",
+                    None,
+                ),
                 {
                     "s3_prefix": "s3-accesspoint-fips.",
                     "domain_suffix": "amazonaws.com",
@@ -625,9 +679,11 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://s3-accesspoint-fips.us-gov-east-1."
-                 "amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-accesspoint-fips.us-gov-east-1."
+                    "amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 {
                     "s3_prefix": "s3-accesspoint-fips.",
                     "domain_suffix": "amazonaws.com",
@@ -637,8 +693,7 @@ class BaseURLTests(TestCase):
             ),
             ###
             Case(
-                ("https://s3-accesspoint-fips.dualstack.amazonaws.com",
-                 None),
+                ("https://s3-accesspoint-fips.dualstack.amazonaws.com", None),
                 {
                     "s3_prefix": "s3-accesspoint-fips.",
                     "domain_suffix": "amazonaws.com",
@@ -647,8 +702,10 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://s3-accesspoint-fips.dualstack.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://s3-accesspoint-fips.dualstack.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 {
                     "s3_prefix": "s3-accesspoint-fips.",
                     "domain_suffix": "amazonaws.com",
@@ -657,9 +714,11 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://s3-accesspoint-fips.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 None),
+                (
+                    "https://s3-accesspoint-fips.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    None,
+                ),
                 {
                     "s3_prefix": "s3-accesspoint-fips.",
                     "domain_suffix": "amazonaws.com",
@@ -668,9 +727,11 @@ class BaseURLTests(TestCase):
                 },
             ),
             Case(
-                ("https://s3-accesspoint-fips.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-accesspoint-fips.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 {
                     "s3_prefix": "s3-accesspoint-fips.",
                     "domain_suffix": "amazonaws.com",
@@ -680,8 +741,11 @@ class BaseURLTests(TestCase):
             ),
             ###
             Case(
-                ("https://my-load-balancer-1234567890.us-west-2.elb."
-                 "amazonaws.com", "us-west-2"),
+                (
+                    "https://my-load-balancer-1234567890.us-west-2.elb."
+                    "amazonaws.com",
+                    "us-west-2",
+                ),
                 None,
             ),
         ]
@@ -723,8 +787,10 @@ class BaseURLTests(TestCase):
                 "https://s3.us-gov-east-1.amazonaws.com/",
             ),
             Case(
-                ("https://s3.dualstack.me-south-1.amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3.dualstack.me-south-1.amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://s3.cn-northwest-1.amazonaws.com/",
             ),
             ###
@@ -741,8 +807,10 @@ class BaseURLTests(TestCase):
                 "https://s3.us-gov-east-1.amazonaws.com/",
             ),
             Case(
-                ("https://s3-accelerate.me-south-1.amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-accelerate.me-south-1.amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://s3.cn-northwest-1.amazonaws.com/",
             ),
             ###
@@ -751,18 +819,24 @@ class BaseURLTests(TestCase):
                 "https://s3.us-east-1.amazonaws.com/",
             ),
             Case(
-                ("https://s3-accelerate.dualstack.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://s3-accelerate.dualstack.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 "https://s3.ap-south-1a.amazonaws.com/",
             ),
             Case(
-                ("https://s3-accelerate.dualstack.us-gov-east-1.amazonaws.com",
-                 None),
+                (
+                    "https://s3-accelerate.dualstack.us-gov-east-1.amazonaws.com",
+                    None,
+                ),
                 "https://s3.us-gov-east-1.amazonaws.com/",
             ),
             Case(
-                ("https://s3-accelerate.dualstack.me-south-1.amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-accelerate.dualstack.me-south-1.amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://s3.cn-northwest-1.amazonaws.com/",
             ),
             ###
@@ -796,8 +870,10 @@ class BaseURLTests(TestCase):
                 "https://s3.us-gov-east-1.amazonaws.com/",
             ),
             Case(
-                ("https://s3-fips.dualstack.me-south-1.amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-fips.dualstack.me-south-1.amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://s3.cn-northwest-1.amazonaws.com/",
             ),
             ###
@@ -815,14 +891,20 @@ class BaseURLTests(TestCase):
             ),
             ###
             Case(
-                ("https://bucket.vpce-1a2b3c4d-5e6f.s3.us-east-1."
-                 "vpce.amazonaws.com", None),
+                (
+                    "https://bucket.vpce-1a2b3c4d-5e6f.s3.us-east-1."
+                    "vpce.amazonaws.com",
+                    None,
+                ),
                 "https://bucket.vpce-1a2b3c4d-5e6f.s3.us-east-1."
                 "vpce.amazonaws.com/",
             ),
             Case(
-                ("https://accesspoint.vpce-1a2b3c4d-5e6f.s3.us-east-1."
-                 "vpce.amazonaws.com", None),
+                (
+                    "https://accesspoint.vpce-1a2b3c4d-5e6f.s3.us-east-1."
+                    "vpce.amazonaws.com",
+                    None,
+                ),
                 "https://accesspoint.vpce-1a2b3c4d-5e6f.s3.us-east-1."
                 "vpce.amazonaws.com/",
             ),
@@ -832,44 +914,56 @@ class BaseURLTests(TestCase):
                 "https://012345678901.s3-control.us-east-1.amazonaws.com/",
             ),
             Case(
-                ("https://012345678901.s3-control.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://012345678901.s3-control.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 "https://012345678901.s3-control.ap-south-1a.amazonaws.com/",
             ),
             Case(
-                ("https://012345678901.s3-control.us-gov-east-1.amazonaws.com",
-                 None),
+                (
+                    "https://012345678901.s3-control.us-gov-east-1.amazonaws.com",
+                    None,
+                ),
                 "https://012345678901.s3-control.us-gov-east-1.amazonaws.com/",
             ),
             Case(
-                ("https://012345678901.s3-control.us-gov-east-1.amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://012345678901.s3-control.us-gov-east-1.amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://012345678901.s3-control.cn-northwest-1.amazonaws.com/",
             ),
             ###
             Case(
-                ("https://012345678901.s3-control.dualstack.amazonaws.com",
-                 None),
-                "https://012345678901.s3-control.us-east-1."
-                "amazonaws.com/",
+                (
+                    "https://012345678901.s3-control.dualstack.amazonaws.com",
+                    None,
+                ),
+                "https://012345678901.s3-control.us-east-1." "amazonaws.com/",
             ),
             Case(
-                ("https://012345678901.s3-control.dualstack.amazonaws.com",
-                 "ap-south-1a"),
-                "https://012345678901.s3-control.ap-south-1a."
-                "amazonaws.com/",
+                (
+                    "https://012345678901.s3-control.dualstack.amazonaws.com",
+                    "ap-south-1a",
+                ),
+                "https://012345678901.s3-control.ap-south-1a." "amazonaws.com/",
             ),
             Case(
-                ("https://012345678901.s3-control.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 None),
+                (
+                    "https://012345678901.s3-control.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    None,
+                ),
                 "https://012345678901.s3-control.us-gov-east-1."
                 "amazonaws.com/",
             ),
             Case(
-                ("https://012345678901.s3-control.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://012345678901.s3-control.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://012345678901.s3-control.cn-northwest-1."
                 "amazonaws.com/",
             ),
@@ -879,49 +973,63 @@ class BaseURLTests(TestCase):
                 "https://012345678901.s3-control-fips.us-east-1.amazonaws.com/",
             ),
             Case(
-                ("https://012345678901.s3-control-fips.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://012345678901.s3-control-fips.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 "https://012345678901.s3-control-fips.ap-south-1a."
                 "amazonaws.com/",
             ),
             Case(
-                ("https://012345678901.s3-control-fips.us-gov-east-1."
-                 "amazonaws.com",
-                 None),
+                (
+                    "https://012345678901.s3-control-fips.us-gov-east-1."
+                    "amazonaws.com",
+                    None,
+                ),
                 "https://012345678901.s3-control-fips.us-gov-east-1."
                 "amazonaws.com/",
             ),
             Case(
-                ("https://012345678901.s3-control-fips.us-gov-east-1."
-                 "amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://012345678901.s3-control-fips.us-gov-east-1."
+                    "amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://012345678901.s3-control-fips.cn-northwest-1."
                 "amazonaws.com/",
             ),
             ###
             Case(
-                ("https://012345678901.s3-control-fips.dualstack.amazonaws.com",
-                 None),
+                (
+                    "https://012345678901.s3-control-fips.dualstack.amazonaws.com",
+                    None,
+                ),
                 "https://012345678901.s3-control-fips.us-east-1."
                 "amazonaws.com/",
             ),
             Case(
-                ("https://012345678901.s3-control-fips.dualstack.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://012345678901.s3-control-fips.dualstack.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 "https://012345678901.s3-control-fips.ap-south-1a."
                 "amazonaws.com/",
             ),
             Case(
-                ("https://012345678901.s3-control-fips.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 None),
+                (
+                    "https://012345678901.s3-control-fips.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    None,
+                ),
                 "https://012345678901.s3-control-fips.us-gov-east-1."
                 "amazonaws.com/",
             ),
             Case(
-                ("https://012345678901.s3-control-fips.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://012345678901.s3-control-fips.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://012345678901.s3-control-fips.cn-northwest-1."
                 "amazonaws.com/",
             ),
@@ -931,41 +1039,46 @@ class BaseURLTests(TestCase):
                 "https://s3.us-east-1.amazonaws.com/",
             ),
             Case(
-                ("https://s3-accesspoint.amazonaws.com",
-                 "ap-south-1a"),
+                ("https://s3-accesspoint.amazonaws.com", "ap-south-1a"),
                 "https://s3.ap-south-1a.amazonaws.com/",
             ),
             Case(
-                ("https://s3-accesspoint.us-gov-east-1.amazonaws.com",
-                 None),
+                ("https://s3-accesspoint.us-gov-east-1.amazonaws.com", None),
                 "https://s3.us-gov-east-1.amazonaws.com/",
             ),
             Case(
-                ("https://s3-accesspoint.us-gov-east-1.amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-accesspoint.us-gov-east-1.amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://s3.cn-northwest-1.amazonaws.com/",
             ),
             ###
             Case(
-                ("https://s3-accesspoint.dualstack.amazonaws.com",
-                 None),
+                ("https://s3-accesspoint.dualstack.amazonaws.com", None),
                 "https://s3.us-east-1.amazonaws.com/",
             ),
             Case(
-                ("https://s3-accesspoint.dualstack.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://s3-accesspoint.dualstack.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 "https://s3.ap-south-1a.amazonaws.com/",
             ),
             Case(
-                ("https://s3-accesspoint.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 None),
+                (
+                    "https://s3-accesspoint.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    None,
+                ),
                 "https://s3.us-gov-east-1.amazonaws.com/",
             ),
             Case(
-                ("https://s3-accesspoint.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-accesspoint.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://s3.cn-northwest-1.amazonaws.com/",
             ),
             ###
@@ -974,49 +1087,60 @@ class BaseURLTests(TestCase):
                 "https://s3.us-east-1.amazonaws.com/",
             ),
             Case(
-                ("https://s3-accesspoint-fips.amazonaws.com",
-                 "ap-south-1a"),
+                ("https://s3-accesspoint-fips.amazonaws.com", "ap-south-1a"),
                 "https://s3.ap-south-1a.amazonaws.com/",
             ),
             Case(
-                ("https://s3-accesspoint-fips.us-gov-east-1."
-                 "amazonaws.com",
-                 None),
+                (
+                    "https://s3-accesspoint-fips.us-gov-east-1."
+                    "amazonaws.com",
+                    None,
+                ),
                 "https://s3.us-gov-east-1.amazonaws.com/",
             ),
             Case(
-                ("https://s3-accesspoint-fips.us-gov-east-1."
-                 "amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-accesspoint-fips.us-gov-east-1."
+                    "amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://s3.cn-northwest-1.amazonaws.com/",
             ),
             ###
             Case(
-                ("https://s3-accesspoint-fips.dualstack.amazonaws.com",
-                 None),
+                ("https://s3-accesspoint-fips.dualstack.amazonaws.com", None),
                 "https://s3.us-east-1.amazonaws.com/",
             ),
             Case(
-                ("https://s3-accesspoint-fips.dualstack.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://s3-accesspoint-fips.dualstack.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 "https://s3.ap-south-1a.amazonaws.com/",
             ),
             Case(
-                ("https://s3-accesspoint-fips.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 None),
+                (
+                    "https://s3-accesspoint-fips.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    None,
+                ),
                 "https://s3.us-gov-east-1.amazonaws.com/",
             ),
             Case(
-                ("https://s3-accesspoint-fips.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-accesspoint-fips.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://s3.cn-northwest-1.amazonaws.com/",
             ),
             ###
             Case(
-                ("https://my-load-balancer-1234567890.us-west-2.elb."
-                 "amazonaws.com", "us-west-2"),
+                (
+                    "https://my-load-balancer-1234567890.us-west-2.elb."
+                    "amazonaws.com",
+                    "us-west-2",
+                ),
                 "https://my-load-balancer-1234567890.us-west-2.elb."
                 "amazonaws.com/",
             ),
@@ -1024,8 +1148,9 @@ class BaseURLTests(TestCase):
 
         for case in cases:
             base_url = BaseURL(*case.args)
-            url = urlunsplit(base_url.build(
-                "GET", base_url.region or "us-east-1"))
+            url = urlunsplit(
+                base_url.build("GET", base_url.region or "us-east-1")
+            )
             self.assertEqual(str(url), case.result)
 
     def test_aws_bucket_build(self):
@@ -1061,8 +1186,10 @@ class BaseURLTests(TestCase):
                 "https://my-bucket.s3.dualstack.us-gov-east-1.amazonaws.com/",
             ),
             Case(
-                ("https://s3.dualstack.me-south-1.amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3.dualstack.me-south-1.amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://my-bucket.s3.dualstack.cn-northwest-1.amazonaws.com/",
             ),
             ###
@@ -1079,8 +1206,10 @@ class BaseURLTests(TestCase):
                 "https://my-bucket.s3-accelerate.amazonaws.com/",
             ),
             Case(
-                ("https://s3-accelerate.me-south-1.amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-accelerate.me-south-1.amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://my-bucket.s3-accelerate.amazonaws.com/",
             ),
             ###
@@ -1089,18 +1218,24 @@ class BaseURLTests(TestCase):
                 "https://my-bucket.s3-accelerate.dualstack.amazonaws.com/",
             ),
             Case(
-                ("https://s3-accelerate.dualstack.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://s3-accelerate.dualstack.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 "https://my-bucket.s3-accelerate.dualstack.amazonaws.com/",
             ),
             Case(
-                ("https://s3-accelerate.dualstack.us-gov-east-1.amazonaws.com",
-                 None),
+                (
+                    "https://s3-accelerate.dualstack.us-gov-east-1.amazonaws.com",
+                    None,
+                ),
                 "https://my-bucket.s3-accelerate.dualstack.amazonaws.com/",
             ),
             Case(
-                ("https://s3-accelerate.dualstack.me-south-1.amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-accelerate.dualstack.me-south-1.amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://my-bucket.s3-accelerate.dualstack.amazonaws.com/",
             ),
             ###
@@ -1136,8 +1271,10 @@ class BaseURLTests(TestCase):
                 "amazonaws.com/",
             ),
             Case(
-                ("https://s3-fips.dualstack.me-south-1.amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-fips.dualstack.me-south-1.amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://my-bucket.s3-fips.dualstack.cn-northwest-1."
                 "amazonaws.com/",
             ),
@@ -1156,14 +1293,20 @@ class BaseURLTests(TestCase):
             ),
             ###
             Case(
-                ("https://bucket.vpce-1a2b3c4d-5e6f.s3.us-east-1."
-                 "vpce.amazonaws.com", None),
+                (
+                    "https://bucket.vpce-1a2b3c4d-5e6f.s3.us-east-1."
+                    "vpce.amazonaws.com",
+                    None,
+                ),
                 "https://my-bucket.bucket.vpce-1a2b3c4d-5e6f.s3.us-east-1."
                 "vpce.amazonaws.com/",
             ),
             Case(
-                ("https://accesspoint.vpce-1a2b3c4d-5e6f.s3.us-east-1."
-                 "vpce.amazonaws.com", None),
+                (
+                    "https://accesspoint.vpce-1a2b3c4d-5e6f.s3.us-east-1."
+                    "vpce.amazonaws.com",
+                    None,
+                ),
                 "https://my-bucket.accesspoint.vpce-1a2b3c4d-5e6f.s3.us-east-1."
                 "vpce.amazonaws.com/",
             ),
@@ -1174,47 +1317,61 @@ class BaseURLTests(TestCase):
                 "amazonaws.com/",
             ),
             Case(
-                ("https://012345678901.s3-control.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://012345678901.s3-control.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 "https://my-bucket.012345678901.s3-control.ap-south-1a."
                 "amazonaws.com/",
             ),
             Case(
-                ("https://012345678901.s3-control.us-gov-east-1.amazonaws.com",
-                 None),
+                (
+                    "https://012345678901.s3-control.us-gov-east-1.amazonaws.com",
+                    None,
+                ),
                 "https://my-bucket.012345678901.s3-control.us-gov-east-1."
                 "amazonaws.com/",
             ),
             Case(
-                ("https://012345678901.s3-control.us-gov-east-1.amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://012345678901.s3-control.us-gov-east-1.amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://my-bucket.012345678901.s3-control.cn-northwest-1."
                 "amazonaws.com/",
             ),
             ###
             Case(
-                ("https://012345678901.s3-control.dualstack.amazonaws.com",
-                 None),
+                (
+                    "https://012345678901.s3-control.dualstack.amazonaws.com",
+                    None,
+                ),
                 "https://my-bucket.012345678901.s3-control.dualstack.us-east-1."
                 "amazonaws.com/",
             ),
             Case(
-                ("https://012345678901.s3-control.dualstack.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://012345678901.s3-control.dualstack.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 "https://my-bucket.012345678901.s3-control.dualstack."
                 "ap-south-1a.amazonaws.com/",
             ),
             Case(
-                ("https://012345678901.s3-control.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 None),
+                (
+                    "https://012345678901.s3-control.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    None,
+                ),
                 "https://my-bucket.012345678901.s3-control.dualstack."
                 "us-gov-east-1.amazonaws.com/",
             ),
             Case(
-                ("https://012345678901.s3-control.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://012345678901.s3-control.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://my-bucket.012345678901.s3-control.dualstack."
                 "cn-northwest-1.amazonaws.com/",
             ),
@@ -1225,49 +1382,63 @@ class BaseURLTests(TestCase):
                 "amazonaws.com/",
             ),
             Case(
-                ("https://012345678901.s3-control-fips.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://012345678901.s3-control-fips.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 "https://my-bucket.012345678901.s3-control-fips.ap-south-1a."
                 "amazonaws.com/",
             ),
             Case(
-                ("https://012345678901.s3-control-fips.us-gov-east-1."
-                 "amazonaws.com",
-                 None),
+                (
+                    "https://012345678901.s3-control-fips.us-gov-east-1."
+                    "amazonaws.com",
+                    None,
+                ),
                 "https://my-bucket.012345678901.s3-control-fips.us-gov-east-1."
                 "amazonaws.com/",
             ),
             Case(
-                ("https://012345678901.s3-control-fips.us-gov-east-1."
-                 "amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://012345678901.s3-control-fips.us-gov-east-1."
+                    "amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://my-bucket.012345678901.s3-control-fips.cn-northwest-1."
                 "amazonaws.com/",
             ),
             ###
             Case(
-                ("https://012345678901.s3-control-fips.dualstack.amazonaws.com",
-                 None),
+                (
+                    "https://012345678901.s3-control-fips.dualstack.amazonaws.com",
+                    None,
+                ),
                 "https://my-bucket.012345678901.s3-control-fips.dualstack."
                 "us-east-1.amazonaws.com/",
             ),
             Case(
-                ("https://012345678901.s3-control-fips.dualstack.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://012345678901.s3-control-fips.dualstack.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 "https://my-bucket.012345678901.s3-control-fips.dualstack."
                 "ap-south-1a.amazonaws.com/",
             ),
             Case(
-                ("https://012345678901.s3-control-fips.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 None),
+                (
+                    "https://012345678901.s3-control-fips.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    None,
+                ),
                 "https://my-bucket.012345678901.s3-control-fips.dualstack."
                 "us-gov-east-1.amazonaws.com/",
             ),
             Case(
-                ("https://012345678901.s3-control-fips.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://012345678901.s3-control-fips.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://my-bucket.012345678901.s3-control-fips.dualstack."
                 "cn-northwest-1.amazonaws.com/",
             ),
@@ -1277,45 +1448,50 @@ class BaseURLTests(TestCase):
                 "https://my-bucket.s3-accesspoint.us-east-1.amazonaws.com/",
             ),
             Case(
-                ("https://s3-accesspoint.amazonaws.com",
-                 "ap-south-1a"),
+                ("https://s3-accesspoint.amazonaws.com", "ap-south-1a"),
                 "https://my-bucket.s3-accesspoint.ap-south-1a.amazonaws.com/",
             ),
             Case(
-                ("https://s3-accesspoint.us-gov-east-1.amazonaws.com",
-                 None),
+                ("https://s3-accesspoint.us-gov-east-1.amazonaws.com", None),
                 "https://my-bucket.s3-accesspoint.us-gov-east-1.amazonaws.com/",
             ),
             Case(
-                ("https://s3-accesspoint.us-gov-east-1.amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-accesspoint.us-gov-east-1.amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://my-bucket.s3-accesspoint.cn-northwest-1."
                 "amazonaws.com/",
             ),
             ###
             Case(
-                ("https://s3-accesspoint.dualstack.amazonaws.com",
-                 None),
+                ("https://s3-accesspoint.dualstack.amazonaws.com", None),
                 "https://my-bucket.s3-accesspoint.dualstack.us-east-1."
                 "amazonaws.com/",
             ),
             Case(
-                ("https://s3-accesspoint.dualstack.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://s3-accesspoint.dualstack.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 "https://my-bucket.s3-accesspoint.dualstack.ap-south-1a."
                 "amazonaws.com/",
             ),
             Case(
-                ("https://s3-accesspoint.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 None),
+                (
+                    "https://s3-accesspoint.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    None,
+                ),
                 "https://my-bucket.s3-accesspoint.dualstack.us-gov-east-1."
                 "amazonaws.com/",
             ),
             Case(
-                ("https://s3-accesspoint.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-accesspoint.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://my-bucket.s3-accesspoint.dualstack.cn-northwest-1."
                 "amazonaws.com/",
             ),
@@ -1326,56 +1502,67 @@ class BaseURLTests(TestCase):
                 "amazonaws.com/",
             ),
             Case(
-                ("https://s3-accesspoint-fips.amazonaws.com",
-                 "ap-south-1a"),
+                ("https://s3-accesspoint-fips.amazonaws.com", "ap-south-1a"),
                 "https://my-bucket.s3-accesspoint-fips.ap-south-1a."
                 "amazonaws.com/",
             ),
             Case(
-                ("https://s3-accesspoint-fips.us-gov-east-1."
-                 "amazonaws.com",
-                 None),
+                (
+                    "https://s3-accesspoint-fips.us-gov-east-1."
+                    "amazonaws.com",
+                    None,
+                ),
                 "https://my-bucket.s3-accesspoint-fips.us-gov-east-1."
                 "amazonaws.com/",
             ),
             Case(
-                ("https://s3-accesspoint-fips.us-gov-east-1."
-                 "amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-accesspoint-fips.us-gov-east-1."
+                    "amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://my-bucket.s3-accesspoint-fips.cn-northwest-1."
                 "amazonaws.com/",
             ),
             ###
             Case(
-                ("https://s3-accesspoint-fips.dualstack.amazonaws.com",
-                 None),
+                ("https://s3-accesspoint-fips.dualstack.amazonaws.com", None),
                 "https://my-bucket.s3-accesspoint-fips.dualstack.us-east-1."
                 "amazonaws.com/",
             ),
             Case(
-                ("https://s3-accesspoint-fips.dualstack.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://s3-accesspoint-fips.dualstack.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 "https://my-bucket.s3-accesspoint-fips.dualstack.ap-south-1a."
                 "amazonaws.com/",
             ),
             Case(
-                ("https://s3-accesspoint-fips.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 None),
+                (
+                    "https://s3-accesspoint-fips.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    None,
+                ),
                 "https://my-bucket.s3-accesspoint-fips.dualstack.us-gov-east-1."
                 "amazonaws.com/",
             ),
             Case(
-                ("https://s3-accesspoint-fips.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-accesspoint-fips.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://my-bucket.s3-accesspoint-fips.dualstack."
                 "cn-northwest-1.amazonaws.com/",
             ),
             ###
             Case(
-                ("https://my-load-balancer-1234567890.us-west-2.elb."
-                 "amazonaws.com", "us-west-2"),
+                (
+                    "https://my-load-balancer-1234567890.us-west-2.elb."
+                    "amazonaws.com",
+                    "us-west-2",
+                ),
                 "https://my-load-balancer-1234567890.us-west-2.elb."
                 "amazonaws.com/my-bucket",
             ),
@@ -1383,8 +1570,13 @@ class BaseURLTests(TestCase):
 
         for case in cases:
             base_url = BaseURL(*case.args)
-            url = urlunsplit(base_url.build(
-                "GET", base_url.region or "us-east-1", bucket_name="my-bucket"))
+            url = urlunsplit(
+                base_url.build(
+                    "GET",
+                    base_url.region or "us-east-1",
+                    bucket_name="my-bucket",
+                )
+            )
             self.assertEqual(str(url), case.result)
 
     def test_aws_object_build(self):
@@ -1427,8 +1619,10 @@ class BaseURLTests(TestCase):
                 "path/to/my/object",
             ),
             Case(
-                ("https://s3.dualstack.me-south-1.amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3.dualstack.me-south-1.amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://my-bucket.s3.dualstack.cn-northwest-1.amazonaws.com/"
                 "path/to/my/object",
             ),
@@ -1449,8 +1643,10 @@ class BaseURLTests(TestCase):
                 "path/to/my/object",
             ),
             Case(
-                ("https://s3-accelerate.me-south-1.amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-accelerate.me-south-1.amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://my-bucket.s3-accelerate.amazonaws.com/"
                 "path/to/my/object",
             ),
@@ -1461,20 +1657,26 @@ class BaseURLTests(TestCase):
                 "path/to/my/object",
             ),
             Case(
-                ("https://s3-accelerate.dualstack.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://s3-accelerate.dualstack.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 "https://my-bucket.s3-accelerate.dualstack.amazonaws.com/"
                 "path/to/my/object",
             ),
             Case(
-                ("https://s3-accelerate.dualstack.us-gov-east-1.amazonaws.com",
-                 None),
+                (
+                    "https://s3-accelerate.dualstack.us-gov-east-1.amazonaws.com",
+                    None,
+                ),
                 "https://my-bucket.s3-accelerate.dualstack.amazonaws.com/"
                 "path/to/my/object",
             ),
             Case(
-                ("https://s3-accelerate.dualstack.me-south-1.amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-accelerate.dualstack.me-south-1.amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://my-bucket.s3-accelerate.dualstack.amazonaws.com/"
                 "path/to/my/object",
             ),
@@ -1516,8 +1718,10 @@ class BaseURLTests(TestCase):
                 "amazonaws.com/path/to/my/object",
             ),
             Case(
-                ("https://s3-fips.dualstack.me-south-1.amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-fips.dualstack.me-south-1.amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://my-bucket.s3-fips.dualstack.cn-northwest-1."
                 "amazonaws.com/path/to/my/object",
             ),
@@ -1539,14 +1743,20 @@ class BaseURLTests(TestCase):
             ),
             ###
             Case(
-                ("https://bucket.vpce-1a2b3c4d-5e6f.s3.us-east-1."
-                 "vpce.amazonaws.com", None),
+                (
+                    "https://bucket.vpce-1a2b3c4d-5e6f.s3.us-east-1."
+                    "vpce.amazonaws.com",
+                    None,
+                ),
                 "https://my-bucket.bucket.vpce-1a2b3c4d-5e6f.s3.us-east-1."
                 "vpce.amazonaws.com/path/to/my/object",
             ),
             Case(
-                ("https://accesspoint.vpce-1a2b3c4d-5e6f.s3.us-east-1."
-                 "vpce.amazonaws.com", None),
+                (
+                    "https://accesspoint.vpce-1a2b3c4d-5e6f.s3.us-east-1."
+                    "vpce.amazonaws.com",
+                    None,
+                ),
                 "https://my-bucket.accesspoint.vpce-1a2b3c4d-5e6f.s3.us-east-1."
                 "vpce.amazonaws.com/path/to/my/object",
             ),
@@ -1557,47 +1767,61 @@ class BaseURLTests(TestCase):
                 "amazonaws.com/path/to/my/object",
             ),
             Case(
-                ("https://012345678901.s3-control.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://012345678901.s3-control.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 "https://my-bucket.012345678901.s3-control.ap-south-1a."
                 "amazonaws.com/path/to/my/object",
             ),
             Case(
-                ("https://012345678901.s3-control.us-gov-east-1.amazonaws.com",
-                 None),
+                (
+                    "https://012345678901.s3-control.us-gov-east-1.amazonaws.com",
+                    None,
+                ),
                 "https://my-bucket.012345678901.s3-control.us-gov-east-1."
                 "amazonaws.com/path/to/my/object",
             ),
             Case(
-                ("https://012345678901.s3-control.us-gov-east-1.amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://012345678901.s3-control.us-gov-east-1.amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://my-bucket.012345678901.s3-control.cn-northwest-1."
                 "amazonaws.com/path/to/my/object",
             ),
             ###
             Case(
-                ("https://012345678901.s3-control.dualstack.amazonaws.com",
-                 None),
+                (
+                    "https://012345678901.s3-control.dualstack.amazonaws.com",
+                    None,
+                ),
                 "https://my-bucket.012345678901.s3-control.dualstack.us-east-1."
                 "amazonaws.com/path/to/my/object",
             ),
             Case(
-                ("https://012345678901.s3-control.dualstack.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://012345678901.s3-control.dualstack.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 "https://my-bucket.012345678901.s3-control.dualstack."
                 "ap-south-1a.amazonaws.com/path/to/my/object",
             ),
             Case(
-                ("https://012345678901.s3-control.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 None),
+                (
+                    "https://012345678901.s3-control.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    None,
+                ),
                 "https://my-bucket.012345678901.s3-control.dualstack."
                 "us-gov-east-1.amazonaws.com/path/to/my/object",
             ),
             Case(
-                ("https://012345678901.s3-control.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://012345678901.s3-control.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://my-bucket.012345678901.s3-control.dualstack."
                 "cn-northwest-1.amazonaws.com/path/to/my/object",
             ),
@@ -1608,49 +1832,63 @@ class BaseURLTests(TestCase):
                 "amazonaws.com/path/to/my/object",
             ),
             Case(
-                ("https://012345678901.s3-control-fips.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://012345678901.s3-control-fips.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 "https://my-bucket.012345678901.s3-control-fips.ap-south-1a."
                 "amazonaws.com/path/to/my/object",
             ),
             Case(
-                ("https://012345678901.s3-control-fips.us-gov-east-1."
-                 "amazonaws.com",
-                 None),
+                (
+                    "https://012345678901.s3-control-fips.us-gov-east-1."
+                    "amazonaws.com",
+                    None,
+                ),
                 "https://my-bucket.012345678901.s3-control-fips.us-gov-east-1."
                 "amazonaws.com/path/to/my/object",
             ),
             Case(
-                ("https://012345678901.s3-control-fips.us-gov-east-1."
-                 "amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://012345678901.s3-control-fips.us-gov-east-1."
+                    "amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://my-bucket.012345678901.s3-control-fips.cn-northwest-1."
                 "amazonaws.com/path/to/my/object",
             ),
             ###
             Case(
-                ("https://012345678901.s3-control-fips.dualstack.amazonaws.com",
-                 None),
+                (
+                    "https://012345678901.s3-control-fips.dualstack.amazonaws.com",
+                    None,
+                ),
                 "https://my-bucket.012345678901.s3-control-fips.dualstack."
                 "us-east-1.amazonaws.com/path/to/my/object",
             ),
             Case(
-                ("https://012345678901.s3-control-fips.dualstack.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://012345678901.s3-control-fips.dualstack.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 "https://my-bucket.012345678901.s3-control-fips.dualstack."
                 "ap-south-1a.amazonaws.com/path/to/my/object",
             ),
             Case(
-                ("https://012345678901.s3-control-fips.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 None),
+                (
+                    "https://012345678901.s3-control-fips.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    None,
+                ),
                 "https://my-bucket.012345678901.s3-control-fips.dualstack."
                 "us-gov-east-1.amazonaws.com/path/to/my/object",
             ),
             Case(
-                ("https://012345678901.s3-control-fips.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://012345678901.s3-control-fips.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://my-bucket.012345678901.s3-control-fips.dualstack."
                 "cn-northwest-1.amazonaws.com/path/to/my/object",
             ),
@@ -1661,47 +1899,52 @@ class BaseURLTests(TestCase):
                 "path/to/my/object",
             ),
             Case(
-                ("https://s3-accesspoint.amazonaws.com",
-                 "ap-south-1a"),
+                ("https://s3-accesspoint.amazonaws.com", "ap-south-1a"),
                 "https://my-bucket.s3-accesspoint.ap-south-1a.amazonaws.com/"
                 "path/to/my/object",
             ),
             Case(
-                ("https://s3-accesspoint.us-gov-east-1.amazonaws.com",
-                 None),
+                ("https://s3-accesspoint.us-gov-east-1.amazonaws.com", None),
                 "https://my-bucket.s3-accesspoint.us-gov-east-1.amazonaws.com/"
                 "path/to/my/object",
             ),
             Case(
-                ("https://s3-accesspoint.us-gov-east-1.amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-accesspoint.us-gov-east-1.amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://my-bucket.s3-accesspoint.cn-northwest-1."
                 "amazonaws.com/path/to/my/object",
             ),
             ###
             Case(
-                ("https://s3-accesspoint.dualstack.amazonaws.com",
-                 None),
+                ("https://s3-accesspoint.dualstack.amazonaws.com", None),
                 "https://my-bucket.s3-accesspoint.dualstack.us-east-1."
                 "amazonaws.com/path/to/my/object",
             ),
             Case(
-                ("https://s3-accesspoint.dualstack.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://s3-accesspoint.dualstack.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 "https://my-bucket.s3-accesspoint.dualstack.ap-south-1a."
                 "amazonaws.com/path/to/my/object",
             ),
             Case(
-                ("https://s3-accesspoint.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 None),
+                (
+                    "https://s3-accesspoint.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    None,
+                ),
                 "https://my-bucket.s3-accesspoint.dualstack.us-gov-east-1."
                 "amazonaws.com/path/to/my/object",
             ),
             Case(
-                ("https://s3-accesspoint.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-accesspoint.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://my-bucket.s3-accesspoint.dualstack.cn-northwest-1."
                 "amazonaws.com/path/to/my/object",
             ),
@@ -1712,56 +1955,67 @@ class BaseURLTests(TestCase):
                 "amazonaws.com/path/to/my/object",
             ),
             Case(
-                ("https://s3-accesspoint-fips.amazonaws.com",
-                 "ap-south-1a"),
+                ("https://s3-accesspoint-fips.amazonaws.com", "ap-south-1a"),
                 "https://my-bucket.s3-accesspoint-fips.ap-south-1a."
                 "amazonaws.com/path/to/my/object",
             ),
             Case(
-                ("https://s3-accesspoint-fips.us-gov-east-1."
-                 "amazonaws.com",
-                 None),
+                (
+                    "https://s3-accesspoint-fips.us-gov-east-1."
+                    "amazonaws.com",
+                    None,
+                ),
                 "https://my-bucket.s3-accesspoint-fips.us-gov-east-1."
                 "amazonaws.com/path/to/my/object",
             ),
             Case(
-                ("https://s3-accesspoint-fips.us-gov-east-1."
-                 "amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-accesspoint-fips.us-gov-east-1."
+                    "amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://my-bucket.s3-accesspoint-fips.cn-northwest-1."
                 "amazonaws.com/path/to/my/object",
             ),
             ###
             Case(
-                ("https://s3-accesspoint-fips.dualstack.amazonaws.com",
-                 None),
+                ("https://s3-accesspoint-fips.dualstack.amazonaws.com", None),
                 "https://my-bucket.s3-accesspoint-fips.dualstack.us-east-1."
                 "amazonaws.com/path/to/my/object",
             ),
             Case(
-                ("https://s3-accesspoint-fips.dualstack.amazonaws.com",
-                 "ap-south-1a"),
+                (
+                    "https://s3-accesspoint-fips.dualstack.amazonaws.com",
+                    "ap-south-1a",
+                ),
                 "https://my-bucket.s3-accesspoint-fips.dualstack.ap-south-1a."
                 "amazonaws.com/path/to/my/object",
             ),
             Case(
-                ("https://s3-accesspoint-fips.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 None),
+                (
+                    "https://s3-accesspoint-fips.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    None,
+                ),
                 "https://my-bucket.s3-accesspoint-fips.dualstack.us-gov-east-1."
                 "amazonaws.com/path/to/my/object",
             ),
             Case(
-                ("https://s3-accesspoint-fips.dualstack.us-gov-east-1."
-                 "amazonaws.com",
-                 "cn-northwest-1"),
+                (
+                    "https://s3-accesspoint-fips.dualstack.us-gov-east-1."
+                    "amazonaws.com",
+                    "cn-northwest-1",
+                ),
                 "https://my-bucket.s3-accesspoint-fips.dualstack."
                 "cn-northwest-1.amazonaws.com/path/to/my/object",
             ),
             ###
             Case(
-                ("https://my-load-balancer-1234567890.us-west-2.elb."
-                 "amazonaws.com", "us-west-2"),
+                (
+                    "https://my-load-balancer-1234567890.us-west-2.elb."
+                    "amazonaws.com",
+                    "us-west-2",
+                ),
                 "https://my-load-balancer-1234567890.us-west-2.elb."
                 "amazonaws.com/my-bucket/path/to/my/object",
             ),
@@ -1769,7 +2023,12 @@ class BaseURLTests(TestCase):
 
         for case in cases:
             base_url = BaseURL(*case.args)
-            url = urlunsplit(base_url.build(
-                "GET", base_url.region or "us-east-1",
-                bucket_name="my-bucket", object_name="path/to/my/object"))
+            url = urlunsplit(
+                base_url.build(
+                    "GET",
+                    base_url.region or "us-east-1",
+                    bucket_name="my-bucket",
+                    object_name="path/to/my/object",
+                )
+            )
             self.assertEqual(str(url), case.result)

--- a/tests/unit/list_buckets_test.py
+++ b/tests/unit/list_buckets_test.py
@@ -25,45 +25,57 @@ from .minio_mocks import MockConnection, MockResponse
 
 
 class ListBucketsTest(TestCase):
-    @mock.patch('urllib3.PoolManager')
+    @mock.patch("urllib3.PoolManager")
     def test_empty_list_buckets_works(self, mock_connection):
-        mock_data = ('<ListAllMyBucketsResult '
-                     'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
-                     '<Buckets></Buckets><Owner><ID>minio</ID><DisplayName>'
-                     'minio</DisplayName></Owner></ListAllMyBucketsResult>')
+        mock_data = (
+            "<ListAllMyBucketsResult "
+            'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+            "<Buckets></Buckets><Owner><ID>minio</ID><DisplayName>"
+            "minio</DisplayName></Owner></ListAllMyBucketsResult>"
+        )
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
-            MockResponse('GET', 'https://localhost:9000/',
-                         {'User-Agent': _DEFAULT_USER_AGENT},
-                         200, content=mock_data.encode())
+            MockResponse(
+                "GET",
+                "https://localhost:9000/",
+                {"User-Agent": _DEFAULT_USER_AGENT},
+                200,
+                content=mock_data.encode(),
+            )
         )
-        client = Minio('localhost:9000')
+        client = Minio("localhost:9000")
         buckets = client.list_buckets()
         count = 0
         for bucket in buckets:
             count += 1
         self.assertEqual(0, count)
 
-    @mock.patch('urllib3.PoolManager')
+    @mock.patch("urllib3.PoolManager")
     def test_list_buckets_works(self, mock_connection):
-        mock_data = ('<ListAllMyBucketsResult '
-                     'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
-                     '<Buckets><Bucket><Name>hello</Name>'
-                     '<CreationDate>2015-06-22T23:07:43.240Z</CreationDate>'
-                     '</Bucket><Bucket><Name>world</Name>'
-                     '<CreationDate>2015-06-22T23:07:56.766Z</CreationDate>'
-                     '</Bucket></Buckets><Owner><ID>minio</ID>'
-                     '<DisplayName>minio</DisplayName></Owner>'
-                     '</ListAllMyBucketsResult>')
+        mock_data = (
+            "<ListAllMyBucketsResult "
+            'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+            "<Buckets><Bucket><Name>hello</Name>"
+            "<CreationDate>2015-06-22T23:07:43.240Z</CreationDate>"
+            "</Bucket><Bucket><Name>world</Name>"
+            "<CreationDate>2015-06-22T23:07:56.766Z</CreationDate>"
+            "</Bucket></Buckets><Owner><ID>minio</ID>"
+            "<DisplayName>minio</DisplayName></Owner>"
+            "</ListAllMyBucketsResult>"
+        )
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
-            MockResponse('GET', 'https://localhost:9000/',
-                         {'User-Agent': _DEFAULT_USER_AGENT},
-                         200, content=mock_data.encode())
+            MockResponse(
+                "GET",
+                "https://localhost:9000/",
+                {"User-Agent": _DEFAULT_USER_AGENT},
+                200,
+                content=mock_data.encode(),
+            )
         )
-        client = Minio('localhost:9000')
+        client = Minio("localhost:9000")
         buckets = client.list_buckets()
         buckets_list = []
         count = 0
@@ -71,12 +83,12 @@ class ListBucketsTest(TestCase):
             count += 1
             buckets_list.append(bucket)
         self.assertEqual(2, count)
-        self.assertEqual('hello', buckets_list[0].name)
+        self.assertEqual("hello", buckets_list[0].name)
         self.assertEqual(
             datetime(2015, 6, 22, 23, 7, 43, 240000, timezone.utc),
             buckets_list[0].creation_date,
         )
-        self.assertEqual('world', buckets_list[1].name)
+        self.assertEqual("world", buckets_list[1].name)
         self.assertEqual(
             datetime(2015, 6, 22, 23, 7, 56, 766000, timezone.utc),
             buckets_list[1].creation_date,

--- a/tests/unit/list_objects_test.py
+++ b/tests/unit/list_objects_test.py
@@ -25,9 +25,9 @@ from .minio_mocks import MockConnection, MockResponse
 
 
 class ListObjectsTest(TestCase):
-    @mock.patch('urllib3.PoolManager')
+    @mock.patch("urllib3.PoolManager")
     def test_empty_list_objects_works(self, mock_connection):
-        mock_data = '''<?xml version="1.0" encoding="UTF-8"?>
+        mock_data = """<?xml version="1.0" encoding="UTF-8"?>
 <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
   <Name>bucket</Name>
   <Prefix></Prefix>
@@ -35,7 +35,7 @@ class ListObjectsTest(TestCase):
   <MaxKeys>1000</MaxKeys>
   <Delimiter></Delimiter>
   <IsTruncated>false</IsTruncated>
-</ListBucketResult>'''
+</ListBucketResult>"""
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
@@ -48,17 +48,17 @@ class ListObjectsTest(TestCase):
                 content=mock_data.encode(),
             ),
         )
-        client = Minio('localhost:9000')
-        object_iter = client.list_objects('bucket', recursive=True)
+        client = Minio("localhost:9000")
+        object_iter = client.list_objects("bucket", recursive=True)
         objects = []
         for obj in object_iter:
             objects.append(obj)
         self.assertEqual(0, len(objects))
 
-    @mock.patch('urllib3.PoolManager')
+    @mock.patch("urllib3.PoolManager")
     def test_list_objects_works(self, mock_connection):
         start_time = time.time()
-        mock_data = '''<?xml version="1.0" encoding="UTF-8"?>
+        mock_data = """<?xml version="1.0" encoding="UTF-8"?>
 <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
   <Name>bucket</Name>
   <Prefix></Prefix>
@@ -79,7 +79,7 @@ class ListObjectsTest(TestCase):
     <Size>493</Size>
     <StorageClass>REDUCED_REDUNDANCY</StorageClass>
   </Contents>
-</ListBucketResult>'''
+</ListBucketResult>"""
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
@@ -92,12 +92,12 @@ class ListObjectsTest(TestCase):
                 content=mock_data.encode(),
             ),
         )
-        client = Minio('localhost:9000')
-        objects_iter = client.list_objects('bucket')
+        client = Minio("localhost:9000")
+        objects_iter = client.list_objects("bucket")
         objects = []
         for obj in objects_iter:
             objects.append(obj)
 
         self.assertEqual(2, len(objects))
         end_time = time.time()
-        self.assertLess(end_time-start_time, 1)
+        self.assertLess(end_time - start_time, 1)

--- a/tests/unit/list_objects_v1_test.py
+++ b/tests/unit/list_objects_v1_test.py
@@ -25,9 +25,9 @@ from .minio_mocks import MockConnection, MockResponse
 
 
 class ListObjectsV1Test(TestCase):
-    @mock.patch('urllib3.PoolManager')
+    @mock.patch("urllib3.PoolManager")
     def test_empty_list_objects_works(self, mock_connection):
-        mock_data = '''<?xml version="1.0"?>
+        mock_data = """<?xml version="1.0"?>
 <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
   <Name>bucket</Name>
   <Prefix/>
@@ -35,7 +35,7 @@ class ListObjectsV1Test(TestCase):
   <IsTruncated>false</IsTruncated>
   <MaxKeys>1000</MaxKeys>
   <Delimiter/>
-</ListBucketResult>'''
+</ListBucketResult>"""
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
@@ -48,19 +48,21 @@ class ListObjectsV1Test(TestCase):
                 content=mock_data.encode(),
             ),
         )
-        client = Minio('localhost:9000')
+        client = Minio("localhost:9000")
         bucket_iter = client.list_objects(
-            'bucket', recursive=True, use_api_v1=True,
+            "bucket",
+            recursive=True,
+            use_api_v1=True,
         )
         buckets = []
         for bucket in bucket_iter:
             buckets.append(bucket)
         self.assertEqual(0, len(buckets))
 
-    @mock.patch('urllib3.PoolManager')
+    @mock.patch("urllib3.PoolManager")
     def test_list_objects_works(self, mock_connection):
         start_time = time.time()
-        mock_data = '''<?xml version="1.0"?>
+        mock_data = """<?xml version="1.0"?>
 <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
   <Name>bucket</Name>
   <Prefix/>
@@ -90,7 +92,7 @@ class ListObjectsV1Test(TestCase):
       <DisplayName>minio</DisplayName>
     </Owner>
   </Contents>
-</ListBucketResult>'''
+</ListBucketResult>"""
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
@@ -103,8 +105,8 @@ class ListObjectsV1Test(TestCase):
                 content=mock_data.encode(),
             ),
         )
-        client = Minio('localhost:9000')
-        bucket_iter = client.list_objects('bucket', use_api_v1=True)
+        client = Minio("localhost:9000")
+        bucket_iter = client.list_objects("bucket", use_api_v1=True)
         buckets = []
         for bucket in bucket_iter:
             # cause an xml exception and fail if we try retrieving again
@@ -122,12 +124,12 @@ class ListObjectsV1Test(TestCase):
 
         self.assertEqual(2, len(buckets))
         end_time = time.time()
-        self.assertLess(end_time-start_time, 1)
+        self.assertLess(end_time - start_time, 1)
 
-    @mock.patch('urllib3.PoolManager')
+    @mock.patch("urllib3.PoolManager")
     def test_list_objects_works_well(self, mock_connection):
         start_time = time.time()
-        mock_data1 = '''<?xml version="1.0"?>
+        mock_data1 = """<?xml version="1.0"?>
 <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
   <Name>bucket</Name>
   <Prefix/>
@@ -158,8 +160,8 @@ class ListObjectsV1Test(TestCase):
       <DisplayName>minio</DisplayName>
     </Owner>
   </Contents>
-</ListBucketResult>'''
-        mock_data2 = '''<?xml version="1.0"?>
+</ListBucketResult>"""
+        mock_data2 = """<?xml version="1.0"?>
 <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
   <Name>bucket</Name>
   <Prefix/>
@@ -189,7 +191,7 @@ class ListObjectsV1Test(TestCase):
       <DisplayName>minio</DisplayName>
     </Owner>
   </Contents>
-</ListBucketResult>'''
+</ListBucketResult>"""
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
@@ -202,9 +204,11 @@ class ListObjectsV1Test(TestCase):
                 content=mock_data1.encode(),
             ),
         )
-        client = Minio('localhost:9000')
+        client = Minio("localhost:9000")
         bucket_iter = client.list_objects(
-            'bucket', recursive=True, use_api_v1=True,
+            "bucket",
+            recursive=True,
+            use_api_v1=True,
         )
         buckets = []
         for bucket in bucket_iter:
@@ -222,4 +226,4 @@ class ListObjectsV1Test(TestCase):
 
         self.assertEqual(4, len(buckets))
         end_time = time.time()
-        self.assertLess(end_time-start_time, 1)
+        self.assertLess(end_time - start_time, 1)

--- a/tests/unit/make_bucket_test.py
+++ b/tests/unit/make_bucket_test.py
@@ -27,39 +27,49 @@ from .minio_mocks import MockConnection, MockResponse
 
 class MakeBucket(TestCase):
     def test_bucket_is_string(self):
-        client = Minio('localhost:9000')
+        client = Minio("localhost:9000")
         self.assertRaises(TypeError, client.make_bucket, 1234)
 
     def test_bucket_is_not_empty_string(self):
-        client = Minio('localhost:9000')
-        self.assertRaises(ValueError, client.make_bucket, '  \t \n  ')
+        client = Minio("localhost:9000")
+        self.assertRaises(ValueError, client.make_bucket, "  \t \n  ")
 
-    @mock.patch('urllib3.PoolManager')
+    @mock.patch("urllib3.PoolManager")
     def test_make_bucket_works(self, mock_connection):
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
-            MockResponse('PUT',
-                         'https://localhost:9000/hello',
-                         {'User-Agent': _DEFAULT_USER_AGENT},
-                         200)
+            MockResponse(
+                "PUT",
+                "https://localhost:9000/hello",
+                {"User-Agent": _DEFAULT_USER_AGENT},
+                200,
+            )
         )
-        Minio('localhost:9000')
+        Minio("localhost:9000")
 
-    @mock.patch('urllib3.PoolManager')
+    @mock.patch("urllib3.PoolManager")
     def test_make_bucket_throws_fail(self, mock_connection):
-        error_xml = generate_error('code', 'message', 'request_id',
-                                   'host_id', 'resource', 'bucket',
-                                   'object')
+        error_xml = generate_error(
+            "code",
+            "message",
+            "request_id",
+            "host_id",
+            "resource",
+            "bucket",
+            "object",
+        )
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
-            MockResponse('PUT',
-                         'https://localhost:9000/hello',
-                         {'User-Agent': _DEFAULT_USER_AGENT},
-                         409,
-                         response_headers={"Content-Type": "application/xml"},
-                         content=error_xml.encode())
+            MockResponse(
+                "PUT",
+                "https://localhost:9000/hello",
+                {"User-Agent": _DEFAULT_USER_AGENT},
+                409,
+                response_headers={"Content-Type": "application/xml"},
+                content=error_xml.encode(),
+            )
         )
-        client = Minio('localhost:9000')
-        self.assertRaises(S3Error, client.make_bucket, 'hello')
+        client = Minio("localhost:9000")
+        self.assertRaises(S3Error, client.make_bucket, "hello")

--- a/tests/unit/minio_mocks.py
+++ b/tests/unit/minio_mocks.py
@@ -18,8 +18,15 @@ from http import client as httplib
 
 
 class MockResponse(object):
-    def __init__(self, method, url, headers, status_code,
-                 response_headers=None, content=None):
+    def __init__(
+        self,
+        method,
+        url,
+        headers,
+        status_code,
+        response_headers=None,
+        content=None,
+    ):
         self.method = method
         self.url = url
         self.request_headers = {
@@ -27,8 +34,8 @@ class MockResponse(object):
         }
         self.status = status_code
         self.headers = {
-            key.lower(): value for key, value in (
-                response_headers or {}).items()
+            key.lower(): value
+            for key, value in (response_headers or {}).items()
         }
         self.data = content
         if content is None:
@@ -41,16 +48,14 @@ class MockResponse(object):
     def mock_verify(self, method, url, headers):
         assert self.method == method
         assert self.url == url
-        headers = {
-            key.lower(): value for key, value in headers.items()
-        }
+        headers = {key.lower(): value for key, value in headers.items()}
         for header in self.request_headers:
             assert self.request_headers[header] == headers[header]
 
     # noinspection PyUnusedLocal
     def stream(self, chunk_size=1, decode_unicode=False):
         if self.data is not None:
-            return iter(bytearray(self.data, 'utf-8'))
+            return iter(bytearray(self.data, "utf-8"))
         return iter([])
 
     # dummy release connection call.
@@ -81,6 +86,13 @@ class MockConnection(object):
 
     # noinspection PyRedeclaration,PyUnusedLocal,PyUnusedLocal
 
-    def urlopen(self, method, url, headers={}, preload_content=False,
-                body=None, redirect=False):
+    def urlopen(
+        self,
+        method,
+        url,
+        headers={},
+        preload_content=False,
+        body=None,
+        redirect=False,
+    ):
         return self.request(method, url, headers)

--- a/tests/unit/minio_mocks.py
+++ b/tests/unit/minio_mocks.py
@@ -29,13 +29,10 @@ class MockResponse(object):
     ):
         self.method = method
         self.url = url
-        self.request_headers = {
-            key.lower(): value for key, value in headers.items()
-        }
+        self.request_headers = {key.lower(): value for key, value in headers.items()}
         self.status = status_code
         self.headers = {
-            key.lower(): value
-            for key, value in (response_headers or {}).items()
+            key.lower(): value for key, value in (response_headers or {}).items()
         }
         self.data = content
         if content is None:

--- a/tests/unit/minio_test.py
+++ b/tests/unit/minio_test.py
@@ -25,83 +25,107 @@ from minio.helpers import BaseURL, check_bucket_name
 
 class ValidBucketName(TestCase):
     def test_bucket_name(self):
-        self.assertRaises(ValueError, check_bucket_name, 'bucketName=', False)
+        self.assertRaises(ValueError, check_bucket_name, "bucketName=", False)
 
     def test_bucket_name_invalid_characters(self):
-        self.assertRaises(ValueError, check_bucket_name, '$$$bcuket', False)
+        self.assertRaises(ValueError, check_bucket_name, "$$$bcuket", False)
 
     def test_bucket_name_length(self):
-        self.assertRaises(ValueError, check_bucket_name, 'dd', False)
+        self.assertRaises(ValueError, check_bucket_name, "dd", False)
 
     def test_bucket_name_periods(self):
-        self.assertRaises(ValueError, check_bucket_name, 'dd..mybucket', False)
+        self.assertRaises(ValueError, check_bucket_name, "dd..mybucket", False)
 
     def test_bucket_name_begins_period(self):
-        self.assertRaises(ValueError, check_bucket_name, '.ddmybucket', False)
+        self.assertRaises(ValueError, check_bucket_name, ".ddmybucket", False)
 
 
 class GetURLTests(TestCase):
     def test_url_build(self):
-        url = BaseURL('http://localhost:9000', None)
+        url = BaseURL("http://localhost:9000", None)
         self.assertEqual(
-            urlunsplit(url.build("GET", None, bucket_name='bucket-name')),
-            'http://localhost:9000/bucket-name',
+            urlunsplit(url.build("GET", None, bucket_name="bucket-name")),
+            "http://localhost:9000/bucket-name",
         )
         self.assertEqual(
             urlunsplit(
-                url.build("GET", None, bucket_name='bucket-name',
-                          object_name='objectName'),
+                url.build(
+                    "GET",
+                    None,
+                    bucket_name="bucket-name",
+                    object_name="objectName",
+                ),
             ),
-            'http://localhost:9000/bucket-name/objectName',
+            "http://localhost:9000/bucket-name/objectName",
         )
         self.assertEqual(
             urlunsplit(
-                url.build("GET", 'us-east-1', bucket_name='bucket-name',
-                          object_name='objectName',
-                          query_params={'foo': 'bar'}),
+                url.build(
+                    "GET",
+                    "us-east-1",
+                    bucket_name="bucket-name",
+                    object_name="objectName",
+                    query_params={"foo": "bar"},
+                ),
             ),
-            'http://localhost:9000/bucket-name/objectName?foo=bar',
+            "http://localhost:9000/bucket-name/objectName?foo=bar",
         )
         self.assertEqual(
             urlunsplit(
-                url.build("GET", 'us-east-1', bucket_name='bucket-name',
-                          object_name='objectName',
-                          query_params={'foo': 'bar', 'b': 'c', 'a': 'b'}),
+                url.build(
+                    "GET",
+                    "us-east-1",
+                    bucket_name="bucket-name",
+                    object_name="objectName",
+                    query_params={"foo": "bar", "b": "c", "a": "b"},
+                ),
             ),
-            'http://localhost:9000/bucket-name/objectName?a=b&b=c&foo=bar',
+            "http://localhost:9000/bucket-name/objectName?a=b&b=c&foo=bar",
         )
         self.assertEqual(
             urlunsplit(
-                url.build("GET", 'us-east-1', bucket_name='bucket-name',
-                          object_name='path/to/objectName/'),
+                url.build(
+                    "GET",
+                    "us-east-1",
+                    bucket_name="bucket-name",
+                    object_name="path/to/objectName/",
+                ),
             ),
-            'http://localhost:9000/bucket-name/path/to/objectName/',
+            "http://localhost:9000/bucket-name/path/to/objectName/",
         )
 
         # S3 urls.
-        url = BaseURL('https://s3.amazonaws.com', None)
+        url = BaseURL("https://s3.amazonaws.com", None)
         self.assertEqual(
             urlunsplit(url.build("GET", "us-east-1")),
-            'https://s3.us-east-1.amazonaws.com/',
+            "https://s3.us-east-1.amazonaws.com/",
         )
         self.assertEqual(
             urlunsplit(
-                url.build("GET", "eu-west-1", bucket_name='my.bucket.name'),
+                url.build("GET", "eu-west-1", bucket_name="my.bucket.name"),
             ),
-            'https://s3.eu-west-1.amazonaws.com/my.bucket.name',
+            "https://s3.eu-west-1.amazonaws.com/my.bucket.name",
         )
         self.assertEqual(
             urlunsplit(
-                url.build("GET", 'us-west-2', bucket_name='bucket-name',
-                          object_name='objectName'),
+                url.build(
+                    "GET",
+                    "us-west-2",
+                    bucket_name="bucket-name",
+                    object_name="objectName",
+                ),
             ),
-            'https://bucket-name.s3.us-west-2.amazonaws.com/objectName',
+            "https://bucket-name.s3.us-west-2.amazonaws.com/objectName",
         )
         self.assertEqual(
             urlunsplit(
-                url.build("GET", "us-east-1", bucket_name='bucket-name',
-                          object_name='objectName',
-                          query_params={'versionId': 'uuid'}),
+                url.build(
+                    "GET",
+                    "us-east-1",
+                    bucket_name="bucket-name",
+                    object_name="objectName",
+                    query_params={"versionId": "uuid"},
+                ),
             ),
             "https://bucket-name.s3.us-east-1.amazonaws.com"
             "/objectName?versionId=uuid",
@@ -111,50 +135,51 @@ class GetURLTests(TestCase):
         self.assertRaises(TypeError, Minio, 10)
 
     def test_minio_requires_hostname(self):
-        self.assertRaises(ValueError, Minio, 'http://')
+        self.assertRaises(ValueError, Minio, "http://")
 
 
 class UserAgentTests(TestCase):
     def test_default_user_agent(self):
-        client = Minio('localhost')
+        client = Minio("localhost")
         self.assertEqual(client._user_agent, _DEFAULT_USER_AGENT)
 
     def test_set_app_info(self):
-        client = Minio('localhost')
-        expected_user_agent = _DEFAULT_USER_AGENT + ' hello/' + minio_version
-        client.set_app_info('hello', minio_version)
+        client = Minio("localhost")
+        expected_user_agent = _DEFAULT_USER_AGENT + " hello/" + minio_version
+        client.set_app_info("hello", minio_version)
         self.assertEqual(client._user_agent, expected_user_agent)
 
     def test_set_app_info_requires_non_empty_name(self):
-        client = Minio('localhost:9000')
-        self.assertRaises(ValueError, client.set_app_info, '', minio_version)
+        client = Minio("localhost:9000")
+        self.assertRaises(ValueError, client.set_app_info, "", minio_version)
 
     def test_set_app_info_requires_non_empty_version(self):
-        client = Minio('localhost:9000')
-        self.assertRaises(ValueError, client.set_app_info, 'hello', '')
+        client = Minio("localhost:9000")
+        self.assertRaises(ValueError, client.set_app_info, "hello", "")
 
 
 class GetRegionTests(TestCase):
     def test_region_none(self):
-        region = BaseURL('http://localhost', None).region
+        region = BaseURL("http://localhost", None).region
         self.assertIsNone(region)
 
     def test_region_us_west(self):
-        region = BaseURL('https://s3-us-west-1.amazonaws.com', None).region
+        region = BaseURL("https://s3-us-west-1.amazonaws.com", None).region
         self.assertIsNone(region)
 
     def test_region_with_dot(self):
-        region = BaseURL('https://s3.us-west-1.amazonaws.com', None).region
-        self.assertEqual(region, 'us-west-1')
+        region = BaseURL("https://s3.us-west-1.amazonaws.com", None).region
+        self.assertEqual(region, "us-west-1")
 
     def test_region_with_dualstack(self):
         region = BaseURL(
-            'https://s3.dualstack.us-west-1.amazonaws.com', None,
+            "https://s3.dualstack.us-west-1.amazonaws.com",
+            None,
         ).region
-        self.assertEqual(region, 'us-west-1')
+        self.assertEqual(region, "us-west-1")
 
     def test_region_us_east(self):
-        region = BaseURL('http://s3.amazonaws.com', None).region
+        region = BaseURL("http://s3.amazonaws.com", None).region
         self.assertIsNone(region)
 
     def test_invalid_value(self):

--- a/tests/unit/notificationconfig_test.py
+++ b/tests/unit/notificationconfig_test.py
@@ -17,11 +17,7 @@
 from unittest import TestCase
 
 from minio import xml
-from minio.notificationconfig import (
-    NotificationConfig,
-    PrefixFilterRule,
-    QueueConfig,
-)
+from minio.notificationconfig import NotificationConfig, PrefixFilterRule, QueueConfig
 
 
 class NotificationConfigTest(TestCase):

--- a/tests/unit/notificationconfig_test.py
+++ b/tests/unit/notificationconfig_test.py
@@ -17,8 +17,11 @@
 from unittest import TestCase
 
 from minio import xml
-from minio.notificationconfig import (NotificationConfig, PrefixFilterRule,
-                                      QueueConfig)
+from minio.notificationconfig import (
+    NotificationConfig,
+    PrefixFilterRule,
+    QueueConfig,
+)
 
 
 class NotificationConfigTest(TestCase):
@@ -27,7 +30,7 @@ class NotificationConfigTest(TestCase):
             queue_config_list=[
                 QueueConfig(
                     "QUEUE-ARN-OF-THIS-BUCKET",
-                    ['s3:ObjectCreated:*'],
+                    ["s3:ObjectCreated:*"],
                     config_id="1",
                     prefix_filter_rule=PrefixFilterRule("abc"),
                 ),

--- a/tests/unit/presigned_get_object_test.py
+++ b/tests/unit/presigned_get_object_test.py
@@ -28,9 +28,7 @@ class PresignedGetObjectTest(TestCase):
 
     def test_object_is_not_empty_string(self):
         client = Minio("localhost:9000")
-        self.assertRaises(
-            ValueError, client.presigned_get_object, "hello", " \t \n "
-        )
+        self.assertRaises(ValueError, client.presigned_get_object, "hello", " \t \n ")
 
     def test_expiry_limit(self):
         client = Minio("localhost:9000")
@@ -43,9 +41,7 @@ class PresignedGetObjectTest(TestCase):
         )
 
     def test_can_include_response_headers(self):
-        client = Minio(
-            "localhost:9000", "my_access_key", "my_secret_key", secure=True
-        )
+        client = Minio("localhost:9000", "my_access_key", "my_secret_key", secure=True)
         client._get_region = mock.Mock(return_value="us-east-1")
         r = client.presigned_get_object(
             "mybucket",

--- a/tests/unit/presigned_get_object_test.py
+++ b/tests/unit/presigned_get_object_test.py
@@ -23,33 +23,38 @@ from minio import Minio
 
 class PresignedGetObjectTest(TestCase):
     def test_object_is_string(self):
-        client = Minio('localhost:9000')
-        self.assertRaises(
-            TypeError, client.presigned_get_object, 'hello', 1234)
+        client = Minio("localhost:9000")
+        self.assertRaises(TypeError, client.presigned_get_object, "hello", 1234)
 
     def test_object_is_not_empty_string(self):
-        client = Minio('localhost:9000')
+        client = Minio("localhost:9000")
         self.assertRaises(
-            ValueError, client.presigned_get_object, 'hello', ' \t \n ')
+            ValueError, client.presigned_get_object, "hello", " \t \n "
+        )
 
     def test_expiry_limit(self):
-        client = Minio('localhost:9000')
+        client = Minio("localhost:9000")
         self.assertRaises(
             ValueError,
-            client.presigned_get_object, 'hello', 'key',
-            expires=timedelta(days=8)
+            client.presigned_get_object,
+            "hello",
+            "key",
+            expires=timedelta(days=8),
         )
 
     def test_can_include_response_headers(self):
-        client = Minio('localhost:9000', 'my_access_key', 'my_secret_key',
-                       secure=True)
-        client._get_region = mock.Mock(return_value='us-east-1')
+        client = Minio(
+            "localhost:9000", "my_access_key", "my_secret_key", secure=True
+        )
+        client._get_region = mock.Mock(return_value="us-east-1")
         r = client.presigned_get_object(
-            'mybucket', 'myfile.pdf',
+            "mybucket",
+            "myfile.pdf",
             response_headers={
-                'Response-Content-Type': 'application/pdf',
-                'Response-Content-Disposition': 'inline;  filename="test.pdf"'
-            })
-        self.assertIn('inline', r)
-        self.assertIn('test.pdf', r)
-        self.assertIn('application%2Fpdf', r)
+                "Response-Content-Type": "application/pdf",
+                "Response-Content-Disposition": 'inline;  filename="test.pdf"',
+            },
+        )
+        self.assertIn("inline", r)
+        self.assertIn("test.pdf", r)
+        self.assertIn("application%2Fpdf", r)

--- a/tests/unit/presigned_put_object_test.py
+++ b/tests/unit/presigned_put_object_test.py
@@ -27,9 +27,7 @@ class PresignedPutObjectTest(TestCase):
 
     def test_object_is_not_empty_string(self):
         client = Minio("localhost:9000")
-        self.assertRaises(
-            ValueError, client.presigned_put_object, "hello", " \t \n "
-        )
+        self.assertRaises(ValueError, client.presigned_put_object, "hello", " \t \n ")
 
     def test_expiry_limit(self):
         client = Minio("localhost:9000")

--- a/tests/unit/presigned_put_object_test.py
+++ b/tests/unit/presigned_put_object_test.py
@@ -22,19 +22,21 @@ from minio import Minio
 
 class PresignedPutObjectTest(TestCase):
     def test_object_is_string(self):
-        client = Minio('localhost:9000')
-        self.assertRaises(
-            TypeError, client.presigned_put_object, 'hello', 1234)
+        client = Minio("localhost:9000")
+        self.assertRaises(TypeError, client.presigned_put_object, "hello", 1234)
 
     def test_object_is_not_empty_string(self):
-        client = Minio('localhost:9000')
+        client = Minio("localhost:9000")
         self.assertRaises(
-            ValueError, client.presigned_put_object, 'hello', ' \t \n ')
+            ValueError, client.presigned_put_object, "hello", " \t \n "
+        )
 
     def test_expiry_limit(self):
-        client = Minio('localhost:9000')
+        client = Minio("localhost:9000")
         self.assertRaises(
             ValueError,
-            client.presigned_put_object, 'hello', 'key',
-            expires=timedelta(days=8)
+            client.presigned_put_object,
+            "hello",
+            "key",
+            expires=timedelta(days=8),
         )

--- a/tests/unit/put_object_test.py
+++ b/tests/unit/put_object_test.py
@@ -21,29 +21,35 @@ from minio import Minio
 
 class PutObjectTest(TestCase):
     def test_object_is_string(self):
-        client = Minio('localhost:9000')
+        client = Minio("localhost:9000")
         self.assertRaises(
-            TypeError,
-            client.put_object, 'hello', 1234, 1, iter([1, 2, 3])
+            TypeError, client.put_object, "hello", 1234, 1, iter([1, 2, 3])
         )
 
     def test_object_is_not_empty_string(self):
-        client = Minio('localhost:9000')
+        client = Minio("localhost:9000")
         self.assertRaises(
             ValueError,
-            client.put_object, 'hello', ' \t \n ', 1, iter([1, 2, 3])
+            client.put_object,
+            "hello",
+            " \t \n ",
+            1,
+            iter([1, 2, 3]),
         )
 
     def test_length_is_string(self):
-        client = Minio('localhost:9000')
+        client = Minio("localhost:9000")
         self.assertRaises(
-            TypeError,
-            client.put_object, 'hello', 1234, '1', iter([1, 2, 3])
+            TypeError, client.put_object, "hello", 1234, "1", iter([1, 2, 3])
         )
 
     def test_length_is_not_empty_string(self):
-        client = Minio('localhost:9000')
+        client = Minio("localhost:9000")
         self.assertRaises(
             ValueError,
-            client.put_object, 'hello', ' \t \n ', -1, iter([1, 2, 3])
+            client.put_object,
+            "hello",
+            " \t \n ",
+            -1,
+            iter([1, 2, 3]),
         )

--- a/tests/unit/remove_bucket_test.py
+++ b/tests/unit/remove_bucket_test.py
@@ -25,25 +25,28 @@ from .minio_mocks import MockConnection, MockResponse
 
 class RemoveBucket(TestCase):
     def test_bucket_is_string(self):
-        client = Minio('localhost:9000')
+        client = Minio("localhost:9000")
         self.assertRaises(TypeError, client.remove_bucket, 1234)
 
     def test_bucket_is_not_empty_string(self):
-        client = Minio('localhost:9000')
-        self.assertRaises(ValueError, client.remove_bucket, '  \t \n  ')
+        client = Minio("localhost:9000")
+        self.assertRaises(ValueError, client.remove_bucket, "  \t \n  ")
 
     def test_remove_bucket_invalid_name(self):
-        client = Minio('localhost:9000')
-        self.assertRaises(ValueError, client.remove_bucket, 'AB*CD')
+        client = Minio("localhost:9000")
+        self.assertRaises(ValueError, client.remove_bucket, "AB*CD")
 
-    @mock.patch('urllib3.PoolManager')
+    @mock.patch("urllib3.PoolManager")
     def test_remove_bucket_works(self, mock_connection):
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
-            MockResponse('DELETE',
-                         'https://localhost:9000/hello',
-                         {'User-Agent': _DEFAULT_USER_AGENT}, 204)
+            MockResponse(
+                "DELETE",
+                "https://localhost:9000/hello",
+                {"User-Agent": _DEFAULT_USER_AGENT},
+                204,
+            )
         )
-        client = Minio('localhost:9000')
-        client.remove_bucket('hello')
+        client = Minio("localhost:9000")
+        client.remove_bucket("hello")

--- a/tests/unit/remove_object_test.py
+++ b/tests/unit/remove_object_test.py
@@ -30,9 +30,7 @@ class StatObject(TestCase):
 
     def test_object_is_not_empty_string(self):
         client = Minio("localhost:9000")
-        self.assertRaises(
-            ValueError, client.remove_object, "hello", "  \t \n  "
-        )
+        self.assertRaises(ValueError, client.remove_object, "hello", "  \t \n  ")
 
     def test_remove_bucket_invalid_name(self):
         client = Minio("localhost:9000")

--- a/tests/unit/remove_object_test.py
+++ b/tests/unit/remove_object_test.py
@@ -25,26 +25,30 @@ from .minio_mocks import MockConnection, MockResponse
 
 class StatObject(TestCase):
     def test_object_is_string(self):
-        client = Minio('localhost:9000')
-        self.assertRaises(TypeError, client.remove_object, 'hello', 1234)
+        client = Minio("localhost:9000")
+        self.assertRaises(TypeError, client.remove_object, "hello", 1234)
 
     def test_object_is_not_empty_string(self):
-        client = Minio('localhost:9000')
-        self.assertRaises(ValueError, client.remove_object,
-                          'hello', '  \t \n  ')
+        client = Minio("localhost:9000")
+        self.assertRaises(
+            ValueError, client.remove_object, "hello", "  \t \n  "
+        )
 
     def test_remove_bucket_invalid_name(self):
-        client = Minio('localhost:9000')
-        self.assertRaises(ValueError, client.remove_object, 'AB*CD', 'world')
+        client = Minio("localhost:9000")
+        self.assertRaises(ValueError, client.remove_object, "AB*CD", "world")
 
-    @mock.patch('urllib3.PoolManager')
+    @mock.patch("urllib3.PoolManager")
     def test_remove_object_works(self, mock_connection):
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
-            MockResponse('DELETE',
-                         'https://localhost:9000/hello/world',
-                         {'User-Agent': _DEFAULT_USER_AGENT}, 204)
+            MockResponse(
+                "DELETE",
+                "https://localhost:9000/hello/world",
+                {"User-Agent": _DEFAULT_USER_AGENT},
+                204,
+            )
         )
-        client = Minio('localhost:9000')
-        client.remove_object('hello', 'world')
+        client = Minio("localhost:9000")
+        client.remove_object("hello", "world")

--- a/tests/unit/remove_objects_test.py
+++ b/tests/unit/remove_objects_test.py
@@ -26,54 +26,69 @@ from .minio_mocks import MockConnection, MockResponse
 
 
 class RemoveObjectsTest(TestCase):
-    @mock.patch('urllib3.PoolManager')
+    @mock.patch("urllib3.PoolManager")
     def test_object_is_list(self, mock_connection):
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
-            MockResponse('POST',
-                         'https://localhost:9000/hello?delete=',
-                         {'User-Agent': _DEFAULT_USER_AGENT,
-                          'Content-Md5': u'Te1kmIjQRNNz70DJjsrD8A=='}, 200,
-                         content=b'<Delete/>')
+            MockResponse(
+                "POST",
+                "https://localhost:9000/hello?delete=",
+                {
+                    "User-Agent": _DEFAULT_USER_AGENT,
+                    "Content-Md5": "Te1kmIjQRNNz70DJjsrD8A==",
+                },
+                200,
+                content=b"<Delete/>",
+            )
         )
-        client = Minio('localhost:9000')
+        client = Minio("localhost:9000")
         for err in client.remove_objects(
-                "hello",
-                [DeleteObject("Ab"), DeleteObject("c")],
+            "hello",
+            [DeleteObject("Ab"), DeleteObject("c")],
         ):
             print(err)
 
-    @mock.patch('urllib3.PoolManager')
+    @mock.patch("urllib3.PoolManager")
     def test_object_is_tuple(self, mock_connection):
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
-            MockResponse('POST',
-                         'https://localhost:9000/hello?delete=',
-                         {'User-Agent': _DEFAULT_USER_AGENT,
-                          'Content-Md5': u'Te1kmIjQRNNz70DJjsrD8A=='}, 200,
-                         content=b'<Delete/>')
+            MockResponse(
+                "POST",
+                "https://localhost:9000/hello?delete=",
+                {
+                    "User-Agent": _DEFAULT_USER_AGENT,
+                    "Content-Md5": "Te1kmIjQRNNz70DJjsrD8A==",
+                },
+                200,
+                content=b"<Delete/>",
+            )
         )
-        client = Minio('localhost:9000')
+        client = Minio("localhost:9000")
         for err in client.remove_objects(
-                "hello",
-                (DeleteObject("Ab"), DeleteObject("c")),
+            "hello",
+            (DeleteObject("Ab"), DeleteObject("c")),
         ):
             print(err)
 
-    @mock.patch('urllib3.PoolManager')
+    @mock.patch("urllib3.PoolManager")
     def test_object_is_iterator(self, mock_connection):
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
-            MockResponse('POST',
-                         'https://localhost:9000/hello?delete=',
-                         {'User-Agent': _DEFAULT_USER_AGENT,
-                          'Content-Md5': u'Te1kmIjQRNNz70DJjsrD8A=='}, 200,
-                         content=b'<Delete/>')
+            MockResponse(
+                "POST",
+                "https://localhost:9000/hello?delete=",
+                {
+                    "User-Agent": _DEFAULT_USER_AGENT,
+                    "Content-Md5": "Te1kmIjQRNNz70DJjsrD8A==",
+                },
+                200,
+                content=b"<Delete/>",
+            )
         )
-        client = Minio('localhost:9000')
+        client = Minio("localhost:9000")
         it = itertools.chain((DeleteObject("Ab"), DeleteObject("c")))
-        for err in client.remove_objects('hello', it):
+        for err in client.remove_objects("hello", it):
             print(err)

--- a/tests/unit/replicationconfig_test.py
+++ b/tests/unit/replicationconfig_test.py
@@ -18,8 +18,12 @@ from unittest import TestCase
 
 from minio import xml
 from minio.commonconfig import DISABLED, ENABLED, AndOperator, Filter, Tags
-from minio.replicationconfig import (DeleteMarkerReplication, Destination,
-                                     ReplicationConfig, Rule)
+from minio.replicationconfig import (
+    DeleteMarkerReplication,
+    Destination,
+    ReplicationConfig,
+    Rule,
+)
 
 
 class ReplicationConfigTest(TestCase):

--- a/tests/unit/sign_test.py
+++ b/tests/unit/sign_test.py
@@ -108,18 +108,14 @@ class StringToSignTest(TestCase):
             _get_scope(dt, "us-east-1", "s3"),
             "b93e86965c269a0dfef37a8bec231ef8acf8cdb101a64eb700a46c452c1ad233",
         )
-        self.assertEqual(
-            "\n".join(expected_signing_key_list), actual_signing_key
-        )
+        self.assertEqual("\n".join(expected_signing_key_list), actual_signing_key)
 
 
 class SigningKeyTest(TestCase):
     def test_generate_signing_key(self):
         key1_string = "AWS4" + "S3CR3T"
         key1 = key1_string.encode("utf-8")
-        key2 = hmac.new(
-            key1, "20150620".encode("utf-8"), hashlib.sha256
-        ).digest()
+        key2 = hmac.new(key1, "20150620".encode("utf-8"), hashlib.sha256).digest()
         key3 = hmac.new(key2, "region".encode("utf-8"), hashlib.sha256).digest()
         key4 = hmac.new(key3, "s3".encode("utf-8"), hashlib.sha256).digest()
         expected_result = hmac.new(
@@ -144,9 +140,7 @@ class AuthorizationHeaderTest(TestCase):
             "host;X-Amz-Content-Sha256;X-Amz-Date",
             "signed_request",
         )
-        self.assertEqual(
-            expected_authorization_header, actual_authorization_header
-        )
+        self.assertEqual(expected_authorization_header, actual_authorization_header)
 
 
 class PresignURLTest(TestCase):
@@ -154,9 +148,7 @@ class PresignURLTest(TestCase):
         credentials = Credentials("minio", "minio123")
         url = presign_v4(
             "GET",
-            urlsplit(
-                "http://localhost:9000/bucket-name/objectName?versionId=uuid"
-            ),
+            urlsplit("http://localhost:9000/bucket-name/objectName?versionId=uuid"),
             "us-east-1",
             credentials,
             dt,

--- a/tests/unit/sign_test.py
+++ b/tests/unit/sign_test.py
@@ -23,47 +23,73 @@ from urllib.parse import urlsplit, urlunsplit
 from minio import Minio
 from minio.credentials import Credentials
 from minio.helpers import queryencode, quote, sha256_hash
-from minio.signer import (_get_authorization, _get_canonical_request_hash,
-                          _get_scope, _get_signing_key, _get_string_to_sign,
-                          presign_v4, sign_v4_s3)
+from minio.signer import (
+    _get_authorization,
+    _get_canonical_request_hash,
+    _get_scope,
+    _get_signing_key,
+    _get_string_to_sign,
+    presign_v4,
+    sign_v4_s3,
+)
 
-empty_hash = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+empty_hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 dt = datetime(2015, 6, 20, 1, 2, 3, 0, timezone.utc)
 
 
 class CanonicalRequestTest(TestCase):
     def test_simple_request(self):
-        url = urlsplit('http://localhost:9000/hello')
-        expected_signed_headers = ['x-amz-content-sha256', 'x-amz-date']
-        expected_request_array = ['PUT', '/hello', '',
-                                  'x-amz-content-sha256:' +
-                                  empty_hash, 'x-amz-date:dateString',
-                                  '', ';'.join(expected_signed_headers),
-                                  empty_hash]
-        headers_to_sign = {'x-amz-date': 'dateString',
-                           'x-amz-content-sha256': empty_hash}
+        url = urlsplit("http://localhost:9000/hello")
+        expected_signed_headers = ["x-amz-content-sha256", "x-amz-date"]
+        expected_request_array = [
+            "PUT",
+            "/hello",
+            "",
+            "x-amz-content-sha256:" + empty_hash,
+            "x-amz-date:dateString",
+            "",
+            ";".join(expected_signed_headers),
+            empty_hash,
+        ]
+        headers_to_sign = {
+            "x-amz-date": "dateString",
+            "x-amz-content-sha256": empty_hash,
+        }
 
-        expected_request = sha256_hash('\n'.join(expected_request_array))
+        expected_request = sha256_hash("\n".join(expected_request_array))
         actual_request = _get_canonical_request_hash(
-            "PUT", url, headers_to_sign, empty_hash,
+            "PUT",
+            url,
+            headers_to_sign,
+            empty_hash,
         )
         self.assertEqual(expected_request, actual_request[0])
 
     def test_request_with_query(self):
-        url = urlsplit('http://localhost:9000/hello?c=d&e=f&a=b')
-        expected_signed_headers = ['x-amz-content-sha256', 'x-amz-date']
-        expected_request_array = ['PUT', '/hello', 'a=b&c=d&e=f',
-                                  'x-amz-content-sha256:' + empty_hash,
-                                  'x-amz-date:dateString',
-                                  '', ';'.join(expected_signed_headers),
-                                  empty_hash]
+        url = urlsplit("http://localhost:9000/hello?c=d&e=f&a=b")
+        expected_signed_headers = ["x-amz-content-sha256", "x-amz-date"]
+        expected_request_array = [
+            "PUT",
+            "/hello",
+            "a=b&c=d&e=f",
+            "x-amz-content-sha256:" + empty_hash,
+            "x-amz-date:dateString",
+            "",
+            ";".join(expected_signed_headers),
+            empty_hash,
+        ]
 
-        expected_request = sha256_hash('\n'.join(expected_request_array))
+        expected_request = sha256_hash("\n".join(expected_request_array))
 
-        headers_to_sign = {'x-amz-date': 'dateString',
-                           'x-amz-content-sha256': empty_hash}
+        headers_to_sign = {
+            "x-amz-date": "dateString",
+            "x-amz-content-sha256": empty_hash,
+        }
         actual_request = _get_canonical_request_hash(
-            "PUT", url, headers_to_sign, empty_hash,
+            "PUT",
+            url,
+            headers_to_sign,
+            empty_hash,
         )
         self.assertEqual(expected_request, actual_request[0])
 
@@ -71,68 +97,91 @@ class CanonicalRequestTest(TestCase):
 class StringToSignTest(TestCase):
     def test_signing_key(self):
         expected_signing_key_list = [
-            'AWS4-HMAC-SHA256', '20150620T010203Z',
-            '20150620/us-east-1/s3/aws4_request',
-            'b93e86965c269a0dfef37a8bec231ef8acf8cdb101a64eb700a46c452c1ad233'
+            "AWS4-HMAC-SHA256",
+            "20150620T010203Z",
+            "20150620/us-east-1/s3/aws4_request",
+            "b93e86965c269a0dfef37a8bec231ef8acf8cdb101a64eb700a46c452c1ad233",
         ]
 
         actual_signing_key = _get_string_to_sign(
-            dt, _get_scope(dt, 'us-east-1', "s3"),
-            'b93e86965c269a0dfef37a8bec231ef8acf8cdb101a64eb700a46c452c1ad233')
-        self.assertEqual('\n'.join(expected_signing_key_list),
-                         actual_signing_key)
+            dt,
+            _get_scope(dt, "us-east-1", "s3"),
+            "b93e86965c269a0dfef37a8bec231ef8acf8cdb101a64eb700a46c452c1ad233",
+        )
+        self.assertEqual(
+            "\n".join(expected_signing_key_list), actual_signing_key
+        )
 
 
 class SigningKeyTest(TestCase):
     def test_generate_signing_key(self):
-        key1_string = 'AWS4' + 'S3CR3T'
-        key1 = key1_string.encode('utf-8')
-        key2 = hmac.new(key1, '20150620'.encode(
-            'utf-8'), hashlib.sha256).digest()
-        key3 = hmac.new(key2, 'region'.encode(
-            'utf-8'), hashlib.sha256).digest()
-        key4 = hmac.new(key3, 's3'.encode('utf-8'), hashlib.sha256).digest()
-        expected_result = hmac.new(key4, 'aws4_request'.encode(
-            'utf-8'), hashlib.sha256).digest()
+        key1_string = "AWS4" + "S3CR3T"
+        key1 = key1_string.encode("utf-8")
+        key2 = hmac.new(
+            key1, "20150620".encode("utf-8"), hashlib.sha256
+        ).digest()
+        key3 = hmac.new(key2, "region".encode("utf-8"), hashlib.sha256).digest()
+        key4 = hmac.new(key3, "s3".encode("utf-8"), hashlib.sha256).digest()
+        expected_result = hmac.new(
+            key4, "aws4_request".encode("utf-8"), hashlib.sha256
+        ).digest()
 
-        actual_result = _get_signing_key('S3CR3T', dt, 'region', "s3")
+        actual_result = _get_signing_key("S3CR3T", dt, "region", "s3")
         self.assertEqual(expected_result, actual_result)
 
 
 class AuthorizationHeaderTest(TestCase):
     def test_generate_authentication_header(self):
         expected_authorization_header = (
-            'AWS4-HMAC-SHA256 Credential='
-            'public_key/20150620/region/s3/aws4_request, '
-            'SignedHeaders=host;X-Amz-Content-Sha256;X-Amz-Date, '
-            'Signature=signed_request'
+            "AWS4-HMAC-SHA256 Credential="
+            "public_key/20150620/region/s3/aws4_request, "
+            "SignedHeaders=host;X-Amz-Content-Sha256;X-Amz-Date, "
+            "Signature=signed_request"
         )
         actual_authorization_header = _get_authorization(
-            'public_key', _get_scope(dt, 'region', "s3"),
-            'host;X-Amz-Content-Sha256;X-Amz-Date', 'signed_request')
-        self.assertEqual(expected_authorization_header,
-                         actual_authorization_header)
+            "public_key",
+            _get_scope(dt, "region", "s3"),
+            "host;X-Amz-Content-Sha256;X-Amz-Date",
+            "signed_request",
+        )
+        self.assertEqual(
+            expected_authorization_header, actual_authorization_header
+        )
 
 
 class PresignURLTest(TestCase):
     def test_presigned_versioned_id(self):
         credentials = Credentials("minio", "minio123")
-        url = presign_v4('GET', urlsplit('http://localhost:9000/bucket-name/objectName?versionId=uuid'),
-                         'us-east-1', credentials, dt, 604800)
+        url = presign_v4(
+            "GET",
+            urlsplit(
+                "http://localhost:9000/bucket-name/objectName?versionId=uuid"
+            ),
+            "us-east-1",
+            credentials,
+            dt,
+            604800,
+        )
 
-        self.assertEqual(urlunsplit(url), 'http://localhost:9000/bucket-name/objectName?versionId=uuid&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minio%2F20150620%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20150620T010203Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=3ce13e2ca929fafa20581a05730e4e9435f2a5e20ec7c5a082d175692fb0a663')
+        self.assertEqual(
+            urlunsplit(url),
+            "http://localhost:9000/bucket-name/objectName?versionId=uuid&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minio%2F20150620%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20150620T010203Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=3ce13e2ca929fafa20581a05730e4e9435f2a5e20ec7c5a082d175692fb0a663",
+        )
 
 
 class SignV4Test(TestCase):
     def test_signv4(self):
-        client = Minio("localhost:9000", access_key="minio",
-                       secret_key="minio123", secure=False)
+        client = Minio(
+            "localhost:9000",
+            access_key="minio",
+            secret_key="minio123",
+            secure=False,
+        )
         creds = client._provider.retrieve()
         headers = {
-            'Host': 'localhost:9000',
-            'x-amz-content-sha256':
-            'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
-            'x-amz-date': '20150620T010203Z',
+            "Host": "localhost:9000",
+            "x-amz-content-sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "x-amz-date": "20150620T010203Z",
         }
         url = client._base_url.build(
             "PUT",
@@ -150,34 +199,41 @@ class SignV4Test(TestCase):
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
             dt,
         )
-        self.assertEqual(headers['Authorization'],
-                         'AWS4-HMAC-SHA256 Credential='
-                         'minio/20150620/us-east-1/s3/aws4_request, '
-                         'SignedHeaders=host;x-amz-content-sha256;x-amz-date, '
-                         'Signature='
-                         'a2f4546f647981732bd90dfa5a7599c44dca92f44bea48ecc7565df06032c25b')
+        self.assertEqual(
+            headers["Authorization"],
+            "AWS4-HMAC-SHA256 Credential="
+            "minio/20150620/us-east-1/s3/aws4_request, "
+            "SignedHeaders=host;x-amz-content-sha256;x-amz-date, "
+            "Signature="
+            "a2f4546f647981732bd90dfa5a7599c44dca92f44bea48ecc7565df06032c25b",
+        )
 
 
 class UnicodeEncodeTest(TestCase):
     def test_unicode_quote(self):
-        self.assertEqual(quote('/test/123/汉字'), '/test/123/%E6%B1%89%E5%AD%97')
+        self.assertEqual(quote("/test/123/汉字"), "/test/123/%E6%B1%89%E5%AD%97")
 
     def test_unicode_queryencode(self):
-        self.assertEqual(queryencode('/test/123/汉字'),
-                         '%2Ftest%2F123%2F%E6%B1%89%E5%AD%97')
+        self.assertEqual(
+            queryencode("/test/123/汉字"), "%2Ftest%2F123%2F%E6%B1%89%E5%AD%97"
+        )
 
     def test_unicode_quote_u(self):
-        self.assertEqual(quote(u'/test/123/汉字'),
-                         '/test/123/%E6%B1%89%E5%AD%97')
+        self.assertEqual(quote("/test/123/汉字"), "/test/123/%E6%B1%89%E5%AD%97")
 
     def test_unicode_queryencode_u(self):
-        self.assertEqual(queryencode(u'/test/123/汉字'),
-                         '%2Ftest%2F123%2F%E6%B1%89%E5%AD%97')
+        self.assertEqual(
+            queryencode("/test/123/汉字"), "%2Ftest%2F123%2F%E6%B1%89%E5%AD%97"
+        )
 
     def test_unicode_quote_b(self):
-        self.assertEqual(quote(b'/test/123/\xe6\xb1\x89\xe5\xad\x97'),
-                         '/test/123/%E6%B1%89%E5%AD%97')
+        self.assertEqual(
+            quote(b"/test/123/\xe6\xb1\x89\xe5\xad\x97"),
+            "/test/123/%E6%B1%89%E5%AD%97",
+        )
 
     def test_unicode_queryencode_b(self):
-        self.assertEqual(queryencode(b'/test/123/\xe6\xb1\x89\xe5\xad\x97'),
-                         '%2Ftest%2F123%2F%E6%B1%89%E5%AD%97')
+        self.assertEqual(
+            queryencode(b"/test/123/\xe6\xb1\x89\xe5\xad\x97"),
+            "%2Ftest%2F123%2F%E6%B1%89%E5%AD%97",
+        )

--- a/tests/unit/stat_object_test.py
+++ b/tests/unit/stat_object_test.py
@@ -25,32 +25,35 @@ from .minio_mocks import MockConnection, MockResponse
 
 class StatObject(TestCase):
     def test_object_is_string(self):
-        client = Minio('localhost:9000')
-        self.assertRaises(TypeError, client.stat_object, 'hello', 1234)
+        client = Minio("localhost:9000")
+        self.assertRaises(TypeError, client.stat_object, "hello", 1234)
 
     def test_object_is_not_empty_string(self):
-        client = Minio('localhost:9000')
-        self.assertRaises(ValueError, client.stat_object, 'hello', '  \t \n  ')
+        client = Minio("localhost:9000")
+        self.assertRaises(ValueError, client.stat_object, "hello", "  \t \n  ")
 
     def test_stat_object_invalid_name(self):
-        client = Minio('localhost:9000')
-        self.assertRaises(ValueError, client.stat_object, 'AB#CD', 'world')
+        client = Minio("localhost:9000")
+        self.assertRaises(ValueError, client.stat_object, "AB#CD", "world")
 
-    @mock.patch('urllib3.PoolManager')
+    @mock.patch("urllib3.PoolManager")
     def test_stat_object_works(self, mock_connection):
         mock_headers = {
-            'content-type': 'application/octet-stream',
-            'last-modified': 'Fri, 26 Jun 2015 19:05:37 GMT',
-            'content-length': 11,
-            'etag': '5eb63bbbe01eeed093cb22bb8f5acdc3'
+            "content-type": "application/octet-stream",
+            "last-modified": "Fri, 26 Jun 2015 19:05:37 GMT",
+            "content-length": 11,
+            "etag": "5eb63bbbe01eeed093cb22bb8f5acdc3",
         }
         mock_server = MockConnection()
         mock_connection.return_value = mock_server
         mock_server.mock_add_request(
-            MockResponse('HEAD',
-                         'https://localhost:9000/hello/world',
-                         {'User-Agent': _DEFAULT_USER_AGENT}, 200,
-                         response_headers=mock_headers)
+            MockResponse(
+                "HEAD",
+                "https://localhost:9000/hello/world",
+                {"User-Agent": _DEFAULT_USER_AGENT},
+                200,
+                response_headers=mock_headers,
+            )
         )
-        client = Minio('localhost:9000')
-        client.stat_object('hello', 'world')
+        client = Minio("localhost:9000")
+        client.stat_object("hello", "world")

--- a/tests/unit/trace_test.py
+++ b/tests/unit/trace_test.py
@@ -21,5 +21,5 @@ from minio import Minio
 
 class TraceTest(TestCase):
     def test_bucket_is_string(self):
-        client = Minio('localhost:9000')
+        client = Minio("localhost:9000")
         self.assertRaises(ValueError, client.trace_on, None)


### PR DESCRIPTION
autopep8 doesn't enforce code style in some corner case, use black to make sure formatter of different editor/ide won't cause unnecessary diff.