### PR TITLE
fix install_requires urllib3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     long_description_content_type="text/markdown",
     package_dir={"minio": "minio"},
     packages=["minio", "minio.credentials"],
-    install_requires=["certifi", "urllib3", "argon2-cffi",
+    install_requires=["certifi", "urllib3>=2.0", "argon2-cffi",
                       "pycryptodome", "typing-extensions"],
     tests_require=[],
     license="Apache-2.0",


### PR DESCRIPTION
From #1378 minio 7.2.1 requires urllib3>=2.0 because it uses `urllib3.response.BaseHTTPResponse `

```
➜  minio-py git:(master) pip install git+https://github.com/ydc-0/minio-py.git@master
...
Installing collected packages: urllib3
  Attempting uninstall: urllib3
    Found existing installation: urllib3 1.26.18
    Uninstalling urllib3-1.26.18:
      Successfully uninstalled urllib3-1.26.18
Successfully installed urllib3-2.1.0
```