### PR TITLE
feat: add py.typed in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     long_description=readme,
-    package_data={"": ["LICENSE", "README.md"]},
+    package_data={"": ["LICENSE", "README.md", "py.typed"]},
     include_package_data=True,
 )


### PR DESCRIPTION

`py.typed` is not included in packages. I fixed setting.py.