### PR TITLE
Allow duck typing for Progress objects

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1125,7 +1125,7 @@ __Parameters__
 | `content_type` | _str_       | Content type of the object.                                         |
 | `metadata`     | _dict_      | Any additional metadata to be uploaded along with your PUT request. |
 | `sse`          | _Sse_       | Server-side encryption.                                             |
-| `progress`     | _threading_ | A progress object.                                                  |
+| `progress`     | _Progress_  | A progress object.                                                  |
 | `part_size`    | _int_       | Multipart part size.                                                |
 | `tags`         | _Tags_      | Tags for the object.                                                |
 | `retention`    | _Retention_ | Retention configuration.                                            |
@@ -1261,7 +1261,7 @@ Uploads data from a file to an object in a bucket.
 | `content_type` | _str_       | Content type of the object.                                         |
 | `metadata`     | _dict_      | Any additional metadata to be uploaded along with your PUT request. |
 | `sse`          | _Sse_       | Server-side encryption.                                             |
-| `progress`     | _threading_ | A progress object.                                                  |
+| `progress`     | _Progress_  | A progress object.                                                  |
 | `part_size`    | _int_       | Multipart part size.                                                |
 | `tags`         | _Tags_      | Tags for the object.                                                |
 | `retention`    | _Retention_ | Retention configuration.                                            |

--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -27,6 +27,7 @@ import re
 import urllib.parse
 from queue import Queue
 from threading import BoundedSemaphore, Thread
+from typing import Protocol, runtime_checkable
 
 from .sse import Sse, SseCustomerKey
 from .time import to_iso8601utc
@@ -774,3 +775,12 @@ class ThreadPool:
         if not self._exceptions_queue.empty():
             raise self._exceptions_queue.get()
         return self._results_queue
+
+
+@runtime_checkable
+class Progress(Protocol):
+    def set_meta(self, total_length: int, object_name: str) -> None:
+        ...
+
+    def update(self, size: int) -> None:
+        ...


### PR DESCRIPTION
It's not strictly necessary for `Progress` objects to be Threads, as none of the `Thread` APIs are actually used. Rather, `Progress` must only be an object which implements `set_meta` and `update` methods.

To support (optional) type checking of `Progress`, this also adds a `Progress` protocol, which consumers may choose (but are not required) to subclass.