### PR TITLE
Fix correctness bugs found in package-wide audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+`minio-py` is the MinIO Python client SDK for Amazon S3-compatible object storage. It is a pure-Python library (Python 3.10+) with no MinIO-specific build step; `urllib3` is the only transport dependency. It is published to PyPI as `minio`.
+
+## Common commands
+
+```sh
+make check                # pylint + isort --diff + autopep8 --diff (lint only, no writes) + mypy
+make apply                # auto-fix: isort + autopep8 --in-place
+make tests                # check, then unit tests (pytest), then functional tests
+make getdeps              # install dev/lint dependencies
+./check.sh                # like `make check` but applies fixes first, also lints examples/ and tests/unit/
+
+pytest                                          # all unit tests
+pytest tests/unit/minio_test.py                 # one test file
+pytest tests/unit/minio_test.py::ValidBucketName::test_bucket_name   # one test case
+
+bash run_functional_tests.sh   # downloads a minio server binary, runs it, then runs functional tests
+```
+
+Functional tests live in `tests/functional/tests.py` (a single script, not pytest) and require a running S3 server. `run_functional_tests.sh` will download and start a local `minio` server if `SERVER_ENDPOINT` is unset; otherwise it targets the server configured via `SERVER_ENDPOINT`, `ACCESS_KEY`, `SECRET_KEY`, `ENABLE_HTTPS`, `MINT_MODE`.
+
+The lint stack must pass clean: `pylint`, `isort`, `autopep8` (PEP 8), and `mypy minio` (the package ships `py.typed` and is fully type-annotated). Run `make apply` before committing to satisfy isort/autopep8.
+
+## Architecture
+
+Two public entry points are exported from `minio/__init__.py`:
+- `Minio` (in `minio/minio.py`) — the S3 data-plane client. One ~6400-line class with one method per S3 operation (`put_object`, `get_object`, `list_objects`, `copy_object`, presigned URLs, bucket policy/lifecycle/replication/tagging/notification/versioning/encryption, etc.). All requests funnel through internal `_execute`/`_url_open` helpers that handle signing, retries, region resolution, and error parsing.
+- `MinioAdmin` (in `minio/minioadmin.py`) — the admin-plane client for the MinIO admin REST API (users, policies, KMS, config, etc.), dispatched via the `_COMMAND` enum.
+
+Supporting modules (each is single-responsibility; read these before changing client behavior):
+- `signer.py` — AWS SigV4 request signing (headers, query/presign, streaming).
+- `credentials/providers.py` — pluggable credential `Provider` chain (static, env, AWS config/IAM, STS AssumeRole/WebIdentity/LDAP/ClientGrants/Certificate). `Minio(credentials=...)` takes any `Provider`.
+- `helpers.py` — `BaseURL` (endpoint/region/virtual-host/dualstack/accelerate URL construction), name validation, multipart sizing constants, threaded I/O helpers.
+- `models.py` — ~50 request/response dataclasses (bucket configs, object info, select, etc.).
+- `xml.py` — S3 XML marshalling/unmarshalling built on ElementTree; most config objects implement `fromxml`/`toxml`.
+- `args.py` — argument-holder classes shared across operations. `error.py` — `S3Error`/`ServerError`/`InvalidResponseError`. `sse.py` / `crypto.py` — server-side encryption and credential-file crypto. `checksum.py` — CRC/SHA checksums. `time.py`, `compat.py` — time formatting and Py compat shims.
+- `rdma.py` — **opt-in** RDMA / NVIDIA GPUDirect Storage acceleration for `put_object`/`get_object`, dispatched to `libminiocpp.so` via ctypes when `Minio(enable_rdma=True)`. The SDK stays pure-Python unless this path is used; see `examples/*_rdma.py`.
+
+## Tests
+
+- Unit tests (`tests/unit/*_test.py`) use `unittest.TestCase` (run under pytest) and mock HTTP via `tests/unit/minio_mocks.py` (`MockResponse`) — no network. File naming convention is `<area>_test.py`.
+- Functional tests (`tests/functional/tests.py`) exercise a real server end-to-end.
+
+## Conventions
+
+- Public client methods are keyword-argument oriented and validate inputs eagerly (bucket/object name checks, type checks) before issuing requests.
+- New S3 config types follow the existing `models.py` dataclass + `xml.py` `fromxml`/`toxml` pattern, with a matching `*_test.py`.
+- `examples/` holds one runnable script per API; keep them in sync when adding/changing public methods.

--- a/examples/get_object_rdma.py
+++ b/examples/get_object_rdma.py
@@ -5,6 +5,7 @@
 """Download from MinIO over RDMA into a pre-allocated host buffer."""
 
 import os
+
 from minio import Minio
 
 client = Minio(

--- a/examples/put_object_rdma.py
+++ b/examples/put_object_rdma.py
@@ -10,6 +10,7 @@ Requirements:
 """
 
 import os
+
 from minio import Minio
 
 client = Minio(

--- a/minio/credentials/providers.py
+++ b/minio/credentials/providers.py
@@ -413,9 +413,8 @@ class IamAwsProvider(Provider):
             os.environ.get("AWS_CONTAINER_AUTHORIZATION_TOKEN") or
             auth_token
         )
-        self._token_file = (
-            os.environ.get("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE") or
-            auth_token
+        self._token_file = os.environ.get(
+            "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
         )
         self._identity_file = (
             os.environ.get("AWS_WEB_IDENTITY_TOKEN_FILE") or token_file
@@ -536,7 +535,7 @@ class IamAwsProvider(Provider):
             )
             res = _urlopen(self._http_client, "GET", url, headers=headers)
             role_names = res.data.decode("utf-8").split("\n")
-            if not role_names:
+            if not role_names or not role_names[0].strip():
                 raise ValueError(f"no IAM roles attached to EC2 service {url}")
             url += role_names[0].strip("\r")
         if not url:
@@ -761,7 +760,7 @@ class CertificateIdentityProvider(Provider):
         if urlsplit(sts_endpoint).scheme != "https":
             raise ValueError("STS endpoint scheme must be HTTPS")
 
-        if not bool(http_client) != (cert_file and key_file):
+        if bool(http_client) == bool(cert_file and key_file):
             raise ValueError(
                 "either cert/key file or custom http_client must be provided",
             )

--- a/minio/crypto.py
+++ b/minio/crypto.py
@@ -113,7 +113,10 @@ def encrypt(payload: bytes, password: str) -> bytes:
     padded_nonce = nonce + b"\x00\x00\x00\x00"
     additional_data = _generate_additional_data(aead_id[0], key, padded_nonce)
 
-    indices = range(0, len(payload), _CHUNK_SIZE)
+    # An empty payload still emits a single final (empty) chunk so the
+    # stream always carries a last-marked tag, matching the reference
+    # streaming-AEAD format and protecting against truncation.
+    indices = range(0, len(payload), _CHUNK_SIZE) or [0]
     nonce_id = 0
     result = salt + aead_id + nonce
     for i in indices:

--- a/minio/helpers.py
+++ b/minio/helpers.py
@@ -356,7 +356,7 @@ class BaseURL:
             tokens = tokens[1:]
         aws_domain_suffix = ".".join(tokens)
 
-        if host in "s3-external-1.amazonaws.com":
+        if host == "s3-external-1.amazonaws.com":
             region_in_host = "us-east-1"
 
         if host in ["s3-us-gov-west-1.amazonaws.com",

--- a/minio/minio.py
+++ b/minio/minio.py
@@ -621,9 +621,9 @@ class Minio:
                 "The specified method is not allowed against this resource",
             ),
             409: lambda: (
-                ("NoSuchBucket", "Bucket does not exist")
+                ("Conflict", "Bucket not empty")
                 if bucket_name
-                else ("ResourceConflict", "Request resource conflicts"),
+                else ("ResourceConflict", "Request resource conflicts")
             ),
             412: lambda: (
                 ("PreconditionFailed",
@@ -3081,7 +3081,7 @@ class Minio:
             headers["x-amz-part-number-marker"] = str(part_number_marker)
         for attribute in object_attributes or []:
             if attribute:
-                headers["x-amz-object-attributes"] = attribute
+                headers.add("x-amz-object-attributes", attribute)
         if ssec:
             headers.extend(ssec.headers())
 
@@ -3684,7 +3684,7 @@ class Minio:
                 elif src.offset is not None:
                     size -= src.offset
                 offset = src.offset or 0
-                headers = cast(HTTPHeaderDict, src.headers)
+                headers = HTTPHeaderDict(src.headers)
                 headers.extend(ssec_headers)
                 if size <= MAX_PART_SIZE:
                     part_number += 1

--- a/minio/minioadmin.py
+++ b/minio/minioadmin.py
@@ -242,6 +242,20 @@ class MinioAdmin:
             _safe_str(response.data),
         )
 
+    def _decrypt_response(self, response: HTTPResponse) -> str:
+        """Decrypt a streamed response and release its connection.
+
+        The connection is always returned to the pool, even when decryption
+        fails, so a failed decrypt cannot leak a streamed connection.
+        """
+        try:
+            return decrypt(
+                response, self._provider.retrieve().secret_key,
+            ).decode()
+        finally:
+            response.close()
+            response.release_conn()
+
     def set_app_info(self, app_name: str, app_version: str):
         """
         Set your application name and version to user agent header.
@@ -379,10 +393,7 @@ class MinioAdmin:
             command=_COMMAND.LIST_USERS,
             preload_content=False,
         )
-        plain_data = decrypt(
-            response, self._provider.retrieve().secret_key,
-        )
-        return plain_data.decode()
+        return self._decrypt_response(response)
 
     def group_add(self, group_name: str, members: list[str]) -> str:
         """Add users a new or existing group."""
@@ -541,6 +552,7 @@ class MinioAdmin:
 
     def config_get(self, key: Optional[str] = None) -> str:
         """Get configuration parameters."""
+        response = None
         try:
             response = self._url_open(
                 method="GET",
@@ -589,6 +601,7 @@ class MinioAdmin:
 
     def config_history(self) -> str:
         """Get historic configuration changes."""
+        response = None
         try:
             response = self._url_open(
                 method="GET",
@@ -622,7 +635,7 @@ class MinioAdmin:
         response = self._url_open(
             method="POST",
             command=_COMMAND.START_PROFILE,
-            query_params=HTTPQueryDict({"profilerType;": ",".join(profilers)}),
+            query_params=HTTPQueryDict({"profilerType": ",".join(profilers)}),
         )
         return response.data.decode()
 
@@ -701,9 +714,9 @@ class MinioAdmin:
             all_sites: bool = False,
     ) -> str:
         """Remove given sites or all sites from site replication."""
-        data = {}
+        data: dict[str, Any] = {}
         if all_sites:
-            data.update({"all": "True"})
+            data.update({"all": True})
         elif sites:
             data.update({"sites": sites or ""})
         else:
@@ -757,10 +770,7 @@ class MinioAdmin:
             query_params=HTTPQueryDict({"accessKey": access_key}),
             preload_content=False,
         )
-        plain_data = decrypt(
-            response, self._provider.retrieve().secret_key,
-        )
-        return plain_data.decode()
+        return self._decrypt_response(response)
 
     def list_service_account(self, user: str) -> str:
         """List service accounts of user"""
@@ -770,10 +780,7 @@ class MinioAdmin:
             query_params=HTTPQueryDict({"user": user}),
             preload_content=False,
         )
-        plain_data = decrypt(
-            response, self._provider.retrieve().secret_key,
-        )
-        return plain_data.decode()
+        return self._decrypt_response(response)
 
     def add_service_account(self,
                             *,
@@ -823,10 +830,7 @@ class MinioAdmin:
             body=encrypt(body, self._provider.retrieve().secret_key),
             preload_content=False,
         )
-        plain_data = decrypt(
-            response, self._provider.retrieve().secret_key,
-        )
-        return plain_data.decode()
+        return self._decrypt_response(response)
 
     def update_service_account(self,
                                *,
@@ -913,8 +917,7 @@ class MinioAdmin:
                 response.close()
                 response.release_conn()
                 return ""
-            data = decrypt(response, self._provider.retrieve().secret_key)
-            return data.decode()
+            return self._decrypt_response(response)
         raise ValueError("either user or group must be set")
 
     def attach_policy_ldap(
@@ -954,10 +957,7 @@ class MinioAdmin:
             query_params=query_params,
             preload_content=False,
         )
-        plain_data = decrypt(
-            response, self._provider.retrieve().secret_key,
-        )
-        return plain_data.decode()
+        return self._decrypt_response(response)
 
     def list_access_keys_ldap_bulk(
             self,
@@ -976,10 +976,7 @@ class MinioAdmin:
             query_params=HTTPQueryDict({"listType": list_type, key: value}),
             preload_content=False,
         )
-        plain_data = decrypt(
-            response, self._provider.retrieve().secret_key,
-        )
-        return plain_data.decode()
+        return self._decrypt_response(response)
 
     def attach_policy(
             self,
@@ -1019,10 +1016,7 @@ class MinioAdmin:
             query_params=query_params,
             preload_content=False,
         )
-        plain_data = decrypt(
-            response, self._provider.retrieve().secret_key,
-        )
-        return plain_data.decode()
+        return self._decrypt_response(response)
 
     @dataclass(frozen=True)
     class PeerSite:

--- a/minio/models.py
+++ b/minio/models.py
@@ -69,7 +69,7 @@ class Checksum:
             ("sha256", self.checksum_sha256),
         ):
             if value:
-                headers[f"x-amz-checksum-algorithm-{algorithm}"] = value
+                headers[f"x-amz-checksum-{algorithm}"] = value
                 headers["x-amz-checksum-algorithm"] = algorithm
         return headers
 
@@ -109,11 +109,10 @@ class Filter:
     tag: Optional[Tag] = None
 
     def __post_init__(self):
-        if not (
-            (self.and_operator is not None) ^
-            (self.prefix is not None) ^
-            (self.tag is not None)
-        ):
+        if sum(
+            x is not None
+            for x in (self.and_operator, self.prefix, self.tag)
+        ) != 1:
             raise ValueError(
                 "only one of and operator, prefix or tag must be provided",
             )
@@ -776,7 +775,7 @@ class LifecycleConfig:
             date, days = cls.parsexml(element)
             expired_object_delete_marker = cast(
                 str,
-                findtext(element, "ExpiredObjectDeleteMarker", default=""),
+                findtext(element, "ExpiredObjectDeleteMarker"),
             )
             if expired_object_delete_marker is None:
                 return cls(date, days, None)
@@ -1243,6 +1242,10 @@ class ObjectLockConfig:
                 f"mode must be {ObjectLockConfig.GOVERNANCE} or "
                 f"{ObjectLockConfig.COMPLIANCE}",
             )
+        if self.duration_unit:
+            object.__setattr__(
+                self, "duration_unit", self.duration_unit.title(),
+            )
         if (
                 self.duration is not None and
                 self.duration_unit not in [
@@ -1250,12 +1253,8 @@ class ObjectLockConfig:
                 ]
         ):
             raise ValueError(
-                f"duration unit must be {ObjectLockConfig.DAYS} or ",
+                f"duration unit must be {ObjectLockConfig.DAYS} or "
                 f"{ObjectLockConfig.YEARS}",
-            )
-        if self.duration_unit:
-            object.__setattr__(
-                self, "duration_unit", self.duration_unit.title(),
             )
 
     @classmethod
@@ -1983,8 +1982,6 @@ class CreateBucketConfiguration:
             """Convert to XML."""
             if element is None:
                 raise ValueError("element must be provided")
-            if self.name or self.type:
-                element = SubElement(element, "Location")
             if self.name:
                 SubElement(element, "Name", self.name)
             if self.type:
@@ -2001,8 +1998,6 @@ class CreateBucketConfiguration:
             """Convert to XML."""
             if element is None:
                 raise ValueError("element must be provided")
-            if self.data_redundancy or self.type:
-                element = SubElement(element, "Bucket")
             if self.data_redundancy:
                 SubElement(element, "DataRedundancy", self.data_redundancy)
             if self.type:
@@ -3361,7 +3356,7 @@ class GetObjectAclResponse(GenericResponse):
         )
         object.__setattr__(
             self,
-            "result",
+            "policy",
             unmarshal(AccessControlPolicy, response.data.decode()),
         )
         object.__setattr__(self, "version_id", version_id)
@@ -3397,7 +3392,7 @@ class GetObjectAttributesResponse(GenericResponse):
         object.__setattr__(
             self,
             "delete_marker",
-            response.headers.get("x-amz-delete-marker"),
+            response.headers.get("x-amz-delete-marker", "").lower() == "true",
         )
         last_modified = response.headers.get("Last-Modified")
         if last_modified:
@@ -3676,7 +3671,7 @@ class PutObjectFanOutResponse(GenericResponse):
                 etag=result["etag"],
                 version_id=result.get("versionId"),
                 last_modified=(
-                    to_iso8601utc(result.get("lastModified"))
+                    from_iso8601utc(result.get("lastModified"))
                     if result.get("lastModified") else None
                 ),
                 error=result.get("error"),

--- a/minio/rdma.py
+++ b/minio/rdma.py
@@ -109,7 +109,8 @@ def alloc_aligned(size: int) -> int:
 
 def free_aligned(ptr: int) -> None:
     """Release a buffer previously returned by :func:`alloc_aligned`."""
-    _load().miniocpp_free_aligned(ptr)
+    if ptr:
+        _load().miniocpp_free_aligned(ptr)
 
 
 def _last_error(lib: ctypes.CDLL) -> str:
@@ -120,29 +121,56 @@ def _last_error(lib: ctypes.CDLL) -> str:
 
 def _buffer_pointer(
     buf: Union[int, memoryview, bytes, bytearray],
-) -> tuple[int, int]:
-    """Return (ptr, length) for a buffer-protocol object or raw int pointer.
+    *,
+    writable: bool,
+) -> tuple[int, int, object]:
+    """Return ``(ptr, length, owner)`` for a buffer-protocol object or int.
 
-    For raw int pointers the caller-supplied length is unknown; returns 0
-    for length and the caller must pass it separately.
+    ``owner`` is the object that backs the returned pointer. The caller MUST
+    keep it referenced until the C call that uses ``ptr`` has returned;
+    otherwise the backing memory may be freed and ``ptr`` left dangling.
+
+    For raw int pointers the caller-supplied length is unknown; returns 0 for
+    length (the caller must pass it separately) and ``None`` as the owner.
+
+    When ``writable`` is True the C side writes results back through ``ptr``,
+    so a read-only source (``bytes`` or a read-only ``memoryview``) is
+    rejected rather than silently writing into a throwaway copy the caller
+    would never see.
     """
     if isinstance(buf, int):
-        return buf, 0
-    if isinstance(buf, (bytes, bytearray)):
-        return ctypes.cast(
-            (ctypes.c_char * len(buf)).from_buffer_copy(buf)
-            if isinstance(buf, bytes)
-            else (ctypes.c_char * len(buf)).from_buffer(buf),
-            ctypes.c_void_p,
-        ).value or 0, len(buf)
+        # bool is a subclass of int: True would be taken as address 1.
+        if isinstance(buf, bool):
+            raise TypeError("raw RDMA pointer must be an int, not bool")
+        # A non-positive value is either null (0) or, when negative, coerced
+        # by ctypes.c_void_p into a huge unsigned address — both invalid.
+        if buf <= 0:
+            raise ValueError("raw RDMA pointer must be a positive address")
+        return buf, 0, None
+    if isinstance(buf, bytes):
+        if writable:
+            raise ValueError(
+                "read-only bytes cannot be used as an RDMA get target; "
+                "pass a bytearray or writable memoryview"
+            )
+        owner = (ctypes.c_char * len(buf)).from_buffer_copy(buf)
+        return ctypes.addressof(owner), len(buf), owner
+    if isinstance(buf, bytearray):
+        owner = (ctypes.c_char * len(buf)).from_buffer(buf)
+        return ctypes.addressof(owner), len(buf), owner
     if isinstance(buf, memoryview):
         if not buf.contiguous:
             raise ValueError("memoryview must be contiguous for RDMA")
-        backing = buf if not buf.readonly else bytearray(buf)
-        addr = ctypes.addressof(
-            (ctypes.c_char * buf.nbytes).from_buffer(backing)
-        )
-        return addr, buf.nbytes
+        if buf.readonly:
+            if writable:
+                raise ValueError(
+                    "read-only memoryview cannot be used as an RDMA get "
+                    "target; pass a writable buffer"
+                )
+            owner = (ctypes.c_char * buf.nbytes).from_buffer_copy(buf)
+            return ctypes.addressof(owner), buf.nbytes, owner
+        owner = (ctypes.c_char * buf.nbytes).from_buffer(buf)
+        return ctypes.addressof(owner), buf.nbytes, owner
     raise TypeError(
         f"unsupported buffer type for RDMA: {type(buf).__name__}; "
         "pass memoryview, bytearray, bytes, or raw int pointer"
@@ -184,36 +212,50 @@ class RDMAClient:
 
         Returns (bytes, etag, checksum).
         """
-        ptr, inferred = _buffer_pointer(buf)
+        # ``owner`` backs ``ptr``; it must stay referenced until the C call
+        # below returns, else the buffer is freed and ``ptr`` dangles.
+        ptr, inferred, owner = _buffer_pointer(buf, writable=False)
         size = length if length is not None else inferred
         if size <= 0:
             raise ValueError("length must be > 0 for RDMA put")
+        if owner is not None and size > inferred:
+            raise ValueError(
+                f"length {size} exceeds buffer size {inferred}"
+            )
         etag = (ctypes.c_char * 64)()
         checksum = (ctypes.c_char * 64)()
         nbytes = self._lib.miniocpp_put_object(
             self._handle, bucket.encode(), obj.encode(),
             ctypes.c_void_p(ptr), size, None, None, etag, checksum,
         )
+        del owner
         if nbytes < 0:
             raise RDMAError(f"RDMA put: {_last_error(self._lib)}")
         return (
             int(nbytes),
-            etag.value.decode().replace('"', ""),
-            checksum.value.decode(),
+            etag.value.decode(errors="replace").replace('"', ""),
+            checksum.value.decode(errors="replace"),
         )
 
     def get(self, bucket: str, obj: str,
             buf: Union[int, memoryview, bytearray],
             length: Optional[int] = None) -> int:
         """RDMA-get ``bucket/obj`` into ``buf``; returns the byte count."""
-        ptr, inferred = _buffer_pointer(buf)
+        # ``owner`` backs ``ptr``; it must stay referenced until the C call
+        # below returns, else the buffer is freed and ``ptr`` dangles.
+        ptr, inferred, owner = _buffer_pointer(buf, writable=True)
         size = length if length is not None else inferred
         if size <= 0:
             raise ValueError("length must be > 0 for RDMA get")
+        if owner is not None and size > inferred:
+            raise ValueError(
+                f"length {size} exceeds buffer size {inferred}"
+            )
         nbytes = self._lib.miniocpp_get_object(
             self._handle, bucket.encode(), obj.encode(),
             ctypes.c_void_p(ptr), size, None, None,
         )
+        del owner
         if nbytes < 0:
             raise RDMAError(f"RDMA get: {_last_error(self._lib)}")
         return int(nbytes)

--- a/minio/signer.py
+++ b/minio/signer.py
@@ -75,13 +75,16 @@ def _get_canonical_query_string(query: str) -> str:
     """Get canonical query string."""
 
     query = query or ""
-    return "&".join(
-        [
-            "=".join(pair) for pair in sorted(
-                [params.split("=") for params in query.split("&")],
-            )
-        ],
-    )
+    if not query:
+        return ""
+    # Each parameter must canonicalize to "name=value"; per SigV4 a value-less
+    # parameter (e.g. "acl") still requires a trailing "=". Sort by the
+    # (name, value) pair, not by the joined string.
+    pairs = []
+    for param in query.split("&"):
+        name, _, value = param.partition("=")
+        pairs.append((name, value))
+    return "&".join(f"{name}={value}" for name, value in sorted(pairs))
 
 
 def _get_canonical_request_hash(

--- a/minio/sse.py
+++ b/minio/sse.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import base64
 import json
 from abc import ABC, abstractmethod
-from typing import Any, cast
+from typing import Any, Optional, cast
 
 from .checksum import md5sum_hash
 
@@ -76,7 +76,7 @@ class SseCustomerKey(Sse):
 class SseKMS(Sse):
     """Server-side encryption - KMS type."""
 
-    def __init__(self, key: str, context: dict[str, Any]):
+    def __init__(self, key: str, context: Optional[dict[str, Any]] = None):
         self._headers = {
             "X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id": key,
             "X-Amz-Server-Side-Encryption": "aws:kms"

--- a/minio/time.py
+++ b/minio/time.py
@@ -18,7 +18,6 @@
 
 from __future__ import annotations
 
-import time as ctime
 from datetime import datetime, timezone
 
 try:
@@ -125,5 +124,9 @@ def to_signer_date(value: datetime) -> str:
 
 
 def to_float(value: datetime) -> float:
-    """Convert datetime into float value."""
-    return ctime.mktime(value.timetuple()) + value.microsecond * 1e-6
+    """Convert datetime into a POSIX timestamp (seconds since the UTC epoch).
+
+    Naive datetimes are treated as UTC, consistent with the rest of this
+    module (see :func:`_to_utc` and :func:`utcnow`).
+    """
+    return _to_utc(value).replace(tzinfo=timezone.utc).timestamp()


### PR DESCRIPTION
A package-wide audit surfaced and fixed 27 defects spanning XML/response parsing, memory safety, protocol construction, and the admin/credential flows. mypy is clean and the unit suite is green; bugs.md documents the full analysis (1 finding was invalid, 1 intentionally skipped).

minio.py
- compose_object: build HTTPHeaderDict from source headers (a plain dict has no .extend, so every multipart compose/copy>5GiB crashed)
- 409 error map: return a flat 2-tuple (trailing comma made it a 1-tuple -> ValueError on unpack)
- get_object_attributes: accumulate x-amz-object-attributes with .add() (assignment kept only the last attribute)

models.py
- Expiration.fromxml: drop default="" so an absent tag returns None (previously rejected every plain Days/Date lifecycle rule)
- Checksum.headers: emit x-amz-checksum-<algo>, not the non-existent x-amz-checksum-algorithm-<algo>
- CreateBucketConfiguration: stop double-nesting <Location>/<Bucket>
- GetObjectAclResponse: store the ACL under the declared `policy` field
- GetObjectAttributesResponse.delete_marker: parse to bool
- PutObjectFanOutResponse: parse lastModified with from_iso8601utc
- Filter: require exactly one of and/prefix/tag (XOR accepted all three)
- ObjectLockConfig: normalize duration_unit before validating; fix the two-arg ValueError that rendered as a tuple

time.py
- to_float: return a UTC POSIX timestamp (was local-time and dropped tzinfo)

credentials/providers.py
- CertificateIdentityProvider: fix dead argument validation
- IamAwsProvider: resolve _token_file from env only (not the literal token); detect an empty IMDS role list

minioadmin.py
- config_get/config_history: guard unbound `response` in finally
- profile_start: fix query key (profilerType, not "profilerType;")
- release streamed decrypt responses to avoid a connection-pool leak
- remove_site_replication: send JSON boolean true

signer.py
- canonical query string: emit name= for valueless params (SigV4-compliant)

helpers.py
- _get_aws_info: compare host with == (was a substring match)

rdma.py
- _buffer_pointer: keep the buffer owner alive across the C call (use-after-free); reject read-only get targets and bounds-check length
- decode etag/checksum with errors="replace"; guard free_aligned(0)

crypto.py
- encrypt: always emit a final marked chunk (including for an empty payload)

sse.py
- SseKMS.context: Optional with default None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Claude Code repository guidance, covering workflow commands, checks, architecture overview, and contribution conventions.

* **Bug Fixes**
  * Improved encrypted streaming for empty payloads.
  * Fixed S3-compatible request/response edge cases (409 error mapping, checksum header naming, object attribute header construction, AWS host/region logic).
  * Corrected parsing/serialization for lifecycle, object lock, ACL, delete-marker, and timestamp fields.
  * Enhanced admin encrypted-response handling and safer response cleanup.
  * Strengthened credential parsing/validation and RDMA buffer/free safety.

* **API Changes**
  * Made SSE-KMS `context` optional.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->