### PR TITLE
fix remove_objects() example to convert map to list of map

### DIFF
--- a/minio/api.py
+++ b/minio/api.py
@@ -2002,10 +2002,10 @@ class Minio:  # pylint: disable=too-many-public-methods
                 print("error occurred when deleting object", error)
 
             # Remove a prefix recursively.
-            delete_object_list = map(
+            delete_object_list = list(map(
                 lambda x: DeleteObject(x.object_name),
                 client.list_objects("my-bucket", "my/prefix/", recursive=True),
-            )
+            ))
             errors = client.remove_objects("my-bucket", delete_object_list)
             for error in errors:
                 print("error occurred when deleting object", error)

--- a/minio/api.py
+++ b/minio/api.py
@@ -2002,10 +2002,12 @@ class Minio:  # pylint: disable=too-many-public-methods
                 print("error occurred when deleting object", error)
 
             # Remove a prefix recursively.
-            delete_object_list = list(map(
-                lambda x: DeleteObject(x.object_name),
-                client.list_objects("my-bucket", "my/prefix/", recursive=True),
-            ))
+            delete_object_list = list(
+                map(
+                    lambda x: DeleteObject(x.object_name),
+                    client.list_objects("my-bucket", "my/prefix/", recursive=True),
+                )
+            )
             errors = client.remove_objects("my-bucket", delete_object_list)
             for error in errors:
                 print("error occurred when deleting object", error)

--- a/minio/api.py
+++ b/minio/api.py
@@ -2005,7 +2005,11 @@ class Minio:  # pylint: disable=too-many-public-methods
             delete_object_list = list(
                 map(
                     lambda x: DeleteObject(x.object_name),
-                    client.list_objects("my-bucket", "my/prefix/", recursive=True),
+                    client.list_objects(
+                        "my-bucket",
+                        "my/prefix/",
+                        recursive=True,
+                    ),
                 )
             )
             errors = client.remove_objects("my-bucket", delete_object_list)


### PR DESCRIPTION
`Minio.remove_objects` expects a list of `DeleteObject`s, but the documentation uses a `map`. If a `map` is passed to `Minio.remove_objects`, it will silently fail, and the objects will not be deleted. This PR corrects the documentation to pass a `list` instead of a `map` to `Minio.remove_objects`.