### PR TITLE
prepare temporary directory when `fget_object`

### DIFF
--- a/minio/api.py
+++ b/minio/api.py
@@ -52,7 +52,7 @@ from .helpers import (MAX_MULTIPART_COUNT, MAX_MULTIPART_OBJECT_SIZE,
                       ThreadPool, check_bucket_name, check_non_empty_string,
                       check_sse, check_ssec, genheaders, get_part_info,
                       headers_to_strings, is_valid_policy_type, makedirs,
-                      md5sum_hash, read_part_data, sha256_hash)
+                      md5sum_hash, read_part_data, sha256_hash, queryencode)
 from .legalhold import LegalHold
 from .lifecycleconfig import LifecycleConfig
 from .notificationconfig import NotificationConfig
@@ -1043,7 +1043,9 @@ class Minio:  # pylint: disable=too-many-public-methods
         )
 
         # Write to a temporary file "file_path.part.minio" before saving.
-        tmp_file_path = tmp_file_path or f"{file_path}.{stat.etag}.part.minio"
+        tmp_file_path = (
+            tmp_file_path or f"{file_path}.{queryencode(stat.etag)}.part.minio"
+        )
 
         response = None
         try:


### PR DESCRIPTION
`fget_object` got exception when download temporary file in a non-exists directory.

```
Traceback (most recent call last):
  File "/home/laisky/repo/laisky/ramjet/ramjet/tasks/gptchat/utils.py", line 98, in wrapper
    return await func(self, *args, **kwargs)
  File "/home/laisky/repo/laisky/ramjet/ramjet/tasks/gptchat/utils.py", line 72, in wrapper
    return await func(self, userinfo, *args, **kwargs)
  File "/home/laisky/repo/laisky/ramjet/ramjet/tasks/gptchat/router.py", line 798, in post
    return await ioloop.run_in_executor(
  File "/home/laisky/.pyenv/versions/3.10.0/lib/python3.10/concurrent/futures/thread.py", line 52, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/laisky/repo/laisky/ramjet/ramjet/tasks/gptchat/router.py", line 900, in build_chatbot
    self._build_user_chatbot(
  File "/home/laisky/repo/laisky/ramjet/ramjet/tasks/gptchat/router.py", line 926, in _build_user_chatbot
    index = self.load_datasets(
  File "/home/laisky/repo/laisky/ramjet/ramjet/tasks/gptchat/router.py", line 979, in load_datasets
    s3cli.fget_object(
  File "/home/laisky/repo/laisky/ramjet/venv/lib/python3.10/site-packages/minio/api.py", line 1064, in fget_object
    with open(tmp_file_path, "wb") as tmp_file:
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmplk7ct4to/dataset.index.W/a4dcdf3e0b5d5ffaa18462a6da92e724.part.minio'
```