### PR TITLE
[Fix] Not splitting object names with type of bytes

### DIFF
--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -267,10 +267,10 @@ def check_non_empty_string(string: str | bytes):
         raise TypeError() from exc
 
 
-def check_object_name(object_name: str):
+def check_object_name(object_name: str | bytes):
     """Check whether given object name is valid."""
     check_non_empty_string(object_name)
-    tokens = object_name.split("/")
+    tokens = (object_name.decode() if isinstance(object_name, bytes) else object_name).split("/")
     if "." in tokens or ".." in tokens:
         raise ValueError(
             "object name with '.' or '..' path segment is not supported",


### PR DESCRIPTION
In release **7.2.8** utility method `check_non_empty_string` was replaced with `check_object_name`.

Signature of old method requires the argument `object_name` to be a union of types `str` or `bytes`.

However the newer version `check_object_name` always assume `object_name` is of type `str`.

This assumption causes a compatibility issue for example with `django-minio-backend` package which passes `object_name` with type `bytes`, raising `TypeError` exception.