### PR TITLE
fix typing in remove_objects/upload_snowball_objects APIs

### DIFF
--- a/minio/api.py
+++ b/minio/api.py
@@ -30,6 +30,7 @@ from __future__ import absolute_import, annotations
 import itertools
 import os
 import tarfile
+from collections.abc import Iterable
 from datetime import datetime, timedelta
 from io import BytesIO
 from random import random
@@ -2139,7 +2140,7 @@ class Minio:
     def remove_objects(
             self,
             bucket_name: str,
-            delete_object_list: Iterator[DeleteObject],
+            delete_object_list: Iterable[DeleteObject],
             bypass_governance_mode: bool = False,
     ) -> Iterator[DeleteError]:
         """
@@ -2946,7 +2947,7 @@ class Minio:
     def upload_snowball_objects(
             self,
             bucket_name: str,
-            object_list: Iterator[SnowballObject],
+            object_list: Iterable[SnowballObject],
             metadata: DictType | None = None,
             sse: Sse | None = None,
             tags: Tags | None = None,


### PR DESCRIPTION
The `delete_object_list` argument in `minio.api.remove_objects` was annotated as `Iterator[DeleteObject]`. This means that mypy would complain if client code passes a list of `DeleteObject`-s to remove_objects.

But in practice passing in a list works: the `delete_objects` function converts the list to an iterator using `itertools.chain`.

I changed the type annotation to `Iterable[DeleteObject]`. This way, mypy is happy if we pass an iterator, and when we pass a list.

(And same thing in upload_snowball_objects)

Here's a small isolated testcase demonstrating the problem:

```python
from __future__ import annotations

from collections.abc import Iterable
from typing import Iterator


def foo(data: Iterator[int]):
    pass


a = [1, 2, 3, 4]

foo(a)
foo(iter(a))
```

Running mypy on it results in:

```
experiment.py:13: error: Argument 1 to "foo" has incompatible type "list[int]"; expected "Iterator[int]"  [arg-type]
experiment.py:13: note: "list" is missing following "Iterator" protocol member:
experiment.py:13: note:     __next__
```

But if I change the type annotation from `Iterator[int]` to `Iterable[int]`:

```python
from __future__ import annotations

from collections.abc import Iterable
from typing import Iterator


def foo(data: Iterable[int]):
    pass


a = [1, 2, 3, 4]

foo(a)
foo(iter(a))
```

then mypy is happy:

```
Success: no issues found in 1 source file
```


