### PR TITLE
Add ExcludedPrefixes option to VersioningConfig

### DIFF
--- a/minio/versioningconfig.py
+++ b/minio/versioningconfig.py
@@ -44,8 +44,6 @@ class VersioningConfig:
             raise ValueError(f"status must be {ENABLED} or {SUSPENDED}")
         if mfa_delete is not None and mfa_delete not in [ENABLED, DISABLED]:
             raise ValueError(f"MFA delete must be {ENABLED} or {DISABLED}")
-        if excluded_prefixes is not None and not isinstance(excluded_prefixes, list):
-            raise ValueError("Excluded prefixes must be a list")
         self._status = status
         self._mfa_delete = mfa_delete
         self._excluded_prefixes = excluded_prefixes

--- a/minio/versioningconfig.py
+++ b/minio/versioningconfig.py
@@ -44,7 +44,7 @@ class VersioningConfig:
         if mfa_delete is not None and mfa_delete not in [ENABLED, DISABLED]:
             raise ValueError(f"MFA delete must be {ENABLED} or {DISABLED}")
         if excluded_prefixes is not None and not isinstance(excluded_prefixes, list):
-            raise ValueError(f"Excluded prefixes must be a list")
+            raise ValueError("Excluded prefixes must be a list")
         self._status = status
         self._mfa_delete = mfa_delete
         self._excluded_prefixes = excluded_prefixes

--- a/minio/versioningconfig.py
+++ b/minio/versioningconfig.py
@@ -34,16 +34,20 @@ class VersioningConfig:
     """Versioning configuration."""
 
     def __init__(
-            self,
-            status: str | None = None,
-            mfa_delete: str | None = None,
+        self,
+        status: str | None = None,
+        mfa_delete: str | None = None,
+        excluded_prefixes: list[str] | None = None,
     ):
         if status is not None and status not in [ENABLED, SUSPENDED]:
             raise ValueError(f"status must be {ENABLED} or {SUSPENDED}")
         if mfa_delete is not None and mfa_delete not in [ENABLED, DISABLED]:
             raise ValueError(f"MFA delete must be {ENABLED} or {DISABLED}")
+        if excluded_prefixes is not None and not isinstance(excluded_prefixes, list):
+            raise ValueError(f"Excluded prefixes must be a list")
         self._status = status
         self._mfa_delete = mfa_delete
+        self._excluded_prefixes = excluded_prefixes
 
     @property
     def status(self) -> str:
@@ -55,12 +59,25 @@ class VersioningConfig:
         """Get MFA delete."""
         return self._mfa_delete
 
+    @property
+    def excluded_prefixes(self) -> str | None:
+        """Get MFA delete."""
+        return self._excluded_prefixes
+
     @classmethod
     def fromxml(cls: Type[A], element: ET.Element) -> A:
         """Create new object with values from XML element."""
         status = findtext(element, "Status")
         mfa_delete = findtext(element, "MFADelete")
-        return cls(status, mfa_delete)
+
+        excluded_prefixes_tag = element.find("ExcludedPrefixes")
+        excluded_prefixes = None
+        if excluded_prefixes_tag:
+            excluded_prefixes = [
+                tag.text for tag in excluded_prefixes_tag.findall("ExcludedPrefix")
+            ]
+
+        return cls(status, mfa_delete, excluded_prefixes)
 
     def toxml(self, element: ET.Element | None) -> ET.Element:
         """Convert to XML."""
@@ -69,4 +86,8 @@ class VersioningConfig:
             SubElement(element, "Status", self._status)
         if self._mfa_delete:
             SubElement(element, "MFADelete", self._mfa_delete)
+        if self._excluded_prefixes:
+            SubElement(element, "ExcludedPrefixes")
+            for prefix in self._excluded_prefixes:
+                SubElement(element, "ExcludedPrefix", prefix)
         return element

--- a/minio/versioningconfig.py
+++ b/minio/versioningconfig.py
@@ -18,11 +18,11 @@
 
 from __future__ import absolute_import, annotations
 
-from typing import Type, TypeVar
+from typing import List, Type, TypeVar, Union, cast
 from xml.etree import ElementTree as ET
 
 from .commonconfig import DISABLED, ENABLED
-from .xml import Element, SubElement, findtext
+from .xml import Element, SubElement, findall, findtext
 
 OFF = "Off"
 SUSPENDED = "Suspended"
@@ -77,8 +77,10 @@ class VersioningConfig:
         status = findtext(element, "Status")
         mfa_delete = findtext(element, "MFADelete")
         excluded_prefixes = [
-            prefix.text for prefix in findall(
-                element, "ExcludedPrefixes/Prefix",
+            prefix.text
+            for prefix in findall(
+                element,
+                "ExcludedPrefixes/ExcludedPrefix",
             )
         ]
         exclude_folders = findtext(element, "ExcludeFolders") == "true"
@@ -98,7 +100,9 @@ class VersioningConfig:
             SubElement(element, "MFADelete", self._mfa_delete)
         for prefix in self._excluded_prefixes or []:
             SubElement(
-                SubElement(element, "ExcludedPrefixes"), "Prefix", prefix,
+                SubElement(element, "ExcludedPrefixes"),
+                "ExcludedPrefix",
+                prefix,
             )
         if self._exclude_folders:
             SubElement(element, "ExcludeFolders", "true")

--- a/tests/unit/versioningconfig_test.py
+++ b/tests/unit/versioningconfig_test.py
@@ -18,11 +18,6 @@ from unittest import TestCase
 
 from minio import xml
 from minio.commonconfig import DISABLED, ENABLED
-from minio.versioningconfig import (
-    OFF,
-    SUSPENDED,
-    VersioningConfig,
-)
 
 
 class VersioningConfigTest(TestCase):
@@ -57,22 +52,3 @@ class VersioningConfigTest(TestCase):
         xml.marshal(config)
         self.assertEqual(config.status, SUSPENDED)
         self.assertEqual(config.mfa_delete, DISABLED)
-
-    def test_config_with_excluded_prefixes(self):
-
-        config = xml.unmarshal(
-            VersioningConfig,
-            """
-            <VersioningConfiguration>
-                <Status>Enabled</Status>
-                <MFADelete>Disabled</MFADelete>
-                <ExcludedPrefixes>
-                    <ExcludedPrefix>prefix</ExcludedPrefix>
-                </ExcludedPrefixes>
-            </VersioningConfiguration>
-            """,
-        )
-        xml.marshal(config)
-        self.assertEqual(config.status, ENABLED)
-        self.assertEqual(config.mfa_delete, DISABLED)
-        self.assertListEqual(config.excluded_prefixes, ["prefix"])

--- a/tests/unit/versioningconfig_test.py
+++ b/tests/unit/versioningconfig_test.py
@@ -18,6 +18,7 @@ from unittest import TestCase
 
 from minio import xml
 from minio.commonconfig import DISABLED, ENABLED
+from minio.versioningconfig import OFF, SUSPENDED, VersioningConfig
 
 
 class VersioningConfigTest(TestCase):

--- a/tests/unit/versioningconfig_test.py
+++ b/tests/unit/versioningconfig_test.py
@@ -18,7 +18,11 @@ from unittest import TestCase
 
 from minio import xml
 from minio.commonconfig import DISABLED, ENABLED
-from minio.versioningconfig import OFF, SUSPENDED, VersioningConfig
+from minio.versioningconfig import (
+    OFF,
+    SUSPENDED,
+    VersioningConfig,
+)
 
 
 class VersioningConfigTest(TestCase):
@@ -53,3 +57,22 @@ class VersioningConfigTest(TestCase):
         xml.marshal(config)
         self.assertEqual(config.status, SUSPENDED)
         self.assertEqual(config.mfa_delete, DISABLED)
+
+    def test_config_with_excluded_prefixes(self):
+
+        config = xml.unmarshal(
+            VersioningConfig,
+            """
+            <VersioningConfiguration>
+                <Status>Enabled</Status>
+                <MFADelete>Disabled</MFADelete>
+                <ExcludedPrefixes>
+                    <ExcludedPrefix>prefix</ExcludedPrefix>
+                </ExcludedPrefixes>
+            </VersioningConfiguration>
+            """,
+        )
+        xml.marshal(config)
+        self.assertEqual(config.status, ENABLED)
+        self.assertEqual(config.mfa_delete, DISABLED)
+        self.assertListEqual(config.excluded_prefixes, ["prefix"])


### PR DESCRIPTION
Add ExcludedPrefixes option to VerionningConfig.

Mimicks the behaviour of the minio cli `mc` [link](https://min.io/docs/minio/linux/administration/object-management/object-versioning.html#id9)

Started from issue #1401 