### PR TITLE
ci(rdma): pin minio-cpp to v0.6.0

### DIFF
--- a/.github/workflows/ci-rdma.yml
+++ b/.github/workflows/ci-rdma.yml
@@ -33,13 +33,12 @@ jobs:
     # libs3rdma it vendors, so a floating main makes the build race whatever
     # landed there. It already did -- a run against the pre-libs3rdma tree
     # failed on -lnuma/-lrdmacm, which the libs3rdma build no longer needs.
-    # A commit rather than a tag: the RDMA transport moved to libs3rdma after
-    # v0.5.0 and no release carries it yet.
+    # v0.6.0 is the first release carrying the libs3rdma transport.
     - name: Checkout minio-cpp
       uses: actions/checkout@v4
       with:
         repository: minio/minio-cpp
-        ref: f89cc4d25d30057f30a0c3adabe2244c9e222486
+        ref: v0.6.0
         path: "minio-cpp"
 
     - name: Checkout vcpkg


### PR DESCRIPTION
The RDMA job pinned minio-cpp to a **commit** because no tagged release carried the libs3rdma transport — the comment beside the pin said as much, and to move to a tag once one existed.

[v0.6.0](https://github.com/minio/minio-cpp/releases/tag/v0.6.0) is that release.

## What moving to it picks up

The pin named `f89cc4d`, which predates [minio-cpp#253](https://github.com/minio/minio-cpp/pull/253). v0.6.0 resolves to `edba72c` and adds:

- **in-flight stream parts** — a streaming upload previously sent parts strictly one at a time (167 → 319 MiB/s per caller on an RDMA stream)
- the accompanying environment-variable validation fix

minio-py's RDMA wrapper tests do not exercise the streaming path, so this is about staying current with the other SDKs rather than fixing a failure here.

## Verified

- `v0.6.0` resolves to `edba72c` and its checkout carries `vendor/s3rdma/lib/{x86_64,aarch64}`, which is what the job copies out
- the vendored `libs3rdma.so.0` in the tag is byte-identical to a fresh build of s3rdma master (`361ba84a` / `b4b60832`)
- the workflow YAML parses

warp and minio-go are moving to the same tag in their open PRs, so all three SDKs name one reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated RDMA continuous integration to use the `minio-cpp` v0.6.0 release.
  * Refined workflow comments to reflect the release’s included transport support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->