### PR TITLE
Add import aliases to make mypy happy

### DIFF
--- a/minio/__init__.py
+++ b/minio/__init__.py
@@ -37,7 +37,9 @@ __version__ = "7.2.3"
 __license__ = "Apache 2.0"
 __copyright__ = "Copyright 2015, 2016, 2017, 2018, 2019, 2020 MinIO, Inc."
 
-# pylint: disable=unused-import
-from .api import Minio
-from .error import InvalidResponseError, S3Error, ServerError
-from .minioadmin import MinioAdmin
+# pylint: disable=unused-import,useless-import-alias
+from .api import Minio as Minio
+from .error import InvalidResponseError as InvalidResponseError
+from .error import S3Error as S3Error
+from .error import ServerError as ServerError
+from .minioadmin import MinioAdmin as MinioAdmin


### PR DESCRIPTION
Mypy with strict mode enabled gives the following error on version [7.2.2](https://github.com/minio/minio-py/tree/7.2.2):
```
error: Module "minio" does not explicitly export attribute "Minio"  [attr-defined]
```
The error is caused by rule [--no-implicit-reexport](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-implicit-reexport). There are two ways how to fix it: either define `__all__` in `__init__.py` or use import aliases so that other modules can import it. In this PR I added aliases for all imports in `__init__.py`.
