### PR TITLE
Don't install package on Python below 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     long_description_content_type="text/markdown",
     package_dir={"minio": "minio"},
     packages=["minio", "minio.credentials"],
+    python_requires=">3.8",
     install_requires=["certifi", "urllib3", "argon2-cffi",
                       "pycryptodome", "typing-extensions"],
     tests_require=[],


### PR DESCRIPTION
#1413 removed Python 3.7 from a list of supported Python versions. But `minio-py` still can be installed on Python 3.7.
If some next release introduces any change not compatible with 3.7 (e.g. walrus operator or some new typing annotations), users with this Python version should explicitly add an upper limit for package version, to avoid breaking changes.

Added [python_requires](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#python-requirement) to `setup.py` which prevents installing this package on Python below 3.8.