### PR TITLE
support optional parameters in LdapIdentityProvider

### DIFF
--- a/minio/credentials/providers.py
+++ b/minio/credentials/providers.py
@@ -556,19 +556,29 @@ class LdapIdentityProvider(Provider):
 
     def __init__(
             self,
+            *,
             sts_endpoint: str,
             ldap_username: str,
             ldap_password: str,
+            duration_seconds: Optional[int] = None,
+            policy: Optional[str] = None,
+            token_revoke_type: Optional[str] = None,
             http_client: Optional[PoolManager] = None,
     ):
-        self._sts_endpoint = sts_endpoint + "?" + urlencode(
-            {
-                "Action": "AssumeRoleWithLDAPIdentity",
-                "Version": "2011-06-15",
-                "LDAPUsername": ldap_username,
-                "LDAPPassword": ldap_password,
-            },
-        )
+        query_params = {
+            "Action": "AssumeRoleWithLDAPIdentity",
+            "Version": "2011-06-15",
+            "LDAPUsername": ldap_username,
+            "LDAPPassword": ldap_password,
+        }
+        if duration_seconds:
+            query_params["DurationSeconds"] = str(duration_seconds)
+        if policy:
+            query_params["Policy"] = policy
+        if token_revoke_type:
+            query_params["TokenRevokeType"] = token_revoke_type
+
+        self._sts_endpoint = sts_endpoint + "?" + urlencode(query_params)
         self._http_client = http_client or PoolManager(
             retries=Retry(
                 total=5,


### PR DESCRIPTION
Added support for three optional parameters to `LdapIdentityProvider` class

* `duration_seconds`: Specify the number of seconds after which the temporary credentials expire.
* `policy`: Specify the URL-encoded JSON-formatted policy to use as an inline session policy.
* `token_revoke_type`: A string to assign to the generated token that allows the token's access to be revoked prior to expiration.

Document: https://docs.min.io/enterprise/aistor-object-store/developers/security-token-service/assumerolewithldapidentity/