### PR TITLE
fix: skip functional tests on HTTP 405/501 responses

### DIFF
--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -133,7 +133,7 @@ def _call_test(func, *args, **kwargs):
     try:
         func(log_entry, *args, **kwargs)
     except S3Error as exc:
-        if exc.code == "NotImplemented":
+        if exc.response.status in (405, 501):
             log_entry["alert"] = "Not Implemented"
             log_entry["status"] = "NA"
         else:


### PR DESCRIPTION
Use HTTP status codes directly instead of checking error
code strings, so tests are properly skipped when S3 Select
or other APIs return 405 (Method Not Allowed) or
501 (Not Implemented).