### PR TITLE
docs(example): Avoid `UnboundLocalError` for get_object when exception

### DIFF
--- a/examples/get_object.py
+++ b/examples/get_object.py
@@ -24,14 +24,17 @@ client = Minio(
 )
 
 # Get data of an object.
+response = None
 try:
     response = client.get_object("my-bucket", "my-object")
     # Read data from response.
 finally:
-    response.close()
-    response.release_conn()
+    if response:
+        response.close()
+        response.release_conn()
 
 # Get data of an object of version-ID.
+response = None
 try:
     response = client.get_object(
         "my-bucket", "my-object",
@@ -39,20 +42,24 @@ try:
     )
     # Read data from response.
 finally:
-    response.close()
-    response.release_conn()
+    if response:
+        response.close()
+        response.release_conn()
 
 # Get data of an object from offset and length.
+response = None
 try:
     response = client.get_object(
         "my-bucket", "my-object", offset=512, length=1024,
     )
     # Read data from response.
 finally:
-    response.close()
-    response.release_conn()
+    if response:
+        response.close()
+        response.release_conn()
 
 # Get data of an SSE-C encrypted object.
+response = None
 try:
     response = client.get_object(
         "my-bucket", "my-object",
@@ -60,5 +67,6 @@ try:
     )
     # Read data from response.
 finally:
-    response.close()
-    response.release_conn()
+    if response:
+        response.close()
+        response.release_conn()

--- a/minio/api.py
+++ b/minio/api.py
@@ -1187,14 +1187,17 @@ class Minio:
 
         Example::
             # Get data of an object.
+            response = None
             try:
                 response = client.get_object("my-bucket", "my-object")
                 # Read data from response.
             finally:
-                response.close()
-                response.release_conn()
+                if response:
+                    response.close()
+                    response.release_conn()
 
             # Get data of an object of version-ID.
+            response = None
             try:
                 response = client.get_object(
                     "my-bucket", "my-object",
@@ -1202,20 +1205,24 @@ class Minio:
                 )
                 # Read data from response.
             finally:
-                response.close()
-                response.release_conn()
+                if response:
+                    response.close()
+                    response.release_conn()
 
             # Get data of an object from offset and length.
+            response = None
             try:
                 response = client.get_object(
                     "my-bucket", "my-object", offset=512, length=1024,
                 )
                 # Read data from response.
             finally:
-                response.close()
-                response.release_conn()
+                if response:
+                    response.close()
+                    response.release_conn()
 
             # Get data of an SSE-C encrypted object.
+            response = None
             try:
                 response = client.get_object(
                     "my-bucket", "my-object",
@@ -1223,8 +1230,9 @@ class Minio:
                 )
                 # Read data from response.
             finally:
-                response.close()
-                response.release_conn()
+                if response:
+                    response.close()
+                    response.release_conn()
         """
         check_bucket_name(bucket_name, s3_check=self._base_url.is_aws_host)
         check_object_name(object_name)


### PR DESCRIPTION
I used `get_object` as example shown:

```py
# Get data of an object.
try:
    response = client.get_object("my-bucket", "my-object")
    # Read data from response.
finally:
    response.close()
    response.release_conn()
```

But I got the `UnboundLocalError` when encountered exception in `get_object`. 

```
UnboundLocalError: local variable 'response' referenced before assignment
```

However, the [fget_object](https://github.com/minio/minio-py/blob/b7da8a891466755b3883612d230aa9580781ed6d/minio/api.py#L1131-L1159) api has handled this situation, so I think `get_object` should do so.

```diff
+response = None
try:
    response = client.get_object("my-bucket", "my-object")
    # Read data from response.
except Exception:
    # User can handle exception and don't worry about the `UnboundLocalError`.
finally:
+    if response:
        response.close()
        response.release_conn()
```