### PR TITLE
Fix ExcludedPrefixes in set/get bucket versioning config

### DIFF
--- a/minio/versioningconfig.py
+++ b/minio/versioningconfig.py
@@ -78,7 +78,7 @@ class VersioningConfig:
             prefix.text
             for prefix in findall(
                 element,
-                "ExcludedPrefixes/ExcludedPrefix",
+                "ExcludedPrefixes/Prefix",
             )
         ]
         exclude_folders = findtext(element, "ExcludeFolders") == "true"
@@ -99,7 +99,7 @@ class VersioningConfig:
         for prefix in self._excluded_prefixes or []:
             SubElement(
                 SubElement(element, "ExcludedPrefixes"),
-                "ExcludedPrefix",
+                "Prefix",
                 prefix,
             )
         if self._exclude_folders:


### PR DESCRIPTION
Fix parsing of ExlucdedPrefix in set/get bucket versioning API.
ExcludedPrefixes includes Prefix tag and not ExcludedPrefix as stated in
the S3 spec.