### PR TITLE
Add account_info Admin API

### DIFF
--- a/minio/minioadmin.py
+++ b/minio/minioadmin.py
@@ -323,11 +323,14 @@ class MinioAdmin:
         )
         return response.data.decode()
 
-    def account_info(self) -> str:
-        """Get MinIO Account (aka User) information."""
+    def account_info(self, prefix_usage: bool = False) -> str:
+        """Get usage information for the authenticating account"""
         response = self._url_open(
             "GET",
             _COMMAND.ACCOUNT_INFO,
+            query_params={
+                "prefix-usage": str(prefix_usage).lower(),
+            },
         )
         return response.data.decode()
 

--- a/minio/minioadmin.py
+++ b/minio/minioadmin.py
@@ -53,6 +53,7 @@ from .signer import sign_v4_s3
 @unique
 class _COMMAND(Enum):
     """Admin Command enumerations."""
+    ACCOUNT_INFO = "accountinfo"
     ADD_USER = "add-user"
     USER_INFO = "user-info"
     LIST_USERS = "list-users"
@@ -313,6 +314,14 @@ class MinioAdmin:
         response = self._url_open(
             "GET",
             _COMMAND.INFO,
+        )
+        return response.data.decode()
+
+    def account_info(self) -> str:
+        """Get MinIO Account (aka User) information."""
+        response = self._url_open(
+            "GET",
+            _COMMAND.ACCOUNT_INFO,
         )
         return response.data.decode()
 

--- a/minio/minioadmin.py
+++ b/minio/minioadmin.py
@@ -24,7 +24,7 @@ import json
 import os
 from datetime import timedelta
 from enum import Enum, unique
-from typing import Any, Mapping, TextIO, Tuple, cast
+from typing import Any, TextIO, Tuple, cast
 from urllib.parse import urlunsplit
 
 import certifi
@@ -164,7 +164,7 @@ class MinioAdmin:
             self,
             method: str,
             command: _COMMAND,
-            query_params: Mapping | None = None,
+            query_params: DictType | None = None,
             body: bytes | None = None,
             preload_content: bool = True,
     ) -> BaseHTTPResponse:
@@ -325,15 +325,10 @@ class MinioAdmin:
 
     def account_info(self, prefix_usage: bool = False) -> str:
         """Get usage information for the authenticating account"""
-        query_params = None
-        if prefix_usage:
-            query_params = {
-                "prefix-usage": "true",
-            }
         response = self._url_open(
             "GET",
             _COMMAND.ACCOUNT_INFO,
-            query_params=query_params,
+            query_params={"prefix-usage": "true"} if prefix_usage else None,
         )
         return response.data.decode()
 

--- a/minio/minioadmin.py
+++ b/minio/minioadmin.py
@@ -24,7 +24,7 @@ import json
 import os
 from datetime import timedelta
 from enum import Enum, unique
-from typing import Any, TextIO, Tuple, cast
+from typing import Any, Mapping, TextIO, Tuple, cast
 from urllib.parse import urlunsplit
 
 import certifi
@@ -164,7 +164,7 @@ class MinioAdmin:
             self,
             method: str,
             command: _COMMAND,
-            query_params: DictType | None = None,
+            query_params: Mapping | None = None,
             body: bytes | None = None,
             preload_content: bool = True,
     ) -> BaseHTTPResponse:
@@ -325,12 +325,15 @@ class MinioAdmin:
 
     def account_info(self, prefix_usage: bool = False) -> str:
         """Get usage information for the authenticating account"""
+        query_params = None
+        if prefix_usage:
+            query_params = {
+                "prefix-usage": "true",
+            }
         response = self._url_open(
             "GET",
             _COMMAND.ACCOUNT_INFO,
-            query_params={
-                "prefix-usage": str(prefix_usage).lower(),
-            },
+            query_params=query_params,
         )
         return response.data.decode()
 


### PR DESCRIPTION
Account info admin command was missing in admin client and needed to get bucket information (just like what we have in console)