### PR TITLE
rdma: track libs3rdma, and fix the size guard's off-by-one

### DIFF
--- a/.github/workflows/ci-rdma.yml
+++ b/.github/workflows/ci-rdma.yml
@@ -29,10 +29,17 @@ jobs:
       with:
         path: "minio-py"
 
+    # Pinned, like the other SDKs: this job builds minio-cpp and loads the
+    # libs3rdma it vendors, so a floating main makes the build race whatever
+    # landed there. It already did -- a run against the pre-libs3rdma tree
+    # failed on -lnuma/-lrdmacm, which the libs3rdma build no longer needs.
+    # A commit rather than a tag: the RDMA transport moved to libs3rdma after
+    # v0.5.0 and no release carries it yet.
     - name: Checkout minio-cpp
       uses: actions/checkout@v4
       with:
         repository: minio/minio-cpp
+        ref: f89cc4d25d30057f30a0c3adabe2244c9e222486
         path: "minio-cpp"
 
     - name: Checkout vcpkg

--- a/.github/workflows/ci-rdma.yml
+++ b/.github/workflows/ci-rdma.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt-get -qy update
-        sudo apt-get -qy install libibverbs-dev librdmacm-dev libnuma-dev
+        sudo apt-get -qy install libibverbs-dev
 
     - name: Build libminiocpp.so with RDMA
       shell: bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Supporting modules (each is single-responsibility; read these before changing cl
 - `models.py` — ~50 request/response dataclasses (bucket configs, object info, select, etc.).
 - `xml.py` — S3 XML marshalling/unmarshalling built on ElementTree; most config objects implement `fromxml`/`toxml`.
 - `args.py` — argument-holder classes shared across operations. `error.py` — `S3Error`/`ServerError`/`InvalidResponseError`. `sse.py` / `crypto.py` — server-side encryption and credential-file crypto. `checksum.py` — CRC/SHA checksums. `time.py`, `compat.py` — time formatting and Py compat shims.
-- `rdma.py` — **opt-in** RDMA / NVIDIA GPUDirect Storage acceleration for `put_object`/`get_object`, dispatched to `libminiocpp.so` via ctypes when `Minio(enable_rdma=True)`. The SDK stays pure-Python unless this path is used; see `examples/*_rdma.py`.
+- `rdma.py` — **opt-in** RDMA acceleration for `put_object`/`get_object`, dispatched to `libminiocpp.so` via ctypes when `Minio(enable_rdma=True)`. libminiocpp carries its own transport (`libs3rdma`: RoCE or native InfiniBand, host or GPU memory, no CUDA link dependency). The SDK stays pure-Python unless this path is used; see `examples/*_rdma.py`.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -139,11 +139,11 @@ mc ls play/python-test-bucket
 [2023-11-03 22:18:54 UTC]  20KiB STANDARD my-test-file.txt
 ```
 
-## RDMA / GPUDirect Storage (optional)
+## RDMA (optional)
 
-`put_object` and `get_object` can dispatch to MinIO's RDMA + GPUDirect
-Storage path via [minio-cpp](https://github.com/minio/minio-cpp). It is
-strictly opt-in and the SDK stays pure-Python unless used.
+`put_object` and `get_object` can dispatch to MinIO's RDMA path via
+[minio-cpp](https://github.com/minio/minio-cpp). It is strictly opt-in and
+the SDK stays pure-Python unless used.
 
 ```python
 from minio import Minio
@@ -171,8 +171,15 @@ n = client.get_object(
 
 Requires `libminiocpp.so` (built with `-DMINIO_CPP_ENABLE_RDMA=ON`) on the
 host's library search path (or pointed at via the `MINIOCPP_LIB` env var).
+It carries its own RDMA transport, `libs3rdma`, which supports RoCE and
+native InfiniBand and needs no NVIDIA client library on the host.
+
 GPU buffer pointers (e.g. CuPy's `arr.data.ptr`, PyTorch's `t.data_ptr()`)
-work as `data=` / `into=` arguments unchanged — pass them as `int`.
+work as `data=` / `into=` arguments unchanged — pass them as `int`. The SDK
+links no CUDA itself; allocating device memory stays the application's job.
+
+Set `S3RDMA_DEVICE` to pin a particular HCA on a multi-NIC host; otherwise
+the first usable device is selected.
 
 See `examples/put_object_rdma.py` and `examples/get_object_rdma.py`.
 

--- a/minio/rdma.py
+++ b/minio/rdma.py
@@ -5,7 +5,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # SPDX-License-Identifier: Apache-2.0
 
-"""RDMA / GPUDirect Storage dispatch via libminiocpp.so.
+"""RDMA dispatch via libminiocpp.so.
 
 Loaded lazily on first use when ``Minio(enable_rdma=True)`` was set.
 ``libminiocpp.so`` must be findable via the platform loader
@@ -28,11 +28,15 @@ class RDMAError(RuntimeError):
     """libminiocpp.so returned an error from a put/get call."""
 
 
-# Largest buffer a single cuObject registration (cuMemObjGetDescriptor, inside
-# libminiocpp) can pin -- 4 GiB. A larger buffer cannot be RDMA-registered, so
-# reject it with a clear error instead of an opaque C failure; split the
-# transfer into parts no larger than this (multipart upload / ranged read).
-_CUOBJ_MAX_MEMORY_REG_SIZE = 4 * 1024**3  # 4 GiB
+# Largest transfer a single RDMA descriptor can describe: the
+# x-amz-rdma-token carries the window size in a 32-bit field, so a buffer past
+# this cannot be named to the server at all. Reject it with a clear error
+# instead of an opaque C failure; split the transfer into parts no larger than
+# this (multipart upload / ranged read). Keep in step with
+# kRDMAMaxMemoryRegSize in minio-cpp -- a value even one byte larger lets a
+# buffer through here that libminiocpp then declines, silently falling back to
+# a much slower HTTP transfer.
+_RDMA_MAX_MEMORY_REG_SIZE = 2**32 - 1  # 4 GiB - 1
 
 
 _LIB: Optional[ctypes.CDLL] = None
@@ -99,7 +103,13 @@ def _load() -> ctypes.CDLL:
 
 
 def is_available() -> bool:
-    """True if libminiocpp.so loaded and cuObj is connected to cuObjServer."""
+    """True if libminiocpp.so loaded and this host has a usable RDMA device.
+
+    Reports a usable local device, not a reachable server: DC is
+    connectionless, so there is no session to probe. A server that will not
+    serve RDMA declines per request with ``x-amz-rdma-reply: 501``, and the
+    caller falls back to HTTP there.
+    """
     try:
         return _load().miniocpp_rdma_available() != 0
     except RDMANotAvailable:
@@ -229,10 +239,10 @@ class RDMAClient:
             raise ValueError(
                 f"length {size} exceeds buffer size {inferred}"
             )
-        if size > _CUOBJ_MAX_MEMORY_REG_SIZE:
+        if size > _RDMA_MAX_MEMORY_REG_SIZE:
             raise ValueError(
-                f"RDMA put size {size} exceeds the cuObject registration limit "
-                f"of {_CUOBJ_MAX_MEMORY_REG_SIZE} bytes (4 GiB); split into "
+                f"RDMA put size {size} exceeds the {_RDMA_MAX_MEMORY_REG_SIZE} bytes "
+                f"an RDMA descriptor can describe; split into "
                 f"parts <= 4 GiB (multipart upload / ranged read)"
             )
         etag = (ctypes.c_char * 64)()
@@ -264,10 +274,10 @@ class RDMAClient:
             raise ValueError(
                 f"length {size} exceeds buffer size {inferred}"
             )
-        if size > _CUOBJ_MAX_MEMORY_REG_SIZE:
+        if size > _RDMA_MAX_MEMORY_REG_SIZE:
             raise ValueError(
-                f"RDMA get size {size} exceeds the cuObject registration limit "
-                f"of {_CUOBJ_MAX_MEMORY_REG_SIZE} bytes (4 GiB); split into "
+                f"RDMA get size {size} exceeds the {_RDMA_MAX_MEMORY_REG_SIZE} bytes "
+                f"an RDMA descriptor can describe; split into "
                 f"parts <= 4 GiB (multipart upload / ranged read)"
             )
         nbytes = self._lib.miniocpp_get_object(

--- a/minio/rdma.py
+++ b/minio/rdma.py
@@ -241,9 +241,10 @@ class RDMAClient:
             )
         if size > _RDMA_MAX_MEMORY_REG_SIZE:
             raise ValueError(
-                f"RDMA put size {size} exceeds the {_RDMA_MAX_MEMORY_REG_SIZE} bytes "
-                f"an RDMA descriptor can describe; split into "
-                f"parts <= 4 GiB (multipart upload / ranged read)"
+                f"RDMA put size {size} exceeds the "
+                f"{_RDMA_MAX_MEMORY_REG_SIZE} bytes an RDMA descriptor can "
+                f"describe; split into parts of at most that many "
+                f"bytes (multipart upload / ranged read)"
             )
         etag = (ctypes.c_char * 64)()
         checksum = (ctypes.c_char * 64)()
@@ -276,9 +277,10 @@ class RDMAClient:
             )
         if size > _RDMA_MAX_MEMORY_REG_SIZE:
             raise ValueError(
-                f"RDMA get size {size} exceeds the {_RDMA_MAX_MEMORY_REG_SIZE} bytes "
-                f"an RDMA descriptor can describe; split into "
-                f"parts <= 4 GiB (multipart upload / ranged read)"
+                f"RDMA get size {size} exceeds the "
+                f"{_RDMA_MAX_MEMORY_REG_SIZE} bytes an RDMA descriptor can "
+                f"describe; split into parts of at most that many "
+                f"bytes (multipart upload / ranged read)"
             )
         nbytes = self._lib.miniocpp_get_object(
             self._handle, bucket.encode(), obj.encode(),

--- a/tests/unit/rdma_test.py
+++ b/tests/unit/rdma_test.py
@@ -15,7 +15,7 @@ import unittest
 from unittest import mock
 
 from minio.minio import Minio
-from minio.rdma import _CUOBJ_MAX_MEMORY_REG_SIZE, RDMAClient
+from minio.rdma import _RDMA_MAX_MEMORY_REG_SIZE, RDMAClient
 
 
 class _FakeLib:
@@ -138,7 +138,7 @@ class RDMADispatchTest(unittest.TestCase):
 
 
 class RDMAOversizeGuardTest(unittest.TestCase):
-    """The 4 GiB cuObject registration limit is enforced (inclusive) before the
+    """The RDMA descriptor size limit is enforced (inclusive) before the
     native call. A raw pointer is used so the buffer-vs-length guard cannot fire
     first, isolating the size-limit guard."""
 
@@ -159,26 +159,26 @@ class RDMAOversizeGuardTest(unittest.TestCase):
         client = self._client()
         with self.assertRaises(ValueError):
             client.put("bucket", "object", 1,
-                       length=_CUOBJ_MAX_MEMORY_REG_SIZE + 1)
+                       length=_RDMA_MAX_MEMORY_REG_SIZE + 1)
         self.assertEqual(len(self._fake.put_calls), 0)
 
     def test_get_rejects_over_limit_without_native_call(self):
         client = self._client()
         with self.assertRaises(ValueError):
             client.get("bucket", "object", 1,
-                       length=_CUOBJ_MAX_MEMORY_REG_SIZE + 1)
+                       length=_RDMA_MAX_MEMORY_REG_SIZE + 1)
         self.assertEqual(len(self._fake.get_calls), 0)
 
     def test_put_allows_exact_limit(self):
         client = self._client()
         client.put("bucket", "object", 1,
-                   length=_CUOBJ_MAX_MEMORY_REG_SIZE)
+                   length=_RDMA_MAX_MEMORY_REG_SIZE)
         self.assertEqual(len(self._fake.put_calls), 1)
 
     def test_get_allows_exact_limit(self):
         client = self._client()
         client.get("bucket", "object", 1,
-                   length=_CUOBJ_MAX_MEMORY_REG_SIZE)
+                   length=_RDMA_MAX_MEMORY_REG_SIZE)
         self.assertEqual(len(self._fake.get_calls), 1)
 
 


### PR DESCRIPTION
`libminiocpp`'s RDMA transport moved from NVIDIA's `libcuobjclient` to `libs3rdma` (minio/minio-cpp#250). minio-py reaches RDMA through libminiocpp's C API via ctypes, so the binding surface is unchanged — but two things need updating, one of which is a real bug.

## The off-by-one is a live bug

`_CUOBJ_MAX_MEMORY_REG_SIZE` was `4 * 1024**3`, allowing **exactly** 4 GiB. The real ceiling is what one RDMA descriptor can describe, and the descriptor carries the window size in a 32-bit field — so 4 GiB is one byte too many.

A 4 GiB buffer therefore passed this guard, reached libminiocpp, and was declined there: it fell back to a single ordinary HTTP request, which is precisely the silent slowdown the guard exists to prevent.

Now `2**32 - 1`, matching `kRDMAMaxMemoryRegSize` in minio-cpp, and renamed to `_RDMA_MAX_MEMORY_REG_SIZE` since the bound no longer comes from cuObject. The boundary tests move with it and still assert inclusivity at the limit.

## Doc correction

`is_rdma_available` reported "cuObj is connected to cuObjServer". It now reports a usable local RDMA device: DC is connectionless, so there is no session to probe. A server that will not serve RDMA still declines per request with `x-amz-rdma-reply: 501`, so **fallback behaviour is unchanged** — only the meaning of this predicate is.

## CI

Drops `librdmacm-dev` / `libnuma-dev` from the apt install — `libs3rdma` resolves the RDMA stack itself at run time, so nothing links them.

## What this buys

Through libminiocpp, the RDMA path now works on **native InfiniBand** as well as RoCE, on any HCA, with no NVIDIA client library on the host.

GPU buffers are unaffected: the SDK links no CUDA, and allocating device memory stays the application's job — CuPy / PyTorch pointers still work as `data=` / `into=`. `S3RDMA_DEVICE` pins a particular HCA on a multi-NIC host; README documents it.

## Verification

All 7 RDMA unit tests pass, including the boundary tests at the new limit.

Requires minio/minio-cpp#250.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated RDMA transfer validation to support requests up to the supported descriptor limit.
  * Oversized RDMA PUT and GET requests now fail clearly before attempting a native transfer.
  * Requests exactly at the supported limit continue to work correctly.

* **Documentation**
  * Expanded RDMA guidance for RoCE, native InfiniBand, host and GPU memory, device selection, and server-side fallback behavior.
  * Clarified that RDMA operates without GPUDirect Storage or an NVIDIA client dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->