### PR TITLE
fix(typing): `MinioAdminClient.group_add()` accept `list[str]` as members

### DIFF
--- a/minio/minioadmin.py
+++ b/minio/minioadmin.py
@@ -395,7 +395,7 @@ class MinioAdmin:
         )
         return plain_data.decode()
 
-    def group_add(self, group_name: str, members: str) -> str:
+    def group_add(self, group_name: str, members: list[str]) -> str:
         """Add users a new or existing group."""
         body = json.dumps({
             "group": group_name,


### PR DESCRIPTION
https://github.com/minio/madmin-go/blob/277de7b316d0de2534fc7892772b55629f96c7fc/group-commands.go#L32-L37