### PR TITLE
WebIdentityClientGrantsProvider: use 'id_token' as fallback to 'access_token'

### DIFF
--- a/minio/credentials/providers.py
+++ b/minio/credentials/providers.py
@@ -654,9 +654,10 @@ class WebIdentityClientGrantsProvider(Provider):
         if self._policy:
             query_params["Policy"] = self._policy
 
+        access_token = jwt.get("access_token") or jwt.get("id_token", "")
         if self._is_web_identity():
             query_params["Action"] = "AssumeRoleWithWebIdentity"
-            query_params["WebIdentityToken"] = jwt.get("id_token", "")
+            query_params["WebIdentityToken"] = access_token
             if self._role_arn:
                 query_params["RoleArn"] = self._role_arn
                 query_params["RoleSessionName"] = (
@@ -666,7 +667,7 @@ class WebIdentityClientGrantsProvider(Provider):
                 )
         else:
             query_params["Action"] = "AssumeRoleWithClientGrants"
-            query_params["Token"] = jwt.get("id_token", "")
+            query_params["Token"] = access_token
 
         url = self._sts_endpoint + "?" + urlencode(query_params)
         res = _urlopen(self._http_client, "POST", url)


### PR DESCRIPTION

Fixes #1456